### PR TITLE
feat: add OIOUBL/Nemhandel support for Danish e-invoicing

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ For example:
 gobl.ubl convert ./test/data/invoice-sample.json
 ```
 
+You can also specify a conversion context, for example to generate OIOUBL (Nemhandel)
+invoices:
+
+```bash
+gobl.ubl convert --context nemhandel ./test/data/invoice-sample.json
+```
+
+If you need a specific ProfileID, override it explicitly:
+
+```bash
+gobl.ubl convert --context nemhandel --profile-id "urn:fdc:oioubl.dk:bis:billing_with_response:3" ./test/data/invoice-sample.json
+```
+
 ## Testing
 
 ### testify
@@ -136,6 +149,24 @@ The library uses testify for testing. To run the tests, you can use the followin
 
 ```bash
 go test ./...
+```
+
+### OIOUBL 2.1 schematron validation
+
+There is an integration test that validates generated OIOUBL 2.1 XML with Saxon and the
+legacy schematron file. It runs automatically when dependencies are available and skips
+cleanly otherwise.
+
+```bash
+go test ./... -run TestOIOUBL21Schematron
+```
+
+By default, the test looks for the schematron at:
+`../OIOUBL Schematron/OIOUBL_Invoice_Schematron.xsl` (relative to this module root).
+Override with:
+
+```bash
+OIOUBL21_SCHEMATRON_XSL="/absolute/path/to/OIOUBL_Invoice_Schematron.xsl" go test ./... -run TestOIOUBL21Schematron
 ```
 
 ## Considerations

--- a/charges.go
+++ b/charges.go
@@ -99,18 +99,18 @@ func makeTaxCategory(taxes tax.Set) []*TaxCategory {
 	set := []*TaxCategory{}
 	for _, t := range taxes {
 		category := TaxCategory{}
-		category.TaxScheme = &TaxScheme{ID: t.Category.String()}
+		category.TaxScheme = &TaxScheme{ID: IDType{Value: t.Category.String()}}
 
 		e := t.Ext.Get(untdid.ExtKeyTaxCategory).String()
 		if e != "" {
-			category.ID = &e
+			category.ID = &IDType{Value: e}
 		}
 
 		// Set percent: required unless category is "O" (outside scope)
 		if t.Percent != nil {
 			p := t.Percent.StringWithoutSymbol()
 			category.Percent = &p
-		} else if category.ID == nil || *category.ID != "O" {
+		} else if category.ID == nil || category.ID.Value != "O" {
 			// Default to 0% when not outside scope
 			zero := "0"
 			category.Percent = &zero

--- a/charges_parse.go
+++ b/charges_parse.go
@@ -96,7 +96,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 	if len(ac.TaxCategory) > 0 && ac.TaxCategory[0].TaxScheme != nil {
 		ch.Taxes = tax.Set{
 			{
-				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID),
+				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID.Value),
 			},
 		}
 
@@ -105,10 +105,10 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 			if ch.Taxes[0].Ext == nil {
 				ch.Taxes[0].Ext = tax.Extensions{}
 			}
-			ch.Taxes[0].Ext[untdid.ExtKeyTaxCategory] = cbc.Code(*ac.TaxCategory[0].ID)
+			ch.Taxes[0].Ext[untdid.ExtKeyTaxCategory] = cbc.Code(ac.TaxCategory[0].ID.Value)
 
 			// Look up exemption code from TaxTotal
-			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID, *ac.TaxCategory[0].ID, ac.TaxCategory[0].Percent)
+			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				ch.Taxes[0].Ext[cef.ExtKeyVATEX] = cbc.Code(info.exemptionReasonCode)
 			}
@@ -126,7 +126,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 
 			// Skip setting percent if it's 0% and tax category is not "Z" (zero-rated)
 			// This prevents GOBL from normalizing to "zero" tax rate for exempt/reverse-charge cases
-			if !p.IsZero() || (ac.TaxCategory[0].ID != nil && *ac.TaxCategory[0].ID == "Z") {
+			if !p.IsZero() || (ac.TaxCategory[0].ID != nil && ac.TaxCategory[0].ID.Value == "Z") {
 				ch.Taxes[0].Percent = &p
 			}
 		}
@@ -181,7 +181,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 	if len(ac.TaxCategory) > 0 && ac.TaxCategory[0].TaxScheme != nil {
 		d.Taxes = tax.Set{
 			{
-				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID),
+				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID.Value),
 			},
 		}
 
@@ -190,10 +190,10 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 			if d.Taxes[0].Ext == nil {
 				d.Taxes[0].Ext = tax.Extensions{}
 			}
-			d.Taxes[0].Ext[untdid.ExtKeyTaxCategory] = cbc.Code(*ac.TaxCategory[0].ID)
+			d.Taxes[0].Ext[untdid.ExtKeyTaxCategory] = cbc.Code(ac.TaxCategory[0].ID.Value)
 
 			// Look up exemption code from TaxTotal
-			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID, *ac.TaxCategory[0].ID, ac.TaxCategory[0].Percent)
+			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				d.Taxes[0].Ext[cef.ExtKeyVATEX] = cbc.Code(info.exemptionReasonCode)
 			}
@@ -211,7 +211,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 
 			// Skip setting percent if it's 0% and tax category is not "Z" (zero-rated)
 			// This prevents GOBL from normalizing to "zero" tax rate for exempt/reverse-charge cases
-			if !percent.IsZero() || (ac.TaxCategory[0].ID != nil && *ac.TaxCategory[0].ID == "Z") {
+			if !percent.IsZero() || (ac.TaxCategory[0].ID != nil && ac.TaxCategory[0].ID.Value == "Z") {
 				d.Taxes[0].Percent = &percent
 			}
 		}

--- a/cmd/gobl.ubl/convert.go
+++ b/cmd/gobl.ubl/convert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/invopop/gobl"
 	ubl "github.com/invopop/gobl.ubl"
@@ -12,6 +13,8 @@ import (
 
 type convertOpts struct {
 	*rootOpts
+	contextName string
+	profileID   string
 }
 
 func convert(o *rootOpts) *convertOpts {
@@ -24,6 +27,10 @@ func (c *convertOpts) cmd() *cobra.Command {
 		Short: "Convert a GOBL JSON into a Universal Business Language (UBL) document and vice versa",
 		RunE:  c.runE,
 	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&c.contextName, "context", "", "Context for UBL conversion (en16931, peppol, xrechnung, nemhandel, ...)")
+	flags.StringVar(&c.profileID, "profile-id", "", "Override UBL ProfileID for JSON to XML conversion")
 
 	return cmd
 }
@@ -60,7 +67,11 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 		if err := json.Unmarshal(inData, env); err != nil {
 			return fmt.Errorf("parsing input as GOBL Envelope: %w", err)
 		}
-		doc, err := ubl.ConvertInvoice(env)
+		opts, err := c.buildOptions()
+		if err != nil {
+			return err
+		}
+		doc, err := ubl.ConvertInvoice(env, opts...)
 		if err != nil {
 			return fmt.Errorf("building UBL document: %w", err)
 		}
@@ -72,7 +83,17 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 	} else {
 		// Assume XML if not JSON
 
-		env, err := ubl.Parse(inData)
+		doc, err := ubl.Parse(inData)
+		if err != nil {
+			return fmt.Errorf("building GOBL envelope: %w", err)
+		}
+
+		inv, ok := doc.(*ubl.Invoice)
+		if !ok {
+			return fmt.Errorf("building GOBL envelope: %w", ubl.ErrUnsupportedDocumentType)
+		}
+
+		env, err := inv.Convert()
 		if err != nil {
 			return fmt.Errorf("building GOBL envelope: %w", err)
 		}
@@ -88,4 +109,40 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func (c *convertOpts) buildOptions() ([]ubl.Option, error) {
+	if c.contextName == "" && c.profileID == "" {
+		return nil, nil
+	}
+
+	ctx := ubl.ContextEN16931
+	if c.contextName != "" {
+		switch strings.ToLower(c.contextName) {
+		case "en16931", "en":
+			ctx = ubl.ContextEN16931
+		case "peppol":
+			ctx = ubl.ContextPeppol
+		case "peppol-self-billed", "peppol-selfbilled", "peppol-self":
+			ctx = ubl.ContextPeppolSelfBilled
+		case "xrechnung":
+			ctx = ubl.ContextXRechnung
+		case "peppol-france-cius", "france-cius", "fr-cius":
+			ctx = ubl.ContextPeppolFranceCIUS
+		case "peppol-france-extended", "france-extended", "fr-extended":
+			ctx = ubl.ContextPeppolFranceExtended
+		case "nemhandel", "oioubl":
+			ctx = ubl.ContextOIOUBL
+		case "nemhandel-2.1", "oioubl-2.1", "oioubl21":
+			ctx = ubl.ContextOIOUBL21
+		default:
+			return nil, fmt.Errorf("unknown context %q", c.contextName)
+		}
+	}
+
+	if c.profileID != "" {
+		ctx.ProfileID = c.profileID
+	}
+
+	return []ubl.Option{ubl.WithContext(ctx)}, nil
 }

--- a/cmd/gobl.ubl/convert_test.go
+++ b/cmd/gobl.ubl/convert_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/addons/eu/en16931"
+	"github.com/invopop/gobl/bill"
+	ubl "github.com/invopop/gobl.ubl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertBuildOptionsNemhandel(t *testing.T) {
+	env := loadTestEnvelope(t)
+
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+	inv.SetAddons(en16931.V2017)
+	require.NoError(t, inv.Calculate())
+
+	opts, err := (&convertOpts{contextName: "nemhandel"}).buildOptions()
+	require.NoError(t, err)
+
+	doc, err := ubl.ConvertInvoice(env, opts...)
+	require.NoError(t, err)
+	assert.Equal(t, "urn:fdc:oioubl.dk:trns:billing:invoice:3.0", doc.CustomizationID)
+	assert.Equal(t, "urn:fdc:oioubl.dk:bis:billing_with_response:3", doc.ProfileID)
+	assert.Equal(t, "2.1", doc.UBLVersionID)
+	assert.Empty(t, doc.UUID)
+}
+
+func TestConvertBuildOptionsProfileOverride(t *testing.T) {
+	env := loadTestEnvelope(t)
+
+	inv, ok := env.Extract().(*bill.Invoice)
+	require.True(t, ok)
+	inv.SetAddons(en16931.V2017)
+	require.NoError(t, inv.Calculate())
+
+	opts, err := (&convertOpts{contextName: "nemhandel", profileID: "custom-profile"}).buildOptions()
+	require.NoError(t, err)
+
+	doc, err := ubl.ConvertInvoice(env, opts...)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-profile", doc.ProfileID)
+}
+
+func TestConvertBuildOptionsOIOUBL21(t *testing.T) {
+	env := loadTestEnvelope(t)
+
+	opts, err := (&convertOpts{contextName: "oioubl-2.1"}).buildOptions()
+	require.NoError(t, err)
+
+	doc, err := ubl.ConvertInvoice(env, opts...)
+	require.NoError(t, err)
+	assert.Equal(t, "OIOUBL-2.1", doc.CustomizationID)
+	assert.Equal(t, "urn:www.nesubl.eu:profiles:profile5:ver2.0", doc.ProfileID)
+}
+
+func TestConvertBuildOptionsUnknownContext(t *testing.T) {
+	_, err := (&convertOpts{contextName: "unknown"}).buildOptions()
+	require.EqualError(t, err, `unknown context "unknown"`)
+}
+
+func TestConvertBuildOptionsContextAliases(t *testing.T) {
+	tests := []struct {
+		name        string
+		context     string
+		convertible bool
+		expected    ubl.Context
+	}{
+		{name: "en alias", context: "en", convertible: true, expected: ubl.ContextEN16931},
+		{name: "peppol alias", context: "peppol", convertible: true, expected: ubl.ContextPeppol},
+		{name: "peppol self billed alias", context: "peppol-selfbilled", convertible: true, expected: ubl.ContextPeppolSelfBilled},
+		{name: "xrechnung alias", context: "xrechnung", convertible: false},
+		{name: "france cius alias", context: "fr-cius", convertible: false},
+		{name: "france extended alias", context: "fr-extended", convertible: false},
+		{name: "oioubl alias", context: "oioubl", convertible: true, expected: ubl.ContextOIOUBL},
+		{name: "oioubl 2.1 alias", context: "oioubl-2.1", convertible: true, expected: ubl.ContextOIOUBL21},
+		{name: "mixed case alias", context: "PePpOl-SeLf", convertible: true, expected: ubl.ContextPeppolSelfBilled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := (&convertOpts{contextName: tt.context}).buildOptions()
+			require.NoError(t, err)
+
+			if !tt.convertible {
+				return
+			}
+
+			env := loadTestEnvelope(t)
+			doc, err := ubl.ConvertInvoice(env, opts...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected.CustomizationID, doc.CustomizationID)
+			assert.Equal(t, tt.expected.ProfileID, doc.ProfileID)
+		})
+	}
+}
+
+func TestConvertRunEErrors(t *testing.T) {
+	t.Run("no args", func(t *testing.T) {
+		cmd := root().cmd()
+		cmd.SetArgs([]string{"convert"})
+		err := cmd.Execute()
+		require.EqualError(t, err, "expected one or two arguments, the command usage is `gobl.ubl convert <infile> [outfile]`")
+	})
+
+	t.Run("too many args", func(t *testing.T) {
+		cmd := root().cmd()
+		cmd.SetArgs([]string{"convert", "a", "b", "c"})
+		err := cmd.Execute()
+		require.EqualError(t, err, "expected one or two arguments, the command usage is `gobl.ubl convert <infile> [outfile]`")
+	})
+
+	t.Run("invalid context", func(t *testing.T) {
+		inPath := filepath.Join("..", "..", "test", "data", "convert", "invoice-minimal.json")
+		outPath := filepath.Join(t.TempDir(), "out.xml")
+		cmd := root().cmd()
+		cmd.SetArgs([]string{"convert", "--context", "nope", inPath, outPath})
+		err := cmd.Execute()
+		require.EqualError(t, err, `unknown context "nope"`)
+	})
+
+	t.Run("unknown xml document type", func(t *testing.T) {
+		inPath := filepath.Join(t.TempDir(), "unknown.xml")
+		require.NoError(t, os.WriteFile(inPath, []byte("<foo/>"), 0o644))
+		outPath := filepath.Join(t.TempDir(), "out.json")
+
+		cmd := root().cmd()
+		cmd.SetArgs([]string{"convert", inPath, outPath})
+		err := cmd.Execute()
+		require.ErrorContains(t, err, "building GOBL envelope: unknown document type")
+	})
+}
+
+func TestConvertXMLToJSONEnvelope(t *testing.T) {
+	inPath := filepath.Join("..", "..", "test", "data", "convert", "out", "oioubl30-invoice-minimal.xml")
+	outPath := filepath.Join(t.TempDir(), "out.json")
+
+	cmd := root().cmd()
+	cmd.SetArgs([]string{"convert", inPath, outPath})
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+
+	env := new(gobl.Envelope)
+	require.NoError(t, json.Unmarshal(data, env))
+
+	doc := env.Extract()
+	inv, ok := doc.(*bill.Invoice)
+	require.True(t, ok, "expected extracted document to be a bill.Invoice")
+	assert.Equal(t, "SAMPLE-001", inv.Code.String())
+	assert.Equal(t, "EUR", string(inv.Currency))
+}
+
+func TestConvertJSONToXMLWithOIOUBL21Context(t *testing.T) {
+	inPath := filepath.Join("..", "..", "test", "data", "convert", "oioubl21-invoice-minimal.json")
+	outPath := filepath.Join(t.TempDir(), "out.xml")
+
+	cmd := root().cmd()
+	cmd.SetArgs([]string{"convert", "--context", "oioubl-2.1", inPath, outPath})
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	xml := string(data)
+	assert.Contains(t, xml, "<cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>")
+	assert.Contains(t, xml, "<cbc:ProfileID schemeAgencyID=\"320\" schemeID=\"urn:oioubl:id:profileid-1.4\">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>")
+	assert.Contains(t, xml, "<cbc:InvoiceTypeCode listAgencyID=\"320\" listID=\"urn:oioubl:codelist:invoicetypecode-1.1\">380</cbc:InvoiceTypeCode>")
+}
+
+func TestConvertOIOUBL21BarePartyFallbacks(t *testing.T) {
+	inPath := filepath.Join("..", "..", "test", "data", "convert", "oioubl21-invoice-bare.json")
+	outPath := filepath.Join(t.TempDir(), "out.xml")
+
+	cmd := root().cmd()
+	cmd.SetArgs([]string{"convert", "--context", "oioubl-2.1", inPath, outPath})
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	xml := string(data)
+
+	// EndpointID should fall back to CVR number when no inboxes are present
+	assert.Contains(t, xml, `<cbc:EndpointID schemeID="DK:CVR">DK37990485</cbc:EndpointID>`)
+	assert.Contains(t, xml, `<cbc:EndpointID schemeID="DK:CVR">DK47458714</cbc:EndpointID>`)
+
+	// PartyName should fall back to RegistrationName when no alias is present
+	assert.Contains(t, xml, "<cac:PartyName>\n        <cbc:Name>Worksome Aps</cbc:Name>")
+	assert.Contains(t, xml, "<cac:PartyName>\n        <cbc:Name>Lego System A/S</cbc:Name>")
+
+	// Contact must always be present with a default ID
+	assert.Contains(t, xml, "<cac:Contact>\n        <cbc:ID>1</cbc:ID>\n      </cac:Contact>")
+}
+
+func TestConvertCreditNoteToXMLWithOIOUBL21Context(t *testing.T) {
+	inPath := filepath.Join("..", "..", "test", "data", "convert", "oioubl21-credit-note-minimal.json")
+	outPath := filepath.Join(t.TempDir(), "out.xml")
+
+	cmd := root().cmd()
+	cmd.SetArgs([]string{"convert", "--context", "oioubl-2.1", inPath, outPath})
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	xml := string(data)
+	assert.Contains(t, xml, "<CreditNote ")
+	assert.Contains(t, xml, "<cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>")
+	assert.Contains(t, xml, "<cbc:ProfileID schemeAgencyID=\"320\" schemeID=\"urn:oioubl:id:profileid-1.4\">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>")
+	assert.Contains(t, xml, "<cbc:CreditNoteTypeCode listAgencyID=\"320\" listID=\"urn:oioubl:codelist:invoicetypecode-1.1\">381</cbc:CreditNoteTypeCode>")
+}
+
+func loadTestEnvelope(t *testing.T) *gobl.Envelope {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "test", "data", "convert", "invoice-minimal.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	env := new(gobl.Envelope)
+	require.NoError(t, json.Unmarshal(data, env))
+	require.NoError(t, env.Calculate())
+	require.NoError(t, env.Validate())
+
+	return env
+}

--- a/common.go
+++ b/common.go
@@ -34,12 +34,14 @@ type Extension struct {
 
 // IDType represents an ID with optional scheme attributes
 type IDType struct {
-	ListID        *string `xml:"listID,attr"`
-	ListVersionID *string `xml:"listVersionID,attr"`
-	SchemeID      *string `xml:"schemeID,attr"`
-	SchemeName    *string `xml:"schemeName,attr"`
-	Name          *string `xml:"name,attr"`
-	Value         string  `xml:",chardata"`
+	SchemeAgencyID *string `xml:"schemeAgencyID,attr"`
+	ListAgencyID   *string `xml:"listAgencyID,attr"`
+	ListID         *string `xml:"listID,attr"`
+	ListVersionID  *string `xml:"listVersionID,attr"`
+	SchemeID       *string `xml:"schemeID,attr"`
+	SchemeName     *string `xml:"schemeName,attr"`
+	Name           *string `xml:"name,attr"`
+	Value          string  `xml:",chardata"`
 }
 
 // ExchangeRate represents an exchange rate
@@ -106,9 +108,10 @@ type CommodityClassification struct {
 
 // ClassifiedTaxCategory represents a classified tax category
 type ClassifiedTaxCategory struct {
-	ID        *string    `xml:"cbc:ID,omitempty"`
-	Percent   *string    `xml:"cbc:Percent,omitempty"`
-	TaxScheme *TaxScheme `xml:"cac:TaxScheme,omitempty"`
+	ID                     *IDType    `xml:"cbc:ID,omitempty"`
+	Percent                *string    `xml:"cbc:Percent,omitempty"`
+	TaxExemptionReasonCode *string    `xml:"cbc:TaxExemptionReasonCode,omitempty"`
+	TaxScheme              *TaxScheme `xml:"cac:TaxScheme,omitempty"`
 }
 
 // AdditionalItemProperty represents an additional property of an item

--- a/context.go
+++ b/context.go
@@ -171,6 +171,25 @@ var ContextPeppolFranceExtended = Context{
 	},
 }
 
+// ContextOIOUBL defines the context for OIOUBL (Nemhandel) UBL documents.
+var ContextOIOUBL = Context{
+	CustomizationID: "urn:fdc:oioubl.dk:trns:billing:invoice:3.0",
+	ProfileID:       "urn:fdc:oioubl.dk:bis:billing_with_response:3",
+	Addons:          []cbc.Key{en16931.V2017},
+}
+
+// ContextOIOUBL21 defines the context for legacy OIOUBL 2.1 documents.
+var ContextOIOUBL21 = Context{
+	CustomizationID: "OIOUBL-2.1",
+	ProfileID:       "urn:www.nesubl.eu:profiles:profile5:ver2.0",
+	Addons:          []cbc.Key{en16931.V2017},
+}
+
+// IsOIOUBL reports whether a context is any supported OIOUBL variant.
+func (c *Context) IsOIOUBL() bool {
+	return c.Is(ContextOIOUBL) || c.Is(ContextOIOUBL21)
+}
+
 // contexts is used internally for reverse lookups during parsing.
 // When adding new contexts, remember to add them here AND as exported variables above.
-var contexts = []Context{ContextEN16931, ContextPeppol, ContextPeppolSelfBilled, ContextXRechnung, ContextPeppolFranceCIUS, ContextPeppolFranceExtended}
+var contexts = []Context{ContextEN16931, ContextPeppol, ContextPeppolSelfBilled, ContextXRechnung, ContextPeppolFranceCIUS, ContextPeppolFranceExtended, ContextOIOUBL, ContextOIOUBL21}

--- a/examples_test.go
+++ b/examples_test.go
@@ -65,6 +65,8 @@ func TestConvertToInvoice(t *testing.T) {
 		{"XRechnung", ubl.ContextXRechnung, "xrechnung"},
 		{"FranceCIUS", ubl.ContextPeppolFranceCIUS, "france-cius"},
 		{"FranceExtended", ubl.ContextPeppolFranceExtended, "france-extended"},
+		{"OIOUBL", ubl.ContextOIOUBL, "oioubl"},
+		{"OIOUBL21", ubl.ContextOIOUBL21, "oioubl21"},
 	}
 
 	for _, ctx := range contexts {
@@ -133,6 +135,8 @@ func TestParseInvoice(t *testing.T) {
 		{"XRechnung", "xrechnung"},
 		{"FranceCIUS", "france-cius"},
 		{"FranceExtended", "france-extended"},
+		{"OIOUBL", "oioubl"},
+		{"OIOUBL21", "oioubl21"},
 	}
 
 	for _, ctx := range contexts {
@@ -225,7 +229,16 @@ func testInvoiceFrom(name string) (*ubl.Invoice, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ubl.ConvertInvoice(env, ubl.WithContext(ubl.ContextPeppol))
+	var opts []ubl.Option
+	switch {
+	case strings.HasPrefix(name, "oioubl21-"), strings.HasPrefix(name, "nemhandel21-"), strings.HasPrefix(name, "oioubl-2.1-"):
+		opts = append(opts, ubl.WithContext(ubl.ContextOIOUBL21))
+	case strings.HasPrefix(name, "oioubl30-"), strings.HasPrefix(name, "nemhandel-"), strings.HasPrefix(name, "oioubl-"):
+		opts = append(opts, ubl.WithContext(ubl.ContextOIOUBL))
+	default:
+		opts = append(opts, ubl.WithContext(ubl.ContextPeppol))
+	}
+	return ubl.ConvertInvoice(env, opts...)
 }
 
 // testInvoiceFromContext creates a UBL Invoice from a GOBL file with a specific context

--- a/invoice.go
+++ b/invoice.go
@@ -134,11 +134,21 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		ProfileID:               profileID,
 		ID:                      invoiceNumber(inv.Series, inv.Code),
 		IssueDate:               formatDate(inv.IssueDate),
-		AccountingCost:          "", // TODO: ordering cost
 		InvoiceTypeCode:         tc,
 		DocumentCurrencyCode:    string(inv.Currency),
 		AccountingSupplierParty: SupplierParty{Party: newParty(inv.Supplier)},
 		AccountingCustomerParty: CustomerParty{Party: newParty(inv.Customer)},
+	}
+
+	if inv.Ordering != nil && inv.Ordering.Cost != "" {
+		out.AccountingCost = inv.Ordering.Cost.String()
+	}
+
+	if o.context.IsOIOUBL() {
+		out.UBLVersionID = Version
+	}
+	if o.context.Is(ContextOIOUBL21) && !inv.UUID.IsZero() {
+		out.UUID = inv.UUID.String()
 	}
 
 	if inv.Type.In(bill.InvoiceTypeCreditNote) {
@@ -180,14 +190,17 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 	out.addOrdering(inv.Ordering)
 	out.addCharges(inv)
 	out.addTotals(inv)
-	out.addLines(inv)
+	out.addLines(inv, o)
 	out.addAttachments(inv.Attachments)
 
-	if err = out.addPayment(inv); err != nil {
+	if err = out.addPayment(inv, o); err != nil {
 		return nil, err
 	}
 	if d := newDelivery(inv.Delivery); d != nil {
 		out.Delivery = []*Delivery{d}
+	}
+	if o.context.Is(ContextOIOUBL21) {
+		applyLegacyOIOUBL21Rules(out)
 	}
 
 	return out, nil

--- a/legacy_oioubl21.go
+++ b/legacy_oioubl21.go
@@ -1,0 +1,211 @@
+package ubl
+
+import "strings"
+
+func applyLegacyOIOUBL21Rules(out *Invoice) {
+	if out == nil {
+		return
+	}
+
+	applyLegacyOIOUBL21Party(out.AccountingSupplierParty.Party)
+	applyLegacyOIOUBL21Party(out.AccountingCustomerParty.Party)
+
+	for i := range out.PaymentMeans {
+		pm := &out.PaymentMeans[i]
+		if pm.PaymentChannelCode == nil {
+			pm.PaymentChannelCode = &IDType{Value: "IBAN"}
+		}
+		listID := "urn:oioubl:codelist:paymentchannelcode-1.1"
+		pm.PaymentChannelCode.ListID = &listID
+		if pm.PaymentChannelCode.Value == "IBAN" && pm.PayeeFinancialAccount != nil && pm.PayeeFinancialAccount.FinancialInstitutionBranch != nil {
+			pm.PayeeFinancialAccount.FinancialInstitutionBranch.ID = nil
+		}
+		if out.DueDate != "" && pm.PaymentDueDate == nil {
+			d := out.DueDate
+			pm.PaymentDueDate = &d
+		}
+	}
+	if len(out.PaymentMeans) > 0 && out.DueDate != "" {
+		out.DueDate = ""
+	}
+
+	// Legacy validator expects this relationship in the 2.1 profile.
+	if len(out.TaxTotal) > 0 {
+		out.LegalMonetaryTotal.TaxExclusiveAmount = out.TaxTotal[0].TaxAmount
+	}
+	if out.LegalMonetaryTotal.PayableAmount != nil && len(out.PaymentTerms) > 0 && out.PaymentTerms[0].Amount == nil {
+		out.PaymentTerms[0].Amount = out.LegalMonetaryTotal.PayableAmount
+	}
+	if out.CreditNoteTypeCode != "" {
+		for i := range out.BillingReference {
+			if ref := out.BillingReference[i]; ref != nil && ref.InvoiceDocumentReference != nil {
+				// Legacy OIOUBL 2.1 credit-note schematron rejects DocumentTypeCode here.
+				ref.InvoiceDocumentReference.DocumentTypeCode = ""
+			}
+		}
+	}
+
+	for i := range out.TaxTotal {
+		for j := range out.TaxTotal[i].TaxSubtotal {
+			applyLegacyOIOUBL21TaxCategory(&out.TaxTotal[i].TaxSubtotal[j].TaxCategory)
+		}
+	}
+	for i := range out.InvoiceLines {
+		if line := &out.InvoiceLines[i]; line.Item != nil && line.Item.ClassifiedTaxCategory != nil {
+			applyLegacyOIOUBL21ClassifiedTaxCategory(line.Item.ClassifiedTaxCategory)
+		}
+		for j := range out.InvoiceLines[i].TaxTotal {
+			for k := range out.InvoiceLines[i].TaxTotal[j].TaxSubtotal {
+				applyLegacyOIOUBL21TaxCategory(&out.InvoiceLines[i].TaxTotal[j].TaxSubtotal[k].TaxCategory)
+			}
+		}
+	}
+	for i := range out.CreditNoteLines {
+		if line := &out.CreditNoteLines[i]; line.Item != nil && line.Item.ClassifiedTaxCategory != nil {
+			applyLegacyOIOUBL21ClassifiedTaxCategory(line.Item.ClassifiedTaxCategory)
+		}
+		for j := range out.CreditNoteLines[i].TaxTotal {
+			for k := range out.CreditNoteLines[i].TaxTotal[j].TaxSubtotal {
+				applyLegacyOIOUBL21TaxCategory(&out.CreditNoteLines[i].TaxTotal[j].TaxSubtotal[k].TaxCategory)
+			}
+		}
+	}
+}
+
+func applyLegacyOIOUBL21Party(p *Party) {
+	if p == nil {
+		return
+	}
+	if p.EndpointID != nil && p.EndpointID.SchemeID == "0088" {
+		p.EndpointID.SchemeID = "GLN"
+	}
+	if p.EndpointID == nil {
+		if len(p.PartyTaxScheme) > 0 && p.PartyTaxScheme[0].CompanyID != nil {
+			val := p.PartyTaxScheme[0].CompanyID.Value
+			if !strings.HasPrefix(val, "DK") {
+				val = "DK" + val
+			}
+			p.EndpointID = &EndpointID{
+				SchemeID: "DK:CVR",
+				Value:    val,
+			}
+		}
+	}
+	if p.PartyName == nil && len(p.PartyIdentification) == 0 {
+		if p.PartyLegalEntity != nil && p.PartyLegalEntity.RegistrationName != nil {
+			p.PartyName = &PartyName{
+				Name: *p.PartyLegalEntity.RegistrationName,
+			}
+		}
+	}
+	if p.PostalAddress != nil && p.PostalAddress.AddressFormatCode == nil {
+		listID := "urn:oioubl:codelist:addressformatcode-1.1"
+		listAgencyID := "320"
+		p.PostalAddress.AddressFormatCode = &IDType{
+			ListID:      &listID,
+			ListAgencyID: &listAgencyID,
+			Value:       "StructuredDK",
+		}
+	}
+	if p.PostalAddress != nil && p.PostalAddress.BuildingNumber == nil {
+		if p.PostalAddress.StreetName != nil {
+			parts := strings.Fields(*p.PostalAddress.StreetName)
+			if n := len(parts); n > 0 {
+				bn := parts[n-1]
+				p.PostalAddress.BuildingNumber = &bn
+			}
+		}
+		if p.PostalAddress.BuildingNumber == nil {
+			fallback := "1"
+			p.PostalAddress.BuildingNumber = &fallback
+		}
+	}
+	if p.PartyTaxScheme != nil {
+		for i := range p.PartyTaxScheme {
+			pts := &p.PartyTaxScheme[i]
+			if pts.CompanyID != nil {
+				scheme := "DK:SE"
+				pts.CompanyID.SchemeID = &scheme
+				if !strings.HasPrefix(pts.CompanyID.Value, "DK") {
+					pts.CompanyID.Value = "DK" + pts.CompanyID.Value
+				}
+			}
+			applyLegacyOIOUBL21TaxScheme(pts.TaxScheme)
+		}
+	}
+	if p.PartyLegalEntity != nil && p.PartyLegalEntity.CompanyID != nil {
+		scheme := "DK:CVR"
+		p.PartyLegalEntity.CompanyID.SchemeID = &scheme
+		if !strings.HasPrefix(p.PartyLegalEntity.CompanyID.Value, "DK") {
+			p.PartyLegalEntity.CompanyID.Value = "DK" + p.PartyLegalEntity.CompanyID.Value
+		}
+	}
+	if p.Contact == nil {
+		p.Contact = &Contact{}
+	}
+	if p.Contact.ID == nil {
+		id := "1"
+		p.Contact.ID = &id
+	}
+}
+
+func applyLegacyOIOUBL21TaxCategory(tc *TaxCategory) {
+	if tc == nil {
+		return
+	}
+	if tc.ID == nil {
+		tc.ID = &IDType{Value: "StandardRated"}
+	}
+	tc.ID.Value = legacyTaxCategoryCode(tc.ID.Value)
+	schemeID := "urn:oioubl:id:taxcategoryid-1.1"
+	schemeAgencyID := "320"
+	tc.ID.SchemeID = &schemeID
+	tc.ID.SchemeAgencyID = &schemeAgencyID
+	applyLegacyOIOUBL21TaxScheme(tc.TaxScheme)
+}
+
+func applyLegacyOIOUBL21ClassifiedTaxCategory(tc *ClassifiedTaxCategory) {
+	if tc == nil {
+		return
+	}
+	if tc.ID == nil {
+		tc.ID = &IDType{Value: "StandardRated"}
+	}
+	tc.ID.Value = legacyTaxCategoryCode(tc.ID.Value)
+	schemeID := "urn:oioubl:id:taxcategoryid-1.1"
+	schemeAgencyID := "320"
+	tc.ID.SchemeID = &schemeID
+	tc.ID.SchemeAgencyID = &schemeAgencyID
+	applyLegacyOIOUBL21TaxScheme(tc.TaxScheme)
+}
+
+func applyLegacyOIOUBL21TaxScheme(ts *TaxScheme) {
+	if ts == nil {
+		return
+	}
+	schemeID := "urn:oioubl:id:taxschemeid-1.2"
+	schemeAgencyID := "320"
+	ts.ID = IDType{
+		SchemeID:       &schemeID,
+		SchemeAgencyID: &schemeAgencyID,
+		Value:          "63",
+	}
+	name := "Moms"
+	ts.Name = &name
+}
+
+func legacyTaxCategoryCode(in string) string {
+	switch in {
+	case "S", "Standard", "standard":
+		return "StandardRated"
+	case "Z", "Zero", "zero":
+		return "ZeroRated"
+	case "AE", "ReverseCharge":
+		return "ReverseCharge"
+	default:
+		if in == "" {
+			return "StandardRated"
+		}
+		return in
+	}
+}

--- a/lines.go
+++ b/lines.go
@@ -21,6 +21,7 @@ type InvoiceLine struct {
 	OrderLineReference  *OrderLineReference `xml:"cac:OrderLineReference"`
 	DocumentReference   *LineDocReference   `xml:"cac:DocumentReference,omitempty"`
 	AllowanceCharge     []*AllowanceCharge  `xml:"cac:AllowanceCharge"`
+	TaxTotal            []TaxTotal          `xml:"cac:TaxTotal,omitempty"`
 	Item                *Item               `xml:"cac:Item"`
 	Price               *Price              `xml:"cac:Price"`
 }
@@ -31,7 +32,7 @@ type LineDocReference struct {
 	DocumentTypeCode *string `xml:"cbc:DocumentTypeCode,omitempty"`
 }
 
-func (ui *Invoice) addLines(inv *bill.Invoice) { //nolint:gocyclo
+func (ui *Invoice) addLines(inv *bill.Invoice, o *options) { //nolint:gocyclo
 	if len(inv.Lines) == 0 {
 		return
 	}
@@ -132,20 +133,20 @@ func (ui *Invoice) addLines(inv *bill.Invoice) { //nolint:gocyclo
 			if len(l.Taxes) > 0 && l.Taxes[0].Category != "" {
 				it.ClassifiedTaxCategory = &ClassifiedTaxCategory{
 					TaxScheme: &TaxScheme{
-						ID: l.Taxes[0].Category.String(),
+						ID: IDType{Value: l.Taxes[0].Category.String()},
 					},
 				}
 
 				if l.Taxes[0].Ext != nil && l.Taxes[0].Ext[untdid.ExtKeyTaxCategory].String() != "" {
 					rate := l.Taxes[0].Ext[untdid.ExtKeyTaxCategory].String()
-					it.ClassifiedTaxCategory.ID = &rate
+					it.ClassifiedTaxCategory.ID = &IDType{Value: rate}
 				}
 
 				// Set percent: required unless category is "O" (outside scope)
 				if l.Taxes[0].Percent != nil {
 					p := l.Taxes[0].Percent.StringWithoutSymbol()
 					it.ClassifiedTaxCategory.Percent = &p
-				} else if it.ClassifiedTaxCategory.ID == nil || *it.ClassifiedTaxCategory.ID != "O" {
+				} else if it.ClassifiedTaxCategory.ID == nil || it.ClassifiedTaxCategory.ID.Value != "O" {
 					// Default to 0% when not outside scope
 					p := "0"
 					it.ClassifiedTaxCategory.Percent = &p
@@ -153,7 +154,7 @@ func (ui *Invoice) addLines(inv *bill.Invoice) { //nolint:gocyclo
 
 				if l.Taxes[0].Ext != nil && l.Taxes[0].Ext[untdid.ExtKeyTaxCategory].String() != "" {
 					rate := l.Taxes[0].Ext[untdid.ExtKeyTaxCategory].String()
-					it.ClassifiedTaxCategory.ID = &rate
+					it.ClassifiedTaxCategory.ID = &IDType{Value: rate}
 				}
 			}
 
@@ -223,6 +224,10 @@ func (ui *Invoice) addLines(inv *bill.Invoice) { //nolint:gocyclo
 			}
 		}
 
+		if o.context.IsOIOUBL() {
+			invLine.TaxTotal = makeLineTaxTotals(l, ccy)
+		}
+
 		lines = append(lines, invLine)
 	}
 	if inv.Type.In(bill.InvoiceTypeCreditNote) {
@@ -230,6 +235,62 @@ func (ui *Invoice) addLines(inv *bill.Invoice) { //nolint:gocyclo
 	} else {
 		ui.InvoiceLines = lines
 	}
+}
+
+func makeLineTaxTotals(line *bill.Line, ccy string) []TaxTotal {
+	if line == nil || len(line.Taxes) == 0 {
+		return nil
+	}
+
+	var taxable num.Amount
+	switch {
+	case line.Total != nil:
+		taxable = *line.Total
+	case line.Sum != nil:
+		taxable = *line.Sum
+	default:
+		return nil
+	}
+
+	taxTotal := TaxTotal{
+		TaxAmount: Amount{Value: "0", CurrencyID: &ccy},
+	}
+	totalAmount := num.MakeAmount(0, taxable.Exp())
+
+	for _, tax := range line.Taxes {
+		subtotal := TaxSubtotal{
+			TaxableAmount: Amount{Value: taxable.String(), CurrencyID: &ccy},
+		}
+		taxCat := TaxCategory{}
+
+		if tax.Ext != nil && tax.Ext[untdid.ExtKeyTaxCategory].String() != "" {
+			k := tax.Ext[untdid.ExtKeyTaxCategory].String()
+			taxCat.ID = &IDType{Value: k}
+		}
+
+		if tax.Percent != nil {
+			p := tax.Percent.StringWithoutSymbol()
+			taxCat.Percent = &p
+			amount := tax.Percent.Of(taxable).Rescale(taxable.Exp())
+			subtotal.TaxAmount = Amount{Value: amount.String(), CurrencyID: &ccy}
+			totalAmount = totalAmount.Add(amount)
+		} else {
+			subtotal.TaxAmount = Amount{Value: "0", CurrencyID: &ccy}
+		}
+
+		if tax.Category != "" {
+			taxCat.TaxScheme = &TaxScheme{ID: IDType{Value: tax.Category.String()}}
+		}
+		subtotal.TaxCategory = taxCat
+		taxTotal.TaxSubtotal = append(taxTotal.TaxSubtotal, subtotal)
+	}
+
+	if totalAmount.IsZero() {
+		return nil
+	}
+	taxTotal.TaxAmount = Amount{Value: totalAmount.String(), CurrencyID: &ccy}
+
+	return []TaxTotal{taxTotal}
 }
 
 func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount, ccy string, baseSum *num.Amount) []*AllowanceCharge {

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -192,18 +192,22 @@ func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[stri
 
 	line.Taxes = tax.Set{
 		{
-			Category: cbc.Code(ctc.TaxScheme.ID),
+			Category: cbc.Code(ctc.TaxScheme.ID.Value),
 		},
 	}
 	if ctc.ID != nil {
 		line.Taxes[0].Ext = tax.Extensions{
-			untdid.ExtKeyTaxCategory: cbc.Code(*ctc.ID),
+			untdid.ExtKeyTaxCategory: cbc.Code(ctc.ID.Value),
 		}
 
-		// Try to get exemption code from TaxTotal
-		key := buildTaxCategoryKey(ctc.TaxScheme.ID, *ctc.ID, ctc.Percent)
-		if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
-			line.Taxes[0].Ext[cef.ExtKeyVATEX] = cbc.Code(info.exemptionReasonCode)
+		if ctc.TaxExemptionReasonCode != nil {
+			line.Taxes[0].Ext[cef.ExtKeyVATEX] = cbc.Code(*ctc.TaxExemptionReasonCode)
+		} else {
+			// Try to get exemption code from TaxTotal
+			key := buildTaxCategoryKey(ctc.TaxScheme.ID.Value, ctc.ID.Value, ctc.Percent)
+			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
+				line.Taxes[0].Ext[cef.ExtKeyVATEX] = cbc.Code(info.exemptionReasonCode)
+			}
 		}
 
 	}
@@ -216,7 +220,7 @@ func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[stri
 
 		// Skip setting percent if it's 0% and tax category is not "Z" (zero-rated)
 		// This prevents GOBL from normalizing to "zero" tax rate for exempt/reverse-charge cases
-		if percent.IsZero() && ctc.ID != nil && *ctc.ID != "Z" {
+		if percent.IsZero() && ctc.ID != nil && ctc.ID.Value != "Z" {
 			return
 		}
 

--- a/lines_test.go
+++ b/lines_test.go
@@ -18,7 +18,7 @@ func TestNewLines(t *testing.T) {
 		assert.Equal(t, "1800.00", doc.InvoiceLines[0].LineExtensionAmount.Value)
 		assert.Equal(t, "Development services", doc.InvoiceLines[0].Item.Name)
 		assert.Equal(t, "HUR", doc.InvoiceLines[0].InvoicedQuantity.UnitCode)
-		assert.Equal(t, "VAT", doc.InvoiceLines[0].Item.ClassifiedTaxCategory.TaxScheme.ID)
+		assert.Equal(t, "VAT", doc.InvoiceLines[0].Item.ClassifiedTaxCategory.TaxScheme.ID.Value)
 		assert.Equal(t, "19", *doc.InvoiceLines[0].Item.ClassifiedTaxCategory.Percent)
 		assert.True(t, doc.InvoiceLines[0].AllowanceCharge[0].ChargeIndicator)
 		assert.Equal(t, "Testing", *doc.InvoiceLines[0].AllowanceCharge[0].AllowanceChargeReason)

--- a/oioubl21_schematron_test.go
+++ b/oioubl21_schematron_test.go
@@ -1,0 +1,129 @@
+package ubl_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ubl "github.com/invopop/gobl.ubl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIOUBL21Schematron(t *testing.T) {
+	requireSaxonAndSchematron(t, oioubl21InvoiceSchematronPath())
+	requireSaxonAndSchematron(t, oioubl21CreditNoteSchematronPath())
+
+	fixtures := []string{
+		"oioubl21-invoice-minimal.json",
+		"oioubl21-credit-note-minimal.json",
+		"oioubl30-invoice-minimal.json",
+		"oioubl30-invoice-example.json",
+	}
+	for _, fixture := range fixtures {
+		t.Run(fixture, func(t *testing.T) {
+			xmlData := renderOIOUBL21Fixture(t, fixture)
+			xsl := oioubl21InvoiceSchematronPath()
+			if strings.Contains(string(xmlData), "<CreditNote ") {
+				xsl = oioubl21CreditNoteSchematronPath()
+			}
+			svrl := runSchematron(t, fixture, xsl, xmlData)
+			assertNoFindings(t, svrl)
+		})
+	}
+}
+
+func TestOIOUBL21SchematronNegativeInvoiceEndpoint(t *testing.T) {
+	requireSaxonAndSchematron(t, oioubl21InvoiceSchematronPath())
+	xmlData := renderOIOUBL21Fixture(t, "oioubl21-invoice-minimal.json")
+	bad := strings.Replace(
+		string(xmlData),
+		`<cbc:EndpointID schemeID="GLN">5790000436101</cbc:EndpointID>`,
+		`<cbc:EndpointID schemeID="GLN"></cbc:EndpointID>`,
+		1,
+	)
+	svrl := runSchematron(t, "oioubl21-invoice-minimal-negative-endpoint.json", oioubl21InvoiceSchematronPath(), []byte(bad))
+	require.Contains(t, svrl, "[F-INV031]", "expected invoice endpoint validation failure code")
+}
+
+func TestOIOUBL21SchematronNegativeCreditNoteEndpoint(t *testing.T) {
+	requireSaxonAndSchematron(t, oioubl21CreditNoteSchematronPath())
+	xmlData := renderOIOUBL21Fixture(t, "oioubl21-credit-note-minimal.json")
+	bad := strings.Replace(
+		string(xmlData),
+		`<cbc:EndpointID schemeID="GLN">5790000436057</cbc:EndpointID>`,
+		`<cbc:EndpointID schemeID="GLN"></cbc:EndpointID>`,
+		1,
+	)
+	svrl := runSchematron(t, "oioubl21-credit-note-negative-endpoint.json", oioubl21CreditNoteSchematronPath(), []byte(bad))
+	require.Contains(t, svrl, "[F-CRN040]", "expected credit note endpoint validation failure code")
+}
+
+func requireSaxonAndSchematron(t *testing.T, xsl string) {
+	t.Helper()
+	if _, err := exec.LookPath("saxon"); err != nil {
+		t.Skip("saxon not installed; skipping OIOUBL 2.1 schematron validation")
+	}
+	if _, err := os.Stat(xsl); err != nil {
+		t.Skipf("OIOUBL 2.1 schematron not found at %s", xsl)
+	}
+}
+
+func renderOIOUBL21Fixture(t *testing.T, fixture string) []byte {
+	t.Helper()
+	env, err := loadTestEnvelope(fixture)
+	require.NoError(t, err)
+	doc, err := ubl.ConvertInvoice(env, ubl.WithContext(ubl.ContextOIOUBL21))
+	require.NoError(t, err)
+	xmlData, err := ubl.Bytes(doc)
+	require.NoError(t, err)
+	return xmlData
+}
+
+func runSchematron(t *testing.T, name, xsl string, xmlData []byte) string {
+	t.Helper()
+	tmp := t.TempDir()
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	xmlPath := filepath.Join(tmp, fmt.Sprintf("%s.xml", base))
+	svrlPath := filepath.Join(tmp, fmt.Sprintf("%s.svrl.xml", base))
+	require.NoError(t, os.WriteFile(xmlPath, xmlData, 0o644))
+
+	cmd := exec.Command("saxon",
+		"-xsl:"+xsl,
+		"-s:"+xmlPath,
+		"-o:"+svrlPath,
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "saxon failed: %s", string(out))
+
+	svrl, err := os.ReadFile(svrlPath)
+	require.NoError(t, err)
+	return string(svrl)
+}
+
+func assertNoFindings(t *testing.T, svrl string) {
+	t.Helper()
+	require.NotContains(t, svrl, "failed-assert", "schematron failed assertions")
+	require.NotContains(t, svrl, "[F-", "schematron fatal findings present")
+	require.NotContains(t, svrl, "[E-", "schematron error findings present")
+	require.NotContains(t, svrl, "[W-", "schematron warning findings present")
+}
+
+func oioubl21InvoiceSchematronPath() string {
+	if p := os.Getenv("OIOUBL21_INVOICE_SCHEMATRON_XSL"); p != "" {
+		return p
+	}
+	if p := os.Getenv("OIOUBL21_SCHEMATRON_XSL"); p != "" {
+		return p
+	}
+	return filepath.Join(filepath.Dir(getRootFolder()), "OIOUBL Schematron", "OIOUBL_Invoice_Schematron.xsl")
+}
+
+func oioubl21CreditNoteSchematronPath() string {
+	if p := os.Getenv("OIOUBL21_CREDITNOTE_SCHEMATRON_XSL"); p != "" {
+		return p
+	}
+	return filepath.Join(filepath.Dir(getRootFolder()), "OIOUBL Schematron", "OIOUBL_CreditNote_Schematron.xsl")
+}

--- a/party.go
+++ b/party.go
@@ -3,6 +3,7 @@ package ubl
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/cbc"
@@ -38,8 +39,9 @@ type Party struct {
 
 // EndpointID represents an endpoint identifier
 type EndpointID struct {
-	SchemeID string `xml:"schemeID,attr"`
-	Value    string `xml:",chardata"`
+	SchemeAgencyID *string `xml:"schemeAgencyID,attr"`
+	SchemeID       string  `xml:"schemeID,attr"`
+	Value          string  `xml:",chardata"`
 }
 
 // Identification represents an identification
@@ -54,7 +56,9 @@ type PartyName struct {
 
 // PostalAddress represents a postal address
 type PostalAddress struct {
+	AddressFormatCode    *IDType             `xml:"cbc:AddressFormatCode"`
 	StreetName           *string             `xml:"cbc:StreetName"`
+	BuildingNumber       *string             `xml:"cbc:BuildingNumber"`
 	AdditionalStreetName *string             `xml:"cbc:AdditionalStreetName"`
 	CityName             *string             `xml:"cbc:CityName"`
 	PostalZone           *string             `xml:"cbc:PostalZone"`
@@ -84,14 +88,15 @@ type Country struct {
 
 // PartyTaxScheme represents a party's tax scheme
 type PartyTaxScheme struct {
-	CompanyID *string    `xml:"cbc:CompanyID"`
+	CompanyID *IDType    `xml:"cbc:CompanyID"`
 	TaxScheme *TaxScheme `xml:"cac:TaxScheme"`
 }
 
 // TaxScheme represents a tax scheme
 type TaxScheme struct {
-	ID          string `xml:"cbc:ID"`
-	TaxTypeCode string `xml:"cbc:TaxTypeCode,omitempty"`
+	ID          IDType  `xml:"cbc:ID"`
+	Name        *string `xml:"cbc:Name"`
+	TaxTypeCode string  `xml:"cbc:TaxTypeCode,omitempty"`
 }
 
 // PartyLegalEntity represents the legal entity of a party
@@ -103,6 +108,7 @@ type PartyLegalEntity struct {
 
 // Contact represents contact information
 type Contact struct {
+	ID             *string `xml:"cbc:ID"`
 	Name           *string `xml:"cbc:Name"`
 	Telephone      *string `xml:"cbc:Telephone"`
 	ElectronicMail *string `xml:"cbc:ElectronicMail"`
@@ -148,10 +154,18 @@ func newParty(party *org.Party) *Party { //nolint:gocyclo
 			id = TaxSchemeVAT
 		}
 
+		companyID := &IDType{
+			Value: code,
+		}
+		if string(tID.Country) == "DK" {
+			s := "0198"
+			companyID.SchemeID = &s
+		}
+
 		taxScheme := PartyTaxScheme{
-			CompanyID: &code,
+			CompanyID: companyID,
 			TaxScheme: &TaxScheme{
-				ID: id.String(),
+				ID: IDType{Value: id.String()},
 			},
 		}
 
@@ -193,7 +207,7 @@ func newParty(party *org.Party) *Party { //nolint:gocyclo
 			}
 		} else if ib.Scheme != "" {
 			p.EndpointID = &EndpointID{
-				SchemeID: ib.Scheme.String(),
+				SchemeID: normalizeEndpointScheme(ib.Scheme.String()),
 				Value:    ib.Code.String(),
 			}
 		}
@@ -233,10 +247,16 @@ func newParty(party *org.Party) *Party { //nolint:gocyclo
 		for _, id := range party.Identities {
 			if id.Scope == org.IdentityScopeTax {
 				code := id.Code.String()
+				companyID := &IDType{Value: code}
+				if id.Ext != nil {
+					if s := id.Ext[iso.ExtKeySchemeID].String(); s != "" {
+						companyID.SchemeID = &s
+					}
+				}
 				taxScheme := PartyTaxScheme{
-					CompanyID: &code,
+					CompanyID: companyID,
 					TaxScheme: &TaxScheme{
-						ID: id.Type.String(),
+						ID: IDType{Value: id.Type.String()},
 					},
 				}
 				p.PartyTaxScheme = append(p.PartyTaxScheme, taxScheme)
@@ -266,6 +286,14 @@ func newParty(party *org.Party) *Party { //nolint:gocyclo
 			p.PartyIdentification = append(p.PartyIdentification, Identification{
 				ID: idType,
 			})
+		}
+	}
+
+	if p.PartyLegalEntity != nil && p.PartyLegalEntity.CompanyID == nil && party.TaxID != nil && string(party.TaxID.Country) == "DK" {
+		s := "0184"
+		p.PartyLegalEntity.CompanyID = &IDType{
+			SchemeID: &s,
+			Value:    party.TaxID.Code.String(),
 		}
 	}
 	return p
@@ -393,6 +421,15 @@ func newPayeeParty(party *org.Party) *Party {
 	}
 
 	return p
+}
+
+func normalizeEndpointScheme(s string) string {
+	switch strings.ToUpper(s) {
+	case "GLN":
+		return "0088"
+	default:
+		return s
+	}
 }
 
 func newAddress(addresses []*org.Address) *PostalAddress {

--- a/party_parse.go
+++ b/party_parse.go
@@ -167,7 +167,7 @@ func handlePartyTaxSchemes(party *Party, p *org.Party) {
 func extractValidTaxSchemes(schemes []PartyTaxScheme) []PartyTaxScheme {
 	validSchemes := make([]PartyTaxScheme, 0)
 	for _, pts := range schemes {
-		if pts.CompanyID != nil && *pts.CompanyID != "" && pts.TaxScheme != nil {
+		if pts.CompanyID != nil && pts.CompanyID.Value != "" && pts.TaxScheme != nil {
 			validSchemes = append(validSchemes, pts)
 		}
 	}
@@ -177,15 +177,15 @@ func extractValidTaxSchemes(schemes []PartyTaxScheme) []PartyTaxScheme {
 func setTaxIDFromScheme(pts PartyTaxScheme, p *org.Party, countryCode string) {
 	p.TaxID = &tax.Identity{
 		Country: l10n.TaxCountryCode(countryCode),
-		Code:    cbc.Code(*pts.CompanyID),
+		Code:    cbc.Code(pts.CompanyID.Value),
 	}
-	sc := cbc.Code(pts.TaxScheme.ID)
+	sc := cbc.Code(pts.TaxScheme.ID.Value)
 	if p.TaxID.GetScheme() != sc {
 		var scheme cbc.Code
 		if pts.TaxScheme.TaxTypeCode != "" {
 			scheme = cbc.Code(pts.TaxScheme.TaxTypeCode)
 		} else {
-			scheme = cbc.Code(pts.TaxScheme.ID)
+			scheme = cbc.Code(pts.TaxScheme.ID.Value)
 		}
 		p.TaxID.Scheme = scheme
 	}
@@ -210,7 +210,7 @@ func handleMultipleTaxSchemes(validSchemes []PartyTaxScheme, p *org.Party, count
 
 func findVATSchemeIndex(schemes []PartyTaxScheme) int {
 	for i, pts := range schemes {
-		if pts.TaxScheme.ID == TaxSchemeVAT {
+		if pts.TaxScheme.ID.Value == TaxSchemeVAT {
 			return i
 		}
 	}
@@ -225,9 +225,9 @@ func addRemainingTaxSchemesAsIdentities(validSchemes []PartyTaxScheme, taxIDIdx 
 
 		identity := &org.Identity{
 			Country: l10n.ISOCountryCode(countryCode),
-			Code:    cbc.Code(*pts.CompanyID),
+			Code:    cbc.Code(pts.CompanyID.Value),
 			Scope:   org.IdentityScopeTax,
-			Type:    cbc.Code(pts.TaxScheme.ID),
+			Type:    cbc.Code(pts.TaxScheme.ID.Value),
 		}
 
 		if p.Identities == nil {

--- a/party_test.go
+++ b/party_test.go
@@ -3,17 +3,160 @@ package ubl_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/catalogues/iso"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	ubl "github.com/invopop/gobl.ubl"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewParty(t *testing.T) {
+	t.Run("invoice-de-de.json", func(t *testing.T) {
+		doc, err := testInvoiceFrom("invoice-de-de.json")
+		require.NoError(t, err)
+
+		assert.Equal(t, "DE111111125", doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID.Value)
+		assert.Equal(t, "Provide One GmbH", *doc.AccountingSupplierParty.Party.PartyLegalEntity.RegistrationName)
+		assert.Equal(t, "+49100200300", *doc.AccountingSupplierParty.Party.Contact.Telephone)
+		assert.Equal(t, "billing@example.com", *doc.AccountingSupplierParty.Party.Contact.ElectronicMail)
+
+		assert.Equal(t, "Dietmar-Hopp-Allee 16", *doc.AccountingSupplierParty.Party.PostalAddress.StreetName)
+		assert.Equal(t, "Walldorf", *doc.AccountingSupplierParty.Party.PostalAddress.CityName)
+		assert.Equal(t, "69190", *doc.AccountingSupplierParty.Party.PostalAddress.PostalZone)
+		assert.Equal(t, "DE", doc.AccountingSupplierParty.Party.PostalAddress.Country.IdentificationCode)
+
+		assert.Equal(t, "DE282741168", doc.AccountingCustomerParty.Party.PartyTaxScheme[0].CompanyID.Value)
+		assert.Equal(t, "Sample Consumer", *doc.AccountingCustomerParty.Party.PartyLegalEntity.RegistrationName)
+		assert.Equal(t, "email@sample.com", *doc.AccountingCustomerParty.Party.Contact.ElectronicMail)
+
+		assert.Equal(t, "Werner-Heisenberg-Allee 25", *doc.AccountingCustomerParty.Party.PostalAddress.StreetName)
+		assert.Equal(t, "München", *doc.AccountingCustomerParty.Party.PostalAddress.CityName)
+		assert.Equal(t, "80939", *doc.AccountingCustomerParty.Party.PostalAddress.PostalZone)
+		assert.Equal(t, "DE", doc.AccountingCustomerParty.Party.PostalAddress.Country.IdentificationCode)
+
+		assert.Equal(t, "0088", *doc.AccountingCustomerParty.Party.PartyIdentification[0].ID.SchemeID)
+		assert.Equal(t, "1234567890128", doc.AccountingCustomerParty.Party.PartyIdentification[0].ID.Value)
+	})
+
 	t.Run("invoice-complete.json", func(t *testing.T) {
 		doc, err := testInvoiceFrom("invoice-complete.json")
 		require.NoError(t, err)
 
 		assert.Equal(t, "inbox@example.com", doc.AccountingSupplierParty.Party.EndpointID.Value)
 		assert.Equal(t, "EM", doc.AccountingSupplierParty.Party.EndpointID.SchemeID)
+	})
+
+	t.Run("oioubl30-invoice-example.json", func(t *testing.T) {
+		doc, err := testInvoiceFrom("oioubl30-invoice-example.json")
+		require.NoError(t, err)
+
+		assert.Equal(t, "0088", doc.AccountingSupplierParty.Party.EndpointID.SchemeID)
+		assert.Equal(t, "0088", doc.AccountingCustomerParty.Party.EndpointID.SchemeID)
+
+		supplierLegalID := doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyID
+		require.NotNil(t, supplierLegalID)
+		require.NotNil(t, supplierLegalID.SchemeID)
+		assert.Equal(t, "0184", *supplierLegalID.SchemeID)
+		assert.Equal(t, "13585628", supplierLegalID.Value)
+
+		supplierTaxID := doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID
+		require.NotNil(t, supplierTaxID)
+		require.NotNil(t, supplierTaxID.SchemeID)
+		assert.Equal(t, "0198", *supplierTaxID.SchemeID)
+		assert.Equal(t, "DK13585628", supplierTaxID.Value)
+	})
+
+	t.Run("oioubl21 bare party fallbacks", func(t *testing.T) {
+		doc, err := testInvoiceFrom("oioubl21-invoice-bare.json")
+		require.NoError(t, err)
+
+		supplier := doc.AccountingSupplierParty.Party
+		customer := doc.AccountingCustomerParty.Party
+
+		// EndpointID falls back to CVR from PartyTaxScheme
+		require.NotNil(t, supplier.EndpointID)
+		assert.Equal(t, "DK:CVR", supplier.EndpointID.SchemeID)
+		assert.Equal(t, "DK37990485", supplier.EndpointID.Value)
+
+		require.NotNil(t, customer.EndpointID)
+		assert.Equal(t, "DK:CVR", customer.EndpointID.SchemeID)
+		assert.Equal(t, "DK47458714", customer.EndpointID.Value)
+
+		// PartyName falls back to RegistrationName
+		require.NotNil(t, supplier.PartyName)
+		assert.Equal(t, "Worksome Aps", supplier.PartyName.Name)
+
+		require.NotNil(t, customer.PartyName)
+		assert.Equal(t, "Lego System A/S", customer.PartyName.Name)
+
+		// Contact is always present with default ID
+		require.NotNil(t, supplier.Contact)
+		require.NotNil(t, supplier.Contact.ID)
+		assert.Equal(t, "1", *supplier.Contact.ID)
+
+		require.NotNil(t, customer.Contact)
+		require.NotNil(t, customer.Contact.ID)
+		assert.Equal(t, "1", *customer.Contact.ID)
+	})
+
+	t.Run("identity scopes map to legal and tax identifiers", func(t *testing.T) {
+		env, err := loadTestEnvelope("invoice-minimal.json")
+		require.NoError(t, err)
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Scope: org.IdentityScopeLegal,
+				Code:  cbc.Code("99887766"),
+				Ext: tax.Extensions{
+					iso.ExtKeySchemeID: cbc.Code("0184"),
+				},
+			},
+			{
+				Scope: org.IdentityScopeTax,
+				Type:  cbc.Code("VAT"),
+				Code:  cbc.Code("DK99887766"),
+				Ext: tax.Extensions{
+					iso.ExtKeySchemeID: cbc.Code("0198"),
+				},
+			},
+			{
+				Code: cbc.Code("1234567890128"),
+				Ext: tax.Extensions{
+					iso.ExtKeySchemeID: cbc.Code("0088"),
+				},
+			},
+		}
+
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+		require.NotNil(t, doc.AccountingSupplierParty)
+		require.NotNil(t, doc.AccountingSupplierParty.Party)
+		require.NotNil(t, doc.AccountingSupplierParty.Party.PartyLegalEntity)
+		require.NotNil(t, doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyID)
+		require.NotNil(t, doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyID.SchemeID)
+		assert.Equal(t, "99887766", doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyID.Value)
+		assert.Equal(t, "0184", *doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyID.SchemeID)
+
+		foundTaxIdentity := false
+		for _, pts := range doc.AccountingSupplierParty.Party.PartyTaxScheme {
+			if pts.CompanyID != nil && pts.CompanyID.Value == "DK99887766" {
+				foundTaxIdentity = true
+				require.NotNil(t, pts.CompanyID.SchemeID)
+				assert.Equal(t, "0198", *pts.CompanyID.SchemeID)
+				break
+			}
+		}
+		assert.True(t, foundTaxIdentity, "expected tax-scope identity in PartyTaxScheme")
+
+		require.NotEmpty(t, doc.AccountingSupplierParty.Party.PartyIdentification)
+		require.NotNil(t, doc.AccountingSupplierParty.Party.PartyIdentification[0].ID)
+		assert.Equal(t, "1234567890128", doc.AccountingSupplierParty.Party.PartyIdentification[0].ID.Value)
 	})
 
 }

--- a/payment.go
+++ b/payment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/untdid"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/pay"
 	"github.com/invopop/validation"
 )
@@ -12,6 +13,8 @@ import (
 // PaymentMeans represents the means of payment
 type PaymentMeans struct {
 	PaymentMeansCode      IDType            `xml:"cbc:PaymentMeansCode"`
+	PaymentDueDate        *string           `xml:"cbc:PaymentDueDate,omitempty"`
+	PaymentChannelCode    *IDType           `xml:"cbc:PaymentChannelCode,omitempty"`
 	InstructionID         *string           `xml:"cbc:InstructionID"`
 	InstructionNote       []string          `xml:"cbc:InstructionNote"`
 	PaymentID             *string           `xml:"cbc:PaymentID"`
@@ -44,8 +47,14 @@ type FinancialAccount struct {
 
 // Branch represents a branch of a financial institution
 type Branch struct {
-	ID   *string `xml:"cbc:ID"`
-	Name *string `xml:"cbc:Name"`
+	ID                   *string               `xml:"cbc:ID"`
+	Name                 *string               `xml:"cbc:Name"`
+	FinancialInstitution *FinancialInstitution `xml:"cac:FinancialInstitution"`
+}
+
+// FinancialInstitution represents a financial institution.
+type FinancialInstitution struct {
+	ID *string `xml:"cbc:ID"`
 }
 
 // PaymentTerms represents the terms of payment
@@ -66,14 +75,14 @@ type PrepaidPayment struct {
 
 const sepaSchemeID = "SEPA"
 
-func (ui *Invoice) addPayment(inv *bill.Invoice) error {
+func (ui *Invoice) addPayment(inv *bill.Invoice, o *options) error {
 	if inv == nil || inv.Payment == nil {
 		return nil
 	}
 	pymt := inv.Payment
 
 	if pymt.Instructions != nil {
-		if err := ui.addPaymentInstructions(pymt.Instructions); err != nil {
+		if err := ui.addPaymentInstructions(pymt.Instructions, o); err != nil {
 			return err
 		}
 	}
@@ -106,7 +115,7 @@ func (ui *Invoice) addPayment(inv *bill.Invoice) error {
 	return nil
 }
 
-func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions) error {
+func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions, o *options) error {
 	if instr.Ext == nil || instr.Ext.Get(untdid.ExtKeyPaymentMeans).String() == "" {
 		return validation.Errors{
 			"instructions": validation.Errors{
@@ -116,10 +125,19 @@ func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions) error {
 			},
 		}
 	}
+	paymentMeansCode := instr.Ext.Get(untdid.ExtKeyPaymentMeans).String()
+	if o != nil && o.context.IsOIOUBL() && paymentMeansCode == "30" {
+		paymentMeansCode = "31"
+	}
 	ui.PaymentMeans = []PaymentMeans{
 		{
-			PaymentMeansCode: IDType{Value: instr.Ext.Get(untdid.ExtKeyPaymentMeans).String()},
+			PaymentMeansCode: IDType{Value: paymentMeansCode},
 		},
+	}
+	if instr.Meta != nil {
+		if channel, ok := instr.Meta[cbc.Key("payment-channel")]; ok && channel != "" {
+			ui.PaymentMeans[0].PaymentChannelCode = &IDType{Value: channel}
+		}
 	}
 	if ref := instr.Ref.String(); ref != "" {
 		ui.PaymentMeans[0].PaymentID = &ref
@@ -128,7 +146,10 @@ func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions) error {
 		ui.PaymentMeans[0].PaymentMeansCode.Name = &instr.Detail
 	}
 	if len(instr.CreditTransfer) > 0 {
-		ui.PaymentMeans[0].PayeeFinancialAccount = newCreditTransferAccount(instr.CreditTransfer[0])
+		ui.PaymentMeans[0].PayeeFinancialAccount = newCreditTransferAccount(instr.CreditTransfer[0], o, paymentMeansCode)
+		if o != nil && o.context.IsOIOUBL() && paymentMeansCode == "31" && ui.PaymentMeans[0].PaymentChannelCode == nil {
+			ui.PaymentMeans[0].PaymentChannelCode = &IDType{Value: "IBAN"}
+		}
 	}
 	if instr.DirectDebit != nil {
 		ui.PaymentMeans[0].PaymentMandate = &PaymentMandate{
@@ -151,7 +172,7 @@ func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions) error {
 	return nil
 }
 
-func newCreditTransferAccount(ct *pay.CreditTransfer) *FinancialAccount {
+func newCreditTransferAccount(ct *pay.CreditTransfer, o *options, paymentMeansCode string) *FinancialAccount {
 	pfa := new(FinancialAccount)
 	if ct.IBAN != "" {
 		pfa.ID = &ct.IBAN
@@ -162,7 +183,13 @@ func newCreditTransferAccount(ct *pay.CreditTransfer) *FinancialAccount {
 		pfa.Name = &ct.Name
 	}
 	if ct.BIC != "" {
-		pfa.FinancialInstitutionBranch = &Branch{ID: &ct.BIC}
+		branch := &Branch{ID: &ct.BIC}
+		if o != nil && o.context.IsOIOUBL() && paymentMeansCode == "31" {
+			branch.FinancialInstitution = &FinancialInstitution{
+				ID: &ct.BIC,
+			}
+		}
+		pfa.FinancialInstitutionBranch = branch
 	}
 	return pfa
 }
@@ -192,7 +219,9 @@ func (ui *Invoice) addPaymentTerms(inv *bill.Invoice, pymt *bill.PaymentDetails)
 			ui.PaymentTerms = append(ui.PaymentTerms, term)
 		}
 	} else if len(pymt.Terms.DueDates) == 1 && ui.CreditNoteTypeCode == "" {
-		ui.DueDate = formatDate(*pymt.Terms.DueDates[0].Date)
+		if pymt.Terms.DueDates[0].Date != nil {
+			ui.DueDate = formatDate(*pymt.Terms.DueDates[0].Date)
+		}
 	} else {
 		ui.PaymentTerms = append(ui.PaymentTerms, PaymentTerms{
 			Note: []string{pymt.Terms.Notes},

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -56,8 +56,12 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice) error {
 		}
 	}
 
-	if ui.DueDate != "" {
-		d, err := parseDate(ui.DueDate)
+	dueDate := ui.DueDate
+	if dueDate == "" && len(ui.PaymentMeans) > 0 && ui.PaymentMeans[0].PaymentDueDate != nil {
+		dueDate = *ui.PaymentMeans[0].PaymentDueDate
+	}
+	if dueDate != "" {
+		d, err := parseDate(dueDate)
 		if err != nil {
 			return err
 		}

--- a/payment_test.go
+++ b/payment_test.go
@@ -5,6 +5,7 @@ import (
 
 	ubl "github.com/invopop/gobl.ubl"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,5 +48,78 @@ func TestNewPayment(t *testing.T) {
 
 		_, err = ubl.ConvertInvoice(env)
 		assert.ErrorContains(t, err, "instructions: (ext: (untdid-payment-means: required.).).")
+	})
+
+	t.Run("nemhandel payment mapping", func(t *testing.T) {
+		doc, err := testInvoiceFrom("oioubl30-invoice-example.json")
+		require.NoError(t, err)
+
+		require.NotEmpty(t, doc.PaymentMeans)
+		pm := doc.PaymentMeans[0]
+		assert.Equal(t, "31", pm.PaymentMeansCode.Value)
+		require.NotNil(t, pm.PaymentChannelCode)
+		assert.Equal(t, "IBAN", pm.PaymentChannelCode.Value)
+		require.NotNil(t, pm.PayeeFinancialAccount)
+		require.NotNil(t, pm.PayeeFinancialAccount.FinancialInstitutionBranch)
+		require.NotNil(t, pm.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution)
+		require.NotNil(t, pm.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution.ID)
+		assert.Equal(t, "EXAMGB2L", *pm.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution.ID)
+	})
+
+	t.Run("non OIO keeps payment means untouched", func(t *testing.T) {
+		doc, err := testInvoiceFrom("invoice-minimal.json")
+		require.NoError(t, err)
+		require.NotEmpty(t, doc.PaymentMeans)
+
+		pm := doc.PaymentMeans[0]
+		assert.Equal(t, "30", pm.PaymentMeansCode.Value)
+		assert.Nil(t, pm.PaymentChannelCode)
+		if pm.PayeeFinancialAccount != nil && pm.PayeeFinancialAccount.FinancialInstitutionBranch != nil {
+			assert.Nil(t, pm.PayeeFinancialAccount.FinancialInstitutionBranch.FinancialInstitution)
+		}
+	})
+
+	t.Run("OIO keeps explicit payment-channel", func(t *testing.T) {
+		env, err := loadTestEnvelope("oioubl30-invoice-example.json")
+		require.NoError(t, err)
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		inv.Payment.Instructions.Meta = cbc.Meta{
+			cbc.Key("payment-channel"): "ZZZ",
+		}
+
+		doc, err := ubl.ConvertInvoice(env, ubl.WithContext(ubl.ContextOIOUBL))
+		require.NoError(t, err)
+		require.NotEmpty(t, doc.PaymentMeans)
+		require.NotNil(t, doc.PaymentMeans[0].PaymentChannelCode)
+		assert.Equal(t, "ZZZ", doc.PaymentMeans[0].PaymentChannelCode.Value)
+		assert.Equal(t, "31", doc.PaymentMeans[0].PaymentMeansCode.Value)
+	})
+
+	t.Run("oioubl21 applies OIO payment mapping", func(t *testing.T) {
+		env, err := loadTestEnvelope("invoice-minimal.json")
+		require.NoError(t, err)
+
+		doc, err := ubl.ConvertInvoice(env, ubl.WithContext(ubl.ContextOIOUBL21))
+		require.NoError(t, err)
+		require.NotEmpty(t, doc.PaymentMeans)
+		assert.Equal(t, "31", doc.PaymentMeans[0].PaymentMeansCode.Value)
+	})
+
+	t.Run("single due date without date does not panic", func(t *testing.T) {
+		env, err := loadTestEnvelope("oioubl30-invoice-example.json")
+		require.NoError(t, err)
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		require.NotNil(t, inv.Payment)
+		require.NotNil(t, inv.Payment.Terms)
+		require.Len(t, inv.Payment.Terms.DueDates, 1)
+
+		inv.Payment.Terms.DueDates[0].Date = nil
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+		assert.Empty(t, doc.DueDate)
 	})
 }

--- a/test/data/convert/invoice-de-de.json
+++ b/test/data/convert/invoice-de-de.json
@@ -1,0 +1,174 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "2407803611261dee2462cb304a71a9ccfa020e69f055da5a767f5aca356b1a45"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DE",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-02-13",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"tax_id": {
+				"country": "DE",
+				"code": "111111125"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "John",
+						"surname": "Doe"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "+49100200300"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "DE",
+				"code": "282741168"
+			},
+			"identities": [
+				{
+					"code": "1234567890128",
+					"ext": {
+						"iso-scheme-id": "0088"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "19%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1800.00"
+			}
+		],
+		"ordering": {
+			"code": "PO4711",
+			"period": {
+				"start": "2013-03-10",
+				"end": "2013-04-10"
+			},
+			"contracts": [
+				{
+					"code": "2013-05"
+				}
+			],
+			"purchases": [
+				{
+					"code": "PO4711"
+				}
+			],
+			"receiving": [
+				{
+					"code": "3544"
+				}
+			],
+			"despatch": [
+				{
+					"code": "5433"
+				}
+			]
+		},
+		"payment": {
+			"terms": {
+				"notes": "lorem ipsum"
+			}
+		},
+		"totals": {
+			"sum": "1800.00",
+			"total": "1800.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1800.00",
+								"percent": "19%",
+								"amount": "342.00"
+							}
+						],
+						"amount": "342.00"
+					}
+				],
+				"sum": "342.00"
+			},
+			"tax": "342.00",
+			"total_with_tax": "2142.00",
+			"payable": "2142.00"
+		}
+	}
+}

--- a/test/data/convert/oioubl21-credit-note-minimal.json
+++ b/test/data/convert/oioubl21-credit-note-minimal.json
@@ -1,0 +1,165 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "7a3439bca6ef97fed6a8b96c4509be988e278eab82dfbede62983e8ed32befac"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "credit-note",
+		"series": "CN",
+		"code": "001",
+		"issue_date": "2024-05-15",
+		"currency": "EUR",
+		"preceding": [
+			{
+				"issue_date": "2024-05-01",
+				"series": "SAMPLE",
+				"code": "001",
+				"ext": {
+					"untdid-document-type": "380"
+				}
+			}
+		],
+		"tax": {
+			"ext": {
+				"untdid-document-type": "381"
+			}
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"alias": "Provide One GmbH",
+			"tax_id": {
+				"country": "DK",
+				"code": "16356706"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436101"
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"alias": "Sample Consumer",
+			"tax_id": {
+				"country": "DK",
+				"code": "12345678"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436057"
+				}
+			],
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "19%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1800.00"
+			}
+		],
+		"ordering": {
+			"cost": "5050"
+		},
+		"payment": {
+			"terms": {
+				"notes": "on receipt within 30 days"
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"ref": "0003434323213231",
+				"credit_transfer": [
+					{
+						"iban": "NO9386011117947",
+						"bic": "DNBANOKK"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1800.00",
+			"total": "1800.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1800.00",
+								"percent": "19%",
+								"amount": "342.00"
+							}
+						],
+						"amount": "342.00"
+					}
+				],
+				"sum": "342.00"
+			},
+			"tax": "342.00",
+			"total_with_tax": "2142.00",
+			"payable": "2142.00"
+		}
+	}
+}

--- a/test/data/convert/oioubl21-invoice-bare.json
+++ b/test/data/convert/oioubl21-invoice-bare.json
@@ -1,0 +1,154 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "eacc9132215ea54c092dd79a7960a6251065fe1396482aaf0e70b6fad89fb2ae"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-05-15",
+		"currency": "DKK",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Worksome Aps",
+			"tax_id": {
+				"country": "DK",
+				"code": "37990485"
+			},
+			"addresses": [
+				{
+					"street": "Dampfærgevej 7-9",
+					"locality": "København Ø",
+					"code": "2100",
+					"country": "DK"
+				}
+			]
+		},
+		"customer": {
+			"name": "Lego System A/S",
+			"tax_id": {
+				"country": "DK",
+				"code": "47458714"
+			},
+			"addresses": [
+				{
+					"street": "Aastvej 1",
+					"locality": "Billund",
+					"code": "7190",
+					"country": "DK"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Booking Fee (Fixed Rate)",
+					"price": "31676.00",
+					"unit": "one"
+				},
+				"sum": "31676.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "31676.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Worksome service fee",
+					"price": "1267.04",
+					"unit": "one"
+				},
+				"sum": "1267.04",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1267.04"
+			}
+		],
+		"payment": {
+			"terms": {
+				"due_dates": [
+					{
+						"date": "2024-06-15",
+						"amount": "41178.80",
+						"currency": "DKK"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"ref": "SAMPLE-001",
+				"credit_transfer": [
+					{
+						"iban": "DK5000400440116243",
+						"bic": "DABADKKK",
+						"name": "Danske Bank"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "32943.04",
+			"total": "32943.04",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "32943.04",
+								"percent": "25%",
+								"amount": "8235.76"
+							}
+						],
+						"amount": "8235.76"
+					}
+				],
+				"sum": "8235.76"
+			},
+			"tax": "8235.76",
+			"total_with_tax": "41178.80",
+			"payable": "41178.80"
+		}
+	}
+}

--- a/test/data/convert/oioubl21-invoice-minimal.json
+++ b/test/data/convert/oioubl21-invoice-minimal.json
@@ -1,0 +1,155 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "cc38b56ece9296fb4cee335f4caee5d8781e065ed28dc804010b421a011a97b0"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-05-15",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"alias": "Provide One GmbH",
+			"tax_id": {
+				"country": "DK",
+				"code": "16356706"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436101"
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"alias": "Sample Consumer",
+			"tax_id": {
+				"country": "DK",
+				"code": "12345678"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436057"
+				}
+			],
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "19%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1800.00"
+			}
+		],
+		"ordering": {
+			"cost": "5050"
+		},
+		"payment": {
+			"terms": {
+				"notes": "on receipt within 30 days"
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"ref": "0003434323213231",
+				"credit_transfer": [
+					{
+						"iban": "NO9386011117947",
+						"bic": "DNBANOKK"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1800.00",
+			"total": "1800.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1800.00",
+								"percent": "19%",
+								"amount": "342.00"
+							}
+						],
+						"amount": "342.00"
+					}
+				],
+				"sum": "342.00"
+			},
+			"tax": "342.00",
+			"total_with_tax": "2142.00",
+			"payable": "2142.00"
+		}
+	}
+}

--- a/test/data/convert/oioubl30-invoice-example.json
+++ b/test/data/convert/oioubl30-invoice-example.json
@@ -1,0 +1,223 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "053b9626f0c738a94f438165a88ad5fab8cb488888cb5f71a51e78afd0fcaba5"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"code": "INV-EXAMPLE-001",
+		"issue_date": "2026-02-10",
+		"currency": "EUR",
+		"exchange_rates": [
+			{
+				"from": "EUR",
+				"to": "DKK",
+				"amount": "7.4500"
+			}
+		],
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Example Supplier ApS",
+			"alias": "Example Supplier ApS",
+			"tax_id": {
+				"country": "DK",
+				"code": "13585628"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436101"
+				}
+			],
+			"addresses": [
+				{
+					"num": "35",
+					"street": "Example Street",
+					"locality": "Copenhagen",
+					"code": "1000",
+					"country": "DK"
+				}
+			]
+		},
+		"customer": {
+			"name": "Example Buyer A/S",
+			"alias": "Example Buyer A/S",
+			"tax_id": {
+				"country": "DK",
+				"code": "88146328"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "Billing"
+					}
+				}
+			],
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436057"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Sample Road",
+					"locality": "Aarhus",
+					"code": "8000",
+					"country": "DK"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Service Fee",
+					"price": "12500.00",
+					"unit": "EA"
+				},
+				"sum": "12500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "12500.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Expenses",
+					"price": "950.00",
+					"unit": "EA"
+				},
+				"sum": "950.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "950.00"
+			},
+			{
+				"i": 3,
+				"quantity": "1",
+				"item": {
+					"name": "Platform Fee",
+					"price": "500.00",
+					"unit": "EA"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "500.00"
+			}
+		],
+		"ordering": {
+			"purchases": [
+				{
+					"code": "PO-EXAMPLE-001"
+				}
+			]
+		},
+		"payment": {
+			"terms": {
+				"due_dates": [
+					{
+						"date": "2026-02-27",
+						"amount": "17437.50",
+						"currency": "EUR"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"ref": "INV-EXAMPLE-001",
+				"credit_transfer": [
+					{
+						"iban": "GB00EXAM00000000000000",
+						"bic": "EXAMGB2L",
+						"name": "Example Bank Ltd"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				},
+				"meta": {
+					"payment-channel": "IBAN"
+				}
+			}
+		},
+		"totals": {
+			"sum": "13950.00",
+			"total": "13950.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "13950.00",
+								"percent": "25%",
+								"amount": "3487.50"
+							}
+						],
+						"amount": "3487.50"
+					}
+				],
+				"sum": "3487.50"
+			},
+			"tax": "3487.50",
+			"total_with_tax": "17437.50",
+			"payable": "17437.50"
+		},
+		"notes": [
+			{
+				"key": "general",
+				"text": "Bill ID: EX-0001\nContractor ID: CT-0459\nContractor Name: Example Person\nJob Name: Sample Role\nBill Period: 2026-01-10 - 2026-02-06\nExchanged amounts:\nConversion rate: 1 EUR = 7.4500 DKK\nSubtotal: 105,000.00 DKK, Tax: 26,250.00 DKK, Total: 131,250.00 DKK",
+				"ext": {
+					"untdid-text-subject": "AAI"
+				}
+			}
+		]
+	}
+}

--- a/test/data/convert/oioubl30-invoice-minimal.json
+++ b/test/data/convert/oioubl30-invoice-minimal.json
@@ -1,0 +1,155 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "cc38b56ece9296fb4cee335f4caee5d8781e065ed28dc804010b421a011a97b0"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-05-15",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"alias": "Provide One GmbH",
+			"tax_id": {
+				"country": "DK",
+				"code": "16356706"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436101"
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"alias": "Sample Consumer",
+			"tax_id": {
+				"country": "DK",
+				"code": "12345678"
+			},
+			"inboxes": [
+				{
+					"scheme": "GLN",
+					"code": "5790000436057"
+				}
+			],
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "19%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1800.00"
+			}
+		],
+		"ordering": {
+			"cost": "5050"
+		},
+		"payment": {
+			"terms": {
+				"notes": "on receipt within 30 days"
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"ref": "0003434323213231",
+				"credit_transfer": [
+					{
+						"iban": "NO9386011117947",
+						"bic": "DNBANOKK"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1800.00",
+			"total": "1800.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1800.00",
+								"percent": "19%",
+								"amount": "342.00"
+							}
+						],
+						"amount": "342.00"
+					}
+				],
+				"sum": "342.00"
+			},
+			"tax": "342.00",
+			"total_with_tax": "2142.00",
+			"payable": "2142.00"
+		}
+	}
+}

--- a/test/data/convert/out/oioubl21-credit-note-minimal.xml
+++ b/test/data/convert/out/oioubl21-credit-note-minimal.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2 https://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ID>CN-001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2024-05-15</cbc:IssueDate>
+  <cbc:CreditNoteTypeCode listAgencyID="320" listID="urn:oioubl:codelist:invoicetypecode-1.1">381</cbc:CreditNoteTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>5050</cbc:AccountingCost>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>SAMPLE-001</cbc:ID>
+      <cbc:IssueDate>2024-05-01</cbc:IssueDate>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="GLN">5790000436101</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Provide One GmbH</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+        <cbc:StreetName>Dietmar-Hopp-Allee 16</cbc:StreetName>
+        <cbc:BuildingNumber>16</cbc:BuildingNumber>
+        <cbc:CityName>Walldorf</cbc:CityName>
+        <cbc:PostalZone>69190</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK16356706</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Provide One GmbH</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK16356706</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>1</cbc:ID>
+        <cbc:ElectronicMail>billing@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="GLN">5790000436057</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Sample Consumer</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+        <cbc:StreetName>Werner-Heisenberg-Allee 25</cbc:StreetName>
+        <cbc:BuildingNumber>25</cbc:BuildingNumber>
+        <cbc:CityName>München</cbc:CityName>
+        <cbc:PostalZone>80939</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK12345678</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Sample Consumer</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK12345678</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>1</cbc:ID>
+        <cbc:ElectronicMail>email@sample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+    <cbc:PaymentChannelCode listID="urn:oioubl:codelist:paymentchannelcode-1.1">IBAN</cbc:PaymentChannelCode>
+    <cbc:PaymentID>0003434323213231</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>NO9386011117947</cbc:ID>
+      <cac:FinancialInstitutionBranch>
+        <cac:FinancialInstitution>
+          <cbc:ID>DNBANOKK</cbc:ID>
+        </cac:FinancialInstitution>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>on receipt within 30 days</cbc:Note>
+    <cbc:Amount currencyID="EUR">2142.00</cbc:Amount>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">342.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2142.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">2142.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:CreditNoteLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:CreditedQuantity unitCode="HUR">20</cbc:CreditedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+          <cbc:Percent>19</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+            <cbc:Name>Moms</cbc:Name>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Development services</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">90.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:CreditNoteLine>
+</CreditNote>

--- a/test/data/convert/out/oioubl21-invoice-bare.xml
+++ b/test/data/convert/out/oioubl21-invoice-bare.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ID>SAMPLE-001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2024-05-15</cbc:IssueDate>
+  <cbc:InvoiceTypeCode listAgencyID="320" listID="urn:oioubl:codelist:invoicetypecode-1.1">380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>DKK</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="DK:CVR">DK37990485</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Worksome Aps</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+        <cbc:StreetName>Dampfærgevej 7-9</cbc:StreetName>
+        <cbc:BuildingNumber>7-9</cbc:BuildingNumber>
+        <cbc:CityName>København Ø</cbc:CityName>
+        <cbc:PostalZone>2100</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK37990485</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Worksome Aps</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK37990485</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>1</cbc:ID>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="DK:CVR">DK47458714</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Lego System A/S</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+        <cbc:StreetName>Aastvej 1</cbc:StreetName>
+        <cbc:BuildingNumber>1</cbc:BuildingNumber>
+        <cbc:CityName>Billund</cbc:CityName>
+        <cbc:PostalZone>7190</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK47458714</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Lego System A/S</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK47458714</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>1</cbc:ID>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2024-06-15</cbc:PaymentDueDate>
+    <cbc:PaymentChannelCode listID="urn:oioubl:codelist:paymentchannelcode-1.1">IBAN</cbc:PaymentChannelCode>
+    <cbc:PaymentID>SAMPLE-001</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>DK5000400440116243</cbc:ID>
+      <cbc:Name>Danske Bank</cbc:Name>
+      <cac:FinancialInstitutionBranch>
+        <cac:FinancialInstitution>
+          <cbc:ID>DABADKKK</cbc:ID>
+        </cac:FinancialInstitution>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="DKK">8235.76</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="DKK">32943.04</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="DKK">8235.76</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="DKK">32943.04</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="DKK">8235.76</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="DKK">41178.80</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="DKK">41178.80</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="DKK">31676.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="DKK">7919.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="DKK">31676.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="DKK">7919.00</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+            <cbc:Name>Moms</cbc:Name>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Booking Fee (Fixed Rate)</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="DKK">31676.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="DKK">1267.04</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="DKK">316.76</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="DKK">1267.04</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="DKK">316.76</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+            <cbc:Name>Moms</cbc:Name>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Worksome service fee</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="DKK">1267.04</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/convert/out/oioubl21-invoice-minimal.xml
+++ b/test/data/convert/out/oioubl21-invoice-minimal.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ID>SAMPLE-001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2024-05-15</cbc:IssueDate>
+  <cbc:InvoiceTypeCode listAgencyID="320" listID="urn:oioubl:codelist:invoicetypecode-1.1">380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>5050</cbc:AccountingCost>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="GLN">5790000436101</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Provide One GmbH</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+        <cbc:StreetName>Dietmar-Hopp-Allee 16</cbc:StreetName>
+        <cbc:BuildingNumber>16</cbc:BuildingNumber>
+        <cbc:CityName>Walldorf</cbc:CityName>
+        <cbc:PostalZone>69190</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK16356706</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Provide One GmbH</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK16356706</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>1</cbc:ID>
+        <cbc:ElectronicMail>billing@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="GLN">5790000436057</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Sample Consumer</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+        <cbc:StreetName>Werner-Heisenberg-Allee 25</cbc:StreetName>
+        <cbc:BuildingNumber>25</cbc:BuildingNumber>
+        <cbc:CityName>München</cbc:CityName>
+        <cbc:PostalZone>80939</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK12345678</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Sample Consumer</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK12345678</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>1</cbc:ID>
+        <cbc:ElectronicMail>email@sample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+    <cbc:PaymentChannelCode listID="urn:oioubl:codelist:paymentchannelcode-1.1">IBAN</cbc:PaymentChannelCode>
+    <cbc:PaymentID>0003434323213231</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>NO9386011117947</cbc:ID>
+      <cac:FinancialInstitutionBranch>
+        <cac:FinancialInstitution>
+          <cbc:ID>DNBANOKK</cbc:ID>
+        </cac:FinancialInstitution>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>on receipt within 30 days</cbc:Note>
+    <cbc:Amount currencyID="EUR">2142.00</cbc:Amount>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">342.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2142.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">2142.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="HUR">20</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+          <cbc:Percent>19</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+            <cbc:Name>Moms</cbc:Name>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Development services</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.2">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">90.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/convert/out/oioubl30-invoice-example.xml
+++ b/test/data/convert/out/oioubl30-invoice-example.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>urn:fdc:oioubl.dk:trns:billing:invoice:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:oioubl.dk:bis:billing_with_response:3</cbc:ProfileID>
+  <cbc:ID>INV-EXAMPLE-001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2026-02-10</cbc:IssueDate>
+  <cbc:DueDate>2026-02-27</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:Note>Bill ID: EX-0001&#xA;Contractor ID: CT-0459&#xA;Contractor Name: Example Person&#xA;Job Name: Sample Role&#xA;Bill Period: 2026-01-10 - 2026-02-06&#xA;Exchanged amounts:&#xA;Conversion rate: 1 EUR = 7.4500 DKK&#xA;Subtotal: 105,000.00 DKK, Tax: 26,250.00 DKK, Total: 131,250.00 DKK</cbc:Note>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>PO-EXAMPLE-001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">5790000436101</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Example Supplier ApS</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Example Street 35</cbc:StreetName>
+        <cbc:CityName>Copenhagen</cbc:CityName>
+        <cbc:PostalZone>1000</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="0198">DK13585628</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Example Supplier ApS</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0184">13585628</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">5790000436057</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Example Buyer A/S</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Sample Road 1</cbc:StreetName>
+        <cbc:CityName>Aarhus</cbc:CityName>
+        <cbc:PostalZone>8000</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="0198">DK88146328</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Example Buyer A/S</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0184">88146328</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Billing</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+    <cbc:PaymentChannelCode>IBAN</cbc:PaymentChannelCode>
+    <cbc:PaymentID>INV-EXAMPLE-001</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>GB00EXAM00000000000000</cbc:ID>
+      <cbc:Name>Example Bank Ltd</cbc:Name>
+      <cac:FinancialInstitutionBranch>
+        <cbc:ID>EXAMGB2L</cbc:ID>
+        <cac:FinancialInstitution>
+          <cbc:ID>EXAMGB2L</cbc:ID>
+        </cac:FinancialInstitution>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">3487.50</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">13950.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">3487.50</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">13950.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">13950.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">17437.50</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">17437.50</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">12500.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">3125.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">12500.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">3125.00</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID>S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Service Fee</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">12500.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">950.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">237.50</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">950.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">237.50</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID>S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Expenses</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">950.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>3</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">500.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">125.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">500.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">125.00</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID>S</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Platform Fee</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">500.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/convert/out/oioubl30-invoice-minimal.xml
+++ b/test/data/convert/out/oioubl30-invoice-minimal.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>urn:fdc:oioubl.dk:trns:billing:invoice:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:oioubl.dk:bis:billing_with_response:3</cbc:ProfileID>
+  <cbc:ID>SAMPLE-001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2024-05-15</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:AccountingCost>5050</cbc:AccountingCost>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">5790000436101</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Provide One GmbH</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Dietmar-Hopp-Allee 16</cbc:StreetName>
+        <cbc:CityName>Walldorf</cbc:CityName>
+        <cbc:PostalZone>69190</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="0198">DK16356706</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Provide One GmbH</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0184">16356706</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>billing@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">5790000436057</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Sample Consumer</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Werner-Heisenberg-Allee 25</cbc:StreetName>
+        <cbc:CityName>München</cbc:CityName>
+        <cbc:PostalZone>80939</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="0198">DK12345678</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Sample Consumer</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0184">12345678</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>email@sample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+    <cbc:PaymentChannelCode>IBAN</cbc:PaymentChannelCode>
+    <cbc:PaymentID>0003434323213231</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>NO9386011117947</cbc:ID>
+      <cac:FinancialInstitutionBranch>
+        <cbc:ID>DNBANOKK</cbc:ID>
+        <cac:FinancialInstitution>
+          <cbc:ID>DNBANOKK</cbc:ID>
+        </cac:FinancialInstitution>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>on receipt within 30 days</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">1800.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2142.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">2142.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="HUR">20</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID>S</cbc:ID>
+          <cbc:Percent>19</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID>VAT</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Development services</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">90.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/totals.go
+++ b/totals.go
@@ -25,7 +25,7 @@ type TaxSubtotal struct {
 
 // TaxCategory represents a tax category
 type TaxCategory struct {
-	ID                     *string    `xml:"cbc:ID,omitempty"`
+	ID                     *IDType    `xml:"cbc:ID,omitempty"`
 	Percent                *string    `xml:"cbc:Percent,omitempty"`
 	TaxExemptionReasonCode *string    `xml:"cbc:TaxExemptionReasonCode,omitempty"`
 	TaxExemptionReason     *string    `xml:"cbc:TaxExemptionReason,omitempty"`
@@ -93,8 +93,8 @@ func (ui *Invoice) addTotals(inv *bill.Invoice) {
 
 				if r.Ext != nil {
 					if r.Ext[untdid.ExtKeyTaxCategory].String() != "" {
-						k := r.Ext[untdid.ExtKeyTaxCategory].String()
-						taxCat.ID = &k
+					k := r.Ext[untdid.ExtKeyTaxCategory].String()
+					taxCat.ID = &IDType{Value: k}
 					}
 					if r.Ext[cef.ExtKeyVATEX].String() != "" {
 						v := r.Ext[cef.ExtKeyVATEX].String()
@@ -116,14 +116,14 @@ func (ui *Invoice) addTotals(inv *bill.Invoice) {
 				if r.Percent != nil {
 					p := r.Percent.StringWithoutSymbol()
 					taxCat.Percent = &p
-				} else if taxCat.ID == nil || *taxCat.ID != "O" {
+				} else if taxCat.ID == nil || taxCat.ID.Value != "O" {
 					// Default to 0% when not outside scope
 					p := "0"
 					taxCat.Percent = &p
 				}
 
 				if cat.Code != cbc.CodeEmpty {
-					taxCat.TaxScheme = &TaxScheme{ID: cat.Code.String()}
+					taxCat.TaxScheme = &TaxScheme{ID: IDType{Value: cat.Code.String()}}
 				}
 				subtotal.TaxCategory = taxCat
 				ui.TaxTotal[0].TaxSubtotal = append(ui.TaxTotal[0].TaxSubtotal, subtotal)
@@ -144,9 +144,7 @@ func (ui *Invoice) buildTaxCategoryMap() map[string]*taxCategoryInfo {
 	for _, taxTotal := range ui.TaxTotal {
 		for _, subtotal := range taxTotal.TaxSubtotal {
 			if subtotal.TaxCategory.ID != nil && subtotal.TaxCategory.TaxScheme != nil {
-				schemeID := subtotal.TaxCategory.TaxScheme.ID
-				categoryID := *subtotal.TaxCategory.ID
-				key := buildTaxCategoryKey(schemeID, categoryID, subtotal.TaxCategory.Percent)
+				key := buildTaxCategoryKey(subtotal.TaxCategory.TaxScheme.ID.Value, subtotal.TaxCategory.ID.Value, subtotal.TaxCategory.Percent)
 				info := &taxCategoryInfo{}
 				if subtotal.TaxCategory.TaxExemptionReasonCode != nil {
 					info.exemptionReasonCode = *subtotal.TaxCategory.TaxExemptionReasonCode

--- a/totals_test.go
+++ b/totals_test.go
@@ -21,7 +21,7 @@ func TestNewTotals(t *testing.T) {
 		assert.Equal(t, "1764.18", doc.LegalMonetaryTotal.PayableAmount.Value)
 
 		assert.Equal(t, "340.20", doc.TaxTotal[0].TaxAmount.Value)
-		assert.Equal(t, "VAT", doc.TaxTotal[0].TaxSubtotal[0].TaxCategory.TaxScheme.ID)
+		assert.Equal(t, "VAT", doc.TaxTotal[0].TaxSubtotal[0].TaxCategory.TaxScheme.ID.Value)
 		assert.Equal(t, "21.0", *doc.TaxTotal[0].TaxSubtotal[0].TaxCategory.Percent)
 	})
 }

--- a/ubl.go
+++ b/ubl.go
@@ -172,5 +172,23 @@ func Bytes(in any) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if inv, ok := in.(*Invoice); ok && inv.CustomizationID == ContextOIOUBL21.CustomizationID {
+		if inv.ProfileID != "" {
+			raw := []byte(fmt.Sprintf("<cbc:ProfileID>%s</cbc:ProfileID>", inv.ProfileID))
+			withAttrs := []byte(fmt.Sprintf("<cbc:ProfileID schemeAgencyID=\"320\" schemeID=\"urn:oioubl:id:profileid-1.4\">%s</cbc:ProfileID>", inv.ProfileID))
+			b = bytes.ReplaceAll(b, raw, withAttrs)
+		}
+		if inv.InvoiceTypeCode != "" {
+			raw := []byte(fmt.Sprintf("<cbc:InvoiceTypeCode>%s</cbc:InvoiceTypeCode>", inv.InvoiceTypeCode))
+			withAttrs := []byte(fmt.Sprintf("<cbc:InvoiceTypeCode listAgencyID=\"320\" listID=\"urn:oioubl:codelist:invoicetypecode-1.1\">%s</cbc:InvoiceTypeCode>", inv.InvoiceTypeCode))
+			b = bytes.ReplaceAll(b, raw, withAttrs)
+		}
+		if inv.CreditNoteTypeCode != "" {
+			raw := []byte(fmt.Sprintf("<cbc:CreditNoteTypeCode>%s</cbc:CreditNoteTypeCode>", inv.CreditNoteTypeCode))
+			withAttrs := []byte(fmt.Sprintf("<cbc:CreditNoteTypeCode listAgencyID=\"320\" listID=\"urn:oioubl:codelist:invoicetypecode-1.1\">%s</cbc:CreditNoteTypeCode>", inv.CreditNoteTypeCode))
+			b = bytes.ReplaceAll(b, raw, withAttrs)
+		}
+	}
+
 	return append([]byte(xml.Header), b...), nil
 }


### PR DESCRIPTION
## Summary

- Add OIOUBL 3.0 and legacy OIOUBL 2.1 contexts for Nemhandel Danish e-invoicing
- New `ContextOIOUBL` and `ContextOIOUBL21` document contexts with `IsOIOUBL()` helper
- Extended `IDType` with `SchemeAgencyID`/`ListAgencyID` attributes
- `PartyTaxScheme.CompanyID` and `TaxScheme.ID` changed to `IDType` for richer scheme metadata
- DK-specific party logic (`schemeID="0198"` for VAT, `schemeID="0184"` for legal entity)
- Line-level `TaxTotal` generation for OIOUBL invoices
- `PaymentMeans` extensions (`PaymentDueDate`, `PaymentChannelCode`, `FinancialInstitution`) with code 30->31 mapping
- OIOUBL 2.1 legacy XML attribute injection (`ProfileID schemeAgencyID`, `InvoiceTypeCode listAgencyID/listID`)
- CLI `--context` and `--profile-id` flags for conversion
- Test fixtures and golden files for both OIOUBL variants
- Schematron integration test support for OIOUBL 2.1 validation

All existing Peppol, EN16931, XRechnung, and France CTC/Extended tests continue to pass unchanged.

## Breaking changes

All four changes follow the same pattern: plain string fields widened to `IDType` to support XML scheme attributes required by OIOUBL. This aligns them with other ID fields in the codebase (e.g. `PartyLegalEntity.CompanyID`, `ItemIdentification.ID`) that already use `IDType`.

| Struct | Field | Before | After |
|--------|-------|--------|-------|
| `TaxScheme` | `ID` | `string` | `IDType` |
| `TaxCategory` | `ID` | `*string` | `*IDType` |
| `ClassifiedTaxCategory` | `ID` | `*string` | `*IDType` |
| `PartyTaxScheme` | `CompanyID` | `*string` | `*IDType` |

**Migration guide:**

```go
// Reading a value:
// Before:  scheme.ID
// After:   scheme.ID.Value

// Before:  *category.ID
// After:   category.ID.Value

// Assigning a value:
// Before:  TaxScheme{ID: "VAT"}
// After:   TaxScheme{ID: IDType{Value: "VAT"}}

// Before:  category.ID = &s
// After:   category.ID = &IDType{Value: s}
```

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing + new tests)
- [x] OIOUBL 3.0 XML validates against Nemhandel OIOUBL schematron
- [x] OIOUBL 2.1 XML validates against legacy schematron
- [x] Tested with [OIOUBL online validator](https://oioubl.nemhandel.dk/validation)
- [ ] Reviewer confirms breaking type changes are acceptable
