### PR TITLE
Bump Peppol self-billing VESIDs to 2026.3

### DIFF
--- a/context.go
+++ b/context.go
@@ -167,9 +167,13 @@ var ContextPeppolSelfBilled = Context{
 	CustomizationID: "urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0",
 	ProfileID:       "urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0",
 	Addons:          []cbc.Key{en16931.V2017},
+	// The Peppol self-billing rule sets are versioned independently from the
+	// regular invoice/credit-note ones. phive-rules keeps only a rolling window
+	// of releases, so the older ":2025.3" sets were dropped in phive-rules 4.3.x;
+	// ":2026.3" is the oldest still published and validates the same documents.
 	VESIDs: VESIDMapping{
-		Invoice:    "eu.peppol.bis3:invoice-self-billing:2025.3",
-		CreditNote: "eu.peppol.bis3:creditnote-self-billing:2025.3",
+		Invoice:    "eu.peppol.bis3:invoice-self-billing:2026.3",
+		CreditNote: "eu.peppol.bis3:creditnote-self-billing:2026.3",
 	},
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -210,7 +210,7 @@ func TestGetVESID(t *testing.T) {
 
 		// Get VESID for PeppolSelfBilled context
 		vesid := ubl.ContextPeppolSelfBilled.GetVESID(inv)
-		assert.Equal(t, "eu.peppol.bis3:invoice-self-billing:2025.3", vesid)
+		assert.Equal(t, "eu.peppol.bis3:invoice-self-billing:2026.3", vesid)
 	})
 
 	t.Run("France CIUS VESID", func(t *testing.T) {


### PR DESCRIPTION
## Problem

Outbound Peppol BIS3 **self-billed** invoices/credit notes fail validation with:

```
VESID not found: eu.peppol.bis3:invoice-self-billing:2025.3
```

The `phive` validation service tracks upstream `phive-rules`, which only publishes a **rolling window** of rule-set releases. The `:2025.3` self-billing sets exist in `phive-rules` 4.2.x but were **dropped in 4.3.x** (which now ships `:2026.3` and `:2026.5`). The regular Peppol invoice set (`eu.peppol.bis3:invoice:2025.5`) is still present in 4.3.x, so only self-billing breaks.

## Fix

Bump `ContextPeppolSelfBilled` invoice & credit-note VESIDs `:2025.3` → `:2026.3`.

`:2026.3` is the **oldest self-billing set still published**, and it is present in **both** 4.2.x and 4.3.x `phive-rules`, so it is forward- and backward-compatible across the deployed versions.

## Verification

Built and ran the `phive` gRPC service locally against both `phive-rules` 4.2.2 (older) and 4.3.5 (current), validating the existing self-billed fixtures (`test/data/convert/peppol-self-billed/out/*.xml`):

| phive-rules | VESID | result |
|---|---|---|
| 4.2.2 | `…invoice-self-billing:2025.3` | ✅ success, 0 errors |
| 4.2.2 | `…invoice-self-billing:2026.3` | ✅ success, 0 errors |
| 4.3.5 | `…invoice-self-billing:2025.3` | ❌ VESID not found |
| 4.3.5 | `…invoice-self-billing:2026.3` | ✅ success, 0 errors |
| 4.2.2 | `…creditnote-self-billing:2025.3` | ✅ success, 0 errors |
| 4.3.5 | `…creditnote-self-billing:2026.3` | ✅ success, 0 errors |

The generated self-billed documents (unchanged `CustomizationID`/`ProfileID`) validate cleanly under `2026.3`. `go test ./...` passes.

> Note: this needs a `gobl.ubl` release before the consuming app can pick up its dependency bump.