### PR TITLE
replace tax.ExtValue with generic cbc.Code to support gobl 0.207.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.1
 
 require (
-	github.com/invopop/gobl v0.205.1
+	github.com/invopop/gobl v0.207.0
 	github.com/joho/godotenv v1.5.1
 	// github.com/lestrrat-go/libxml2 v0.0.0-20240521004304-a75c203ac627
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/gobl v0.205.1 h1:khW63/Hu2lzU+IpRN2RF71cfUttCizL0HHAmeakWHyE=
 github.com/invopop/gobl v0.205.1/go.mod h1:DmPohPel8b3ta4nDKnXRNzWQlB89cN74e0/WwPUEZUU=
+github.com/invopop/gobl v0.207.0 h1:Gv6aUYKLdwuAw9HOhkk8eUztsYXPbPy6e/DBoBUDXmI=
+github.com/invopop/gobl v0.207.0/go.mod h1:DmPohPel8b3ta4nDKnXRNzWQlB89cN74e0/WwPUEZUU=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/invopop/validation v0.8.0 h1:e5hXHGnONHImgJdonIpNbctg1hlWy1ncaHoVIQ0JWuw=

--- a/internal/utog/charges.go
+++ b/internal/utog/charges.go
@@ -60,7 +60,7 @@ func (c *Converter) parseCharge(ac *document.AllowanceCharge) (*bill.Charge, err
 	}
 	if ac.AllowanceChargeReasonCode != nil {
 		ch.Ext = tax.Extensions{
-			untdid.ExtKeyCharge: tax.ExtValue(*ac.AllowanceChargeReasonCode),
+			untdid.ExtKeyCharge: cbc.Code(*ac.AllowanceChargeReasonCode),
 		}
 	}
 	if ac.BaseAmount != nil {
@@ -114,7 +114,7 @@ func (c *Converter) parseDiscount(ac *document.AllowanceCharge) (*bill.Discount,
 	}
 	if ac.AllowanceChargeReasonCode != nil {
 		d.Ext = tax.Extensions{
-			untdid.ExtKeyAllowance: tax.ExtValue(*ac.AllowanceChargeReasonCode),
+			untdid.ExtKeyAllowance: cbc.Code(*ac.AllowanceChargeReasonCode),
 		}
 	}
 	if ac.BaseAmount != nil {
@@ -164,7 +164,7 @@ func getLineCharge(ac *document.AllowanceCharge) (*bill.LineCharge, error) {
 	}
 	if ac.AllowanceChargeReasonCode != nil {
 		ch.Ext = tax.Extensions{
-			untdid.ExtKeyCharge: tax.ExtValue(*ac.AllowanceChargeReasonCode),
+			untdid.ExtKeyCharge: cbc.Code(*ac.AllowanceChargeReasonCode),
 		}
 	}
 	if ac.AllowanceChargeReason != nil {
@@ -193,7 +193,7 @@ func getLineDiscount(ac *document.AllowanceCharge) (*bill.LineDiscount, error) {
 	}
 	if ac.AllowanceChargeReasonCode != nil {
 		d.Ext = tax.Extensions{
-			untdid.ExtKeyAllowance: tax.ExtValue(*ac.AllowanceChargeReasonCode),
+			untdid.ExtKeyAllowance: cbc.Code(*ac.AllowanceChargeReasonCode),
 		}
 	}
 	if ac.AllowanceChargeReason != nil {

--- a/internal/utog/instructions.go
+++ b/internal/utog/instructions.go
@@ -12,7 +12,7 @@ func (c *Converter) getInstructions(paymentMeans *document.PaymentMeans) *pay.In
 	instructions := &pay.Instructions{
 		Key: paymentMeansCode(paymentMeans.PaymentMeansCode.Value),
 		Ext: tax.Extensions{
-			untdid.ExtKeyPaymentMeans: tax.ExtValue(paymentMeans.PaymentMeansCode.Value),
+			untdid.ExtKeyPaymentMeans: cbc.Code(paymentMeans.PaymentMeansCode.Value),
 		},
 	}
 

--- a/internal/utog/lines.go
+++ b/internal/utog/lines.go
@@ -142,7 +142,7 @@ func (c *Converter) getIdentities(docLine *document.InvoiceLine) []*org.Identity
 		s := *docLine.Item.StandardItemIdentification.ID.SchemeID
 		id := &org.Identity{
 			Ext: tax.Extensions{
-				iso.ExtKeySchemeID: tax.ExtValue(s),
+				iso.ExtKeySchemeID: cbc.Code(s),
 			},
 			Code: cbc.Code(docLine.Item.StandardItemIdentification.ID.Value),
 		}

--- a/internal/utog/party.go
+++ b/internal/utog/party.go
@@ -98,7 +98,7 @@ func (c *Converter) getParty(party *document.Party) *org.Party {
 		s := *party.PartyIdentification.ID.SchemeID
 		identity := &org.Identity{
 			Ext: tax.Extensions{
-				iso.ExtKeySchemeID: tax.ExtValue(s),
+				iso.ExtKeySchemeID: cbc.Code(s),
 			},
 			Code: cbc.Code(party.PartyIdentification.ID.Value),
 		}


### PR DESCRIPTION
In order to support the latest `gobl 0.207.0` I updated this package and replaced `tax.ExtValue` with generic `cbc.Code`