### PR TITLE
Fix: missing payment notes when due dates > 1

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -83,7 +83,7 @@ type Invoice struct {
 	Delivery                       []*Delivery         `xml:"cac:Delivery,omitempty"`
 	DeliveryTerms                  *DeliveryTerms      `xml:"cac:DeliveryTerms,omitempty"`
 	PaymentMeans                   []PaymentMeans      `xml:"cac:PaymentMeans,omitempty"`
-	PaymentTerms                   []PaymentTerms      `xml:"cac:PaymentTerms,omitempty"`
+	PaymentTerms                   *PaymentTerms       `xml:"cac:PaymentTerms,omitempty"`
 	PrepaidPayment                 []PrepaidPayment    `xml:"cac:PrepaidPayment,omitempty"`
 	AllowanceCharge                []AllowanceCharge   `xml:"cac:AllowanceCharge,omitempty"`
 	TaxExchangeRate                *ExchangeRate       `xml:"cac:TaxExchangeRate,omitempty"`

--- a/payment.go
+++ b/payment.go
@@ -193,7 +193,9 @@ func (ui *Invoice) addPaymentTerms(inv *bill.Invoice, pymt *bill.PaymentDetails)
 		}
 	} else if len(pymt.Terms.DueDates) == 1 && ui.CreditNoteTypeCode == "" {
 		ui.DueDate = formatDate(*pymt.Terms.DueDates[0].Date)
-	} else {
+	}
+
+	if pymt.Terms.Notes != "" {
 		ui.PaymentTerms = append(ui.PaymentTerms, PaymentTerms{
 			Note: []string{pymt.Terms.Notes},
 		})

--- a/payment.go
+++ b/payment.go
@@ -50,10 +50,7 @@ type Branch struct {
 
 // PaymentTerms represents the terms of payment
 type PaymentTerms struct {
-	Note           []string `xml:"cbc:Note"`
-	Amount         *Amount  `xml:"cbc:Amount"`
-	PaymentPercent *string  `xml:"cbc:PaymentPercent"`
-	PaymentDueDate *string  `xml:"cbc:PaymentDueDate"`
+	Note string `xml:"cbc:Note"`
 }
 
 // PrepaidPayment represents a prepaid payment
@@ -79,7 +76,7 @@ func (ui *Invoice) addPayment(inv *bill.Invoice) error {
 	}
 
 	if pymt.Terms != nil {
-		ui.addPaymentTerms(inv, pymt)
+		ui.addPaymentTerms(pymt)
 	}
 
 	if pymt.Payee != nil {
@@ -167,37 +164,18 @@ func newCreditTransferAccount(ct *pay.CreditTransfer) *FinancialAccount {
 	return pfa
 }
 
-func (ui *Invoice) addPaymentTerms(inv *bill.Invoice, pymt *bill.PaymentDetails) {
-	ui.PaymentTerms = make([]PaymentTerms, 0)
-	if (len(pymt.Terms.DueDates) > 1) || (ui.CreditNoteTypeCode != "" && len(pymt.Terms.DueDates) > 0) {
-		for _, dueDate := range pymt.Terms.DueDates {
-			currency := dueDate.Currency.String()
-			if currency == "" {
-				currency = inv.Currency.String()
-			}
-			term := PaymentTerms{
-				Amount: &Amount{Value: dueDate.Amount.String(), CurrencyID: &currency},
-			}
-			if dueDate.Date != nil {
-				d := formatDate(*dueDate.Date)
-				term.PaymentDueDate = &d
-			}
-			if dueDate.Percent != nil {
-				p := dueDate.Percent.String()
-				term.PaymentPercent = &p
-			}
-			if dueDate.Notes != "" {
-				term.Note = []string{dueDate.Notes}
-			}
-			ui.PaymentTerms = append(ui.PaymentTerms, term)
+func (ui *Invoice) addPaymentTerms(pymt *bill.PaymentDetails) {
+	if pymt.Terms.Notes != "" {
+		ui.PaymentTerms = &PaymentTerms{
+			Note: pymt.Terms.Notes,
 		}
-	} else if len(pymt.Terms.DueDates) == 1 && ui.CreditNoteTypeCode == "" {
+	}
+
+	// Only one due date allowed under EN 16931
+	if len(pymt.Terms.DueDates) > 0 && ui.CreditNoteTypeCode == "" {
 		ui.DueDate = formatDate(*pymt.Terms.DueDates[0].Date)
 	}
 
-	if pymt.Terms.Notes != "" {
-		ui.PaymentTerms = append(ui.PaymentTerms, PaymentTerms{
-			Note: []string{pymt.Terms.Notes},
-		})
-	}
+	// TODO: under PEPPOL BIS, credit notes do have an optional PaymentDueDates field.
+	// Future implementations may need to cover this.
 }

--- a/payment.go
+++ b/payment.go
@@ -12,6 +12,7 @@ import (
 // PaymentMeans represents the means of payment
 type PaymentMeans struct {
 	PaymentMeansCode      IDType            `xml:"cbc:PaymentMeansCode"`
+	PaymentDueDate        *string           `xml:"cbc:PaymentDueDate"`
 	InstructionID         *string           `xml:"cbc:InstructionID"`
 	InstructionNote       []string          `xml:"cbc:InstructionNote"`
 	PaymentID             *string           `xml:"cbc:PaymentID"`
@@ -70,7 +71,7 @@ func (ui *Invoice) addPayment(inv *bill.Invoice) error {
 	pymt := inv.Payment
 
 	if pymt.Instructions != nil {
-		if err := ui.addPaymentInstructions(pymt.Instructions); err != nil {
+		if err := ui.addPaymentInstructions(pymt); err != nil {
 			return err
 		}
 	}
@@ -103,7 +104,8 @@ func (ui *Invoice) addPayment(inv *bill.Invoice) error {
 	return nil
 }
 
-func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions) error {
+func (ui *Invoice) addPaymentInstructions(pymt *bill.PaymentDetails) error {
+	instr := pymt.Instructions
 	if instr.Ext == nil || instr.Ext.Get(untdid.ExtKeyPaymentMeans).String() == "" {
 		return validation.Errors{
 			"instructions": validation.Errors{
@@ -145,6 +147,10 @@ func (ui *Invoice) addPaymentInstructions(instr *pay.Instructions) error {
 			ui.PaymentMeans[0].CardAccount.HolderName = &instr.Card.Holder
 		}
 	}
+	if ui.CreditNoteTypeCode != "" && pymt.Terms != nil && len(pymt.Terms.DueDates) > 0 {
+		formattedDate := formatDate(*pymt.Terms.DueDates[0].Date)
+		ui.PaymentMeans[0].PaymentDueDate = &formattedDate
+	}
 	return nil
 }
 
@@ -172,10 +178,7 @@ func (ui *Invoice) addPaymentTerms(pymt *bill.PaymentDetails) {
 	}
 
 	// Only one due date allowed under EN 16931
-	if len(pymt.Terms.DueDates) > 0 && ui.CreditNoteTypeCode == "" {
+	if ui.CreditNoteTypeCode == "" && len(pymt.Terms.DueDates) > 0 {
 		ui.DueDate = formatDate(*pymt.Terms.DueDates[0].Date)
 	}
-
-	// TODO: under PEPPOL BIS, credit notes do have an optional PaymentDueDates field.
-	// Future implementations may need to cover this.
 }

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -42,8 +42,16 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice) error {
 		}
 	}
 
-	if ui.DueDate != "" {
-		d, err := parseDate(ui.DueDate)
+	var dueDate string
+	if ui.CreditNoteTypeCode == "" && ui.DueDate != "" {
+		dueDate = ui.DueDate
+	}
+	if ui.CreditNoteTypeCode != "" && len(ui.PaymentMeans) > 0 && ui.PaymentMeans[0].PaymentDueDate != nil {
+		dueDate = *ui.PaymentMeans[0].PaymentDueDate
+	}
+
+	if dueDate != "" {
+		d, err := parseDate(dueDate)
 		if err != nil {
 			return err
 		}

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -36,23 +36,9 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice) error {
 		payment.Payee = goblParty(ui.PayeeParty)
 	}
 
-	if len(ui.PaymentTerms) > 0 {
-		payment.Terms = &pay.Terms{}
-		note := make([]string, 0)
-		for _, term := range ui.PaymentTerms {
-			note = append(note, term.Note...)
-			if term.Amount != nil {
-				amount, err := num.AmountFromString(normalizeNumericString(term.Amount.Value))
-				if err != nil {
-					return err
-				}
-				payment.Terms.DueDates = append(payment.Terms.DueDates, &pay.DueDate{
-					Amount: amount,
-				})
-			}
-		}
-		if len(note) > 0 {
-			payment.Terms.Notes = cleanString(strings.Join(note, " "))
+	if ui.PaymentTerms != nil {
+		payment.Terms = &pay.Terms{
+			Notes: cleanString(ui.PaymentTerms.Note),
 		}
 	}
 

--- a/test/data/convert/en16931/out/invoice-attachments.xml
+++ b/test/data/convert/en16931/out/invoice-attachments.xml
@@ -114,6 +114,9 @@
       </cac:FinancialInstitutionBranch>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>2 % discount if paid within 2 days&#xA;            Penalty percentage 10% from due date</cbc:Note>
+  </cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Freight</cbc:AllowanceChargeReason>

--- a/test/data/convert/en16931/out/invoice-complete.xml
+++ b/test/data/convert/en16931/out/invoice-complete.xml
@@ -104,6 +104,9 @@
       </cac:FinancialInstitutionBranch>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>2 % discount if paid within 2 days&#xA;            Penalty percentage 10% from due date</cbc:Note>
+  </cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Freight</cbc:AllowanceChargeReason>

--- a/test/data/convert/peppol-self-billed/out/self-billed-invoice.xml
+++ b/test/data/convert/peppol-self-billed/out/self-billed-invoice.xml
@@ -84,6 +84,9 @@
       </cac:FinancialInstitutionBranch>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>2 % discount if paid within 2 days&#xA;            Penalty percentage 10% from due date</cbc:Note>
+  </cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="EUR">342.00</cbc:TaxAmount>
     <cac:TaxSubtotal>

--- a/test/data/convert/peppol/credit-note-peppol.json
+++ b/test/data/convert/peppol/credit-note-peppol.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "524d7440523c8d96d5e59fe9755c1749e4ae54b33350ff85a9eb3b8932284b91"
+			"val": "f62c75efa044da7a139acd099d6f7e3d337bc776d1c347c8b31cf1d21d39f9f7"
 		}
 	},
 	"doc": {
@@ -121,6 +121,12 @@
 		},
 		"payment": {
 			"terms": {
+				"due_dates": [
+					{
+						"date": "2024-06-14",
+						"amount": "2142.00"
+					}
+				],
 				"notes": "on receipt within 30 days"
 			},
 			"instructions": {

--- a/test/data/convert/peppol/out/credit-note-peppol.xml
+++ b/test/data/convert/peppol/out/credit-note-peppol.xml
@@ -67,6 +67,7 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode>30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2024-06-14</cbc:PaymentDueDate>
     <cbc:PaymentID>0003434323213231</cbc:PaymentID>
     <cac:PayeeFinancialAccount>
       <cbc:ID>NO9386011117947</cbc:ID>

--- a/test/data/convert/peppol/out/credit-note.xml
+++ b/test/data/convert/peppol/out/credit-note.xml
@@ -76,6 +76,9 @@
     <cbc:Amount currencyID="EUR">2142.00</cbc:Amount>
     <cbc:PaymentDueDate>2024-03-15</cbc:PaymentDueDate>
   </cac:PaymentTerms>
+  <cac:PaymentTerms>
+    <cbc:Note>lorem ipsum</cbc:Note>
+  </cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="EUR">378.00</cbc:TaxAmount>
     <cac:TaxSubtotal>

--- a/test/data/convert/peppol/out/credit-note.xml
+++ b/test/data/convert/peppol/out/credit-note.xml
@@ -73,10 +73,6 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:PaymentTerms>
-    <cbc:Amount currencyID="EUR">2142.00</cbc:Amount>
-    <cbc:PaymentDueDate>2024-03-15</cbc:PaymentDueDate>
-  </cac:PaymentTerms>
-  <cac:PaymentTerms>
     <cbc:Note>lorem ipsum</cbc:Note>
   </cac:PaymentTerms>
   <cac:TaxTotal>

--- a/test/data/convert/peppol/out/invoice-complete.xml
+++ b/test/data/convert/peppol/out/invoice-complete.xml
@@ -89,6 +89,9 @@
       </cac:FinancialInstitutionBranch>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>2 % discount if paid within 2 days&#xA;            Penalty percentage 10% from due date</cbc:Note>
+  </cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Freight</cbc:AllowanceChargeReason>

--- a/test/data/convert/xrechnung/invoice-due-date-with-notes.json
+++ b/test/data/convert/xrechnung/invoice-due-date-with-notes.json
@@ -1,0 +1,196 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "dcdb66415c7b1a6c2aa6f2d21f139af734166bf5137885b19126f4f0d7401be1"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DE",
+		"$addons": [
+			"eu-en16931-v2017",
+			"de-xrechnung-v3"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2022-02-01",
+		"currency": "USD",
+		"exchange_rates": [
+			{
+				"from": "USD",
+				"to": "EUR",
+				"amount": "0.86"
+			}
+		],
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"tax_id": {
+				"country": "DE",
+				"code": "111111125"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "John",
+						"surname": "Doe"
+					},
+					"emails": [
+						{
+							"addr": "billing@example.com"
+						}
+					]
+				}
+			],
+			"inboxes": [
+				{
+					"email": "billing@example.com"
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DE"
+				}
+			],
+			"telephones": [
+				{
+					"num": "+49100200300"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "DE",
+				"code": "282741168"
+			},
+			"inboxes": [
+				{
+					"email": "billing@example.com"
+				}
+			],
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "+49100200300"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"reason": "Special discount",
+						"percent": "10%",
+						"amount": "180.00"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "19%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"ordering": {
+			"code": "12345"
+		},
+		"payment": {
+			"terms": {
+				"due_dates": [
+					{
+						"date": "2022-02-01",
+						"notes": "First payment",
+						"amount": "100.00"
+					},
+					{
+						"date": "2022-02-09",
+						"notes": "Second and last payment",
+						"amount": "50.00"
+					}
+				],
+				"notes": "Please pay within 10 days"
+			},
+			"instructions": {
+				"key": "credit-transfer+sepa",
+				"credit_transfer": [
+					{
+						"iban": "DE89370400440532013000",
+						"name": "Random Bank Co."
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "58"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1620.00",
+								"percent": "19%",
+								"amount": "307.80"
+							}
+						],
+						"amount": "307.80"
+					}
+				],
+				"sum": "307.80"
+			},
+			"tax": "307.80",
+			"total_with_tax": "1927.80",
+			"payable": "1927.80"
+		}
+	}
+}

--- a/test/data/convert/xrechnung/invoice-due-date-with-notes.json
+++ b/test/data/convert/xrechnung/invoice-due-date-with-notes.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "dcdb66415c7b1a6c2aa6f2d21f139af734166bf5137885b19126f4f0d7401be1"
+			"val": "c07f905e25237061940b5ff941c7abff6bdd08dba82808bf80b2243e7fbc3675"
 		}
 	},
 	"doc": {
@@ -63,6 +63,11 @@
 					"locality": "Walldorf",
 					"code": "69190",
 					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
 				}
 			],
 			"telephones": [

--- a/test/data/convert/xrechnung/out/invoice-due-date-with-notes.xml
+++ b/test/data/convert/xrechnung/out/invoice-due-date-with-notes.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>SAMPLE-001</cbc:ID>
+  <cbc:IssueDate>2022-02-01</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>12345</cbc:BuyerReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="EM">billing@example.com</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Provide One GmbH</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Dietmar-Hopp-Allee 16</cbc:StreetName>
+        <cbc:CityName>Walldorf</cbc:CityName>
+        <cbc:PostalZone>69190</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>DE111111125</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Provide One GmbH</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>John Doe</cbc:Name>
+        <cbc:Telephone>+49100200300</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="EM">billing@example.com</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Sample Consumer</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Werner-Heisenberg-Allee 25</cbc:StreetName>
+        <cbc:CityName>München</cbc:CityName>
+        <cbc:PostalZone>80939</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>DE282741168</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Sample Consumer</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+49100200300</cbc:Telephone>
+        <cbc:ElectronicMail>email@sample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>58</cbc:PaymentMeansCode>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>DE89370400440532013000</cbc:ID>
+      <cbc:Name>Random Bank Co.</cbc:Name>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>First payment</cbc:Note>
+    <cbc:Amount currencyID="USD">100.00</cbc:Amount>
+    <cbc:PaymentDueDate>2022-02-01</cbc:PaymentDueDate>
+  </cac:PaymentTerms>
+  <cac:PaymentTerms>
+    <cbc:Note>Second and last payment</cbc:Note>
+    <cbc:Amount currencyID="USD">50.00</cbc:Amount>
+    <cbc:PaymentDueDate>2022-02-09</cbc:PaymentDueDate>
+  </cac:PaymentTerms>
+  <cac:PaymentTerms>
+    <cbc:Note>Please pay within 10 days</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">307.80</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">1620.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">307.80</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">1620.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">1620.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">1927.80</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="USD">1927.80</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="HUR">20</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1620.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReason>Special discount</cbc:AllowanceChargeReason>
+      <cbc:MultiplierFactorNumeric>10</cbc:MultiplierFactorNumeric>
+      <cbc:Amount currencyID="USD">180.00</cbc:Amount>
+      <cbc:BaseAmount currencyID="USD">1800.00</cbc:BaseAmount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Name>Development services</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>19</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">90.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/convert/xrechnung/out/invoice-due-date-with-notes.xml
+++ b/test/data/convert/xrechnung/out/invoice-due-date-with-notes.xml
@@ -4,6 +4,7 @@
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
   <cbc:ID>SAMPLE-001</cbc:ID>
   <cbc:IssueDate>2022-02-01</cbc:IssueDate>
+  <cbc:DueDate>2022-02-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
   <cbc:BuyerReference>12345</cbc:BuyerReference>
@@ -33,6 +34,7 @@
       <cac:Contact>
         <cbc:Name>John Doe</cbc:Name>
         <cbc:Telephone>+49100200300</cbc:Telephone>
+        <cbc:ElectronicMail>email@sample.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingSupplierParty>
@@ -72,16 +74,6 @@
       <cbc:Name>Random Bank Co.</cbc:Name>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
-  <cac:PaymentTerms>
-    <cbc:Note>First payment</cbc:Note>
-    <cbc:Amount currencyID="USD">100.00</cbc:Amount>
-    <cbc:PaymentDueDate>2022-02-01</cbc:PaymentDueDate>
-  </cac:PaymentTerms>
-  <cac:PaymentTerms>
-    <cbc:Note>Second and last payment</cbc:Note>
-    <cbc:Amount currencyID="USD">50.00</cbc:Amount>
-    <cbc:PaymentDueDate>2022-02-09</cbc:PaymentDueDate>
-  </cac:PaymentTerms>
   <cac:PaymentTerms>
     <cbc:Note>Please pay within 10 days</cbc:Note>
   </cac:PaymentTerms>


### PR DESCRIPTION
Moved out of the else statement

```go 
if (len(pymt.Terms.DueDates) > 1) || (ui.CreditNoteTypeCode != "" && len(pymt.Terms.DueDates) > 0) {
...

} else {
	ui.PaymentTerms = append(ui.PaymentTerms, PaymentTerms{
		Note: []string{pymt.Terms.Notes},
	})
}
``` 