### PR TITLE
Adding generic UBL 2.1 ApplicationResponse mapping

### DIFF
--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -34,8 +34,9 @@ type ApplicationResponse struct {
 	DocumentResponse []*DocumentResponse `xml:"cac:DocumentResponse"`
 }
 
-// DocumentResponse couples a response with the document it concerns. It is
-// modelled as a single response, which is all the supported profiles need.
+// DocumentResponse pairs one Response with the document it concerns. An
+// ApplicationResponse may carry several (generic UBL allows one per status
+// line); the Peppol Invoice Response is restricted to one per message.
 type DocumentResponse struct {
 	Response          *Response                  `xml:"cac:Response"`
 	DocumentReference *ResponseDocumentReference `xml:"cac:DocumentReference"`

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -114,6 +114,14 @@ func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
 		}
 	}
 
+	if o.context.Is(ContextPeppolInvoiceResponse) {
+		// T111's data model omits these root elements and restricts the parties.
+		out.UBLVersionID = ""
+		out.UUID = ""
+		trimToResponseParty(out.SenderParty)
+		trimToResponseParty(out.ReceiverParty)
+	}
+
 	for _, line := range st.Lines {
 		dr := &DocumentResponse{Response: &Response{}}
 		// ReferenceID and Description are valid generic UBL but are not part of the
@@ -269,6 +277,18 @@ func applyPeppolDocumentResponse(dr *DocumentResponse, line *bill.StatusLine) {
 		listID := documentTypeCodeListID
 		dr.DocumentReference.DocumentTypeCode = &IDType{ListID: &listID, Value: docType}
 	}
+}
+
+// trimToResponseParty reduces a party to the elements the Peppol Invoice
+// Response (T111) permits on SenderParty/ReceiverParty: EndpointID,
+// PartyIdentification, PartyLegalEntity and Contact. The CIUS forbids the rest.
+func trimToResponseParty(p *Party) {
+	if p == nil {
+		return
+	}
+	p.PartyName = nil
+	p.PostalAddress = nil
+	p.PartyTaxScheme = nil
 }
 
 func peppolStatus(listID, code, reason string) *Status {

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -31,9 +31,9 @@ type ApplicationResponse struct {
 
 	Note []string `xml:"cbc:Note,omitempty"`
 
-	SenderParty      *Party            `xml:"cac:SenderParty"`
-	ReceiverParty    *Party            `xml:"cac:ReceiverParty"`
-	DocumentResponse *DocumentResponse `xml:"cac:DocumentResponse"`
+	SenderParty      *Party              `xml:"cac:SenderParty"`
+	ReceiverParty    *Party              `xml:"cac:ReceiverParty"`
+	DocumentResponse []*DocumentResponse `xml:"cac:DocumentResponse"`
 }
 
 // DocumentResponse couples a response with the document it concerns. It is
@@ -75,10 +75,11 @@ type ResponseDocumentReference struct {
 // its code-list attributes, the document-type code, profile identifiers and any
 // regional party formatting) are stamped afterwards by the matching context.
 func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, error) {
-	if len(st.Lines) != 1 {
-		return nil, fmt.Errorf("ApplicationResponse requires a single document response, got %d", len(st.Lines))
+	// Generic UBL allows one DocumentResponse per status line (cac:DocumentResponse
+	// is [0..*]); the Peppol Invoice Response is constrained to one per message.
+	if o.context.Is(ContextPeppolInvoiceResponse) && len(st.Lines) != 1 {
+		return nil, fmt.Errorf("peppol invoice response supports a single document response, got %d", len(st.Lines))
 	}
-	line := st.Lines[0]
 
 	// SenderParty is who sends the response, ReceiverParty who receives it. The
 	// base supplier/customer roles flip with the status type (a response travels
@@ -121,34 +122,38 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 		}
 	}
 
-	out.DocumentResponse = &DocumentResponse{
-		Response: &Response{
-			ReferenceID: strconv.Itoa(responseReferenceID(line.Index)),
-		},
-	}
-	if desc := responseDescription(line); desc != "" {
-		out.DocumentResponse.Response.Description = []string{desc}
-	}
-	if line.Date != nil {
-		out.DocumentResponse.Response.EffectiveDate = formatDate(*line.Date)
-	}
-	if line.Doc != nil {
-		ref := &ResponseDocumentReference{
-			ID: invoiceNumber(line.Doc.Series, line.Doc.Code),
+	for _, line := range st.Lines {
+		dr := &DocumentResponse{
+			Response: &Response{
+				ReferenceID: strconv.Itoa(responseReferenceID(line.Index)),
+			},
 		}
-		if !line.Doc.UUID.IsZero() {
-			ref.UUID = line.Doc.UUID.String()
+		if desc := responseDescription(line); desc != "" {
+			dr.Response.Description = []string{desc}
 		}
-		if line.Doc.IssueDate != nil {
-			ref.IssueDate = formatDate(*line.Doc.IssueDate)
+		if line.Date != nil {
+			dr.Response.EffectiveDate = formatDate(*line.Date)
 		}
-		out.DocumentResponse.DocumentReference = ref
-	}
+		if line.Doc != nil {
+			ref := &ResponseDocumentReference{
+				ID: invoiceNumber(line.Doc.Series, line.Doc.Code),
+			}
+			if !line.Doc.UUID.IsZero() {
+				ref.UUID = line.Doc.UUID.String()
+			}
+			if line.Doc.IssueDate != nil {
+				ref.IssueDate = formatDate(*line.Doc.IssueDate)
+			}
+			dr.DocumentReference = ref
+		}
 
-	if o.context.Is(ContextPeppolInvoiceResponse) {
-		if err := applyPeppolApplicationResponse(out, line); err != nil {
-			return nil, err
+		if o.context.Is(ContextPeppolInvoiceResponse) {
+			if err := applyPeppolDocumentResponse(dr, line); err != nil {
+				return nil, err
+			}
 		}
+
+		out.DocumentResponse = append(out.DocumentResponse, dr)
 	}
 
 	return out, nil
@@ -243,15 +248,15 @@ var peppolStatusActionCodes = map[cbc.Key]string{
 	bill.ActionKeyOther:         "OTH",
 }
 
-// applyPeppolApplicationResponse stamps the Peppol Invoice Response specifics:
-// the UNCL4343 response code, and one cac:Status per reason and action carrying
-// the OPStatusReason / OPStatusAction coded clarification.
-func applyPeppolApplicationResponse(out *ApplicationResponse, line *bill.StatusLine) error {
+// applyPeppolDocumentResponse stamps the Peppol Invoice Response specifics onto
+// a single DocumentResponse: the UNCL4343 response code, and one cac:Status per
+// reason and action carrying the OPStatusReason / OPStatusAction clarification.
+func applyPeppolDocumentResponse(dr *DocumentResponse, line *bill.StatusLine) error {
 	code, ok := peppolResponseCodes[line.Key]
 	if !ok {
 		return fmt.Errorf("peppol invoice response does not support status event %q", line.Key)
 	}
-	resp := out.DocumentResponse.Response
+	resp := dr.Response
 	resp.ResponseCode = &IDType{Value: code}
 	for _, r := range line.Reasons {
 		if r == nil {

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -2,7 +2,6 @@ package ubl
 
 import (
 	"encoding/xml"
-	"fmt"
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
@@ -72,13 +71,7 @@ type ResponseDocumentReference struct {
 
 // ublApplicationResponse builds the generic UBL 2.1 ApplicationResponse skeleton
 // from a GOBL bill.Status.
-func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, error) {
-	// Generic UBL allows one DocumentResponse per status line (cac:DocumentResponse
-	// is [0..*]); the Peppol Invoice Response is constrained to one per message.
-	if o.context.Is(ContextPeppolInvoiceResponse) && len(st.Lines) != 1 {
-		return nil, fmt.Errorf("peppol invoice response supports a single document response, got %d", len(st.Lines))
-	}
-
+func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
 	// SenderParty is who sends the response, ReceiverParty who receives it. The
 	// base supplier/customer roles flip with the status type (a response travels
 	// customer->supplier, an update supplier->customer, e.g. towards a tax agency
@@ -147,15 +140,13 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 		}
 
 		if o.context.Is(ContextPeppolInvoiceResponse) {
-			if err := applyPeppolDocumentResponse(dr, line); err != nil {
-				return nil, err
-			}
+			applyPeppolDocumentResponse(dr, line)
 		}
 
 		out.DocumentResponse = append(out.DocumentResponse, dr)
 	}
 
-	return out, nil
+	return out
 }
 
 // responseDescription prefers the line description and falls back to the first
@@ -249,59 +240,35 @@ var peppolStatusActionCodes = map[cbc.Key]string{
 // applyPeppolDocumentResponse stamps the Peppol Invoice Response specifics onto
 // a single DocumentResponse: the UNCL4343 response code, and one cac:Status per
 // reason and action carrying the OPStatusReason / OPStatusAction clarification.
-func applyPeppolDocumentResponse(dr *DocumentResponse, line *bill.StatusLine) error {
-	code, ok := peppolResponseCodes[line.Key]
-	if !ok {
-		return fmt.Errorf("peppol invoice response does not support status event %q", line.Key)
-	}
+func applyPeppolDocumentResponse(dr *DocumentResponse, line *bill.StatusLine) {
 	resp := dr.Response
-	resp.ResponseCode = &IDType{Value: code}
+	if code := peppolResponseCodes[line.Key]; code != "" {
+		resp.ResponseCode = &IDType{Value: code}
+	}
 	for _, r := range line.Reasons {
 		if r == nil {
 			continue
 		}
-		rc, ok := peppolStatusReasonCodes[r.Key]
-		if !ok {
-			return fmt.Errorf("peppol invoice response does not support reason %q", r.Key)
+		if rc := peppolStatusReasonCodes[r.Key]; rc != "" {
+			resp.Status = append(resp.Status, peppolStatus(peppolStatusReasonListID, rc, r.Description))
 		}
-		resp.Status = append(resp.Status, peppolStatus(peppolStatusReasonListID, rc, r.Description))
 	}
 	for _, a := range line.Actions {
 		if a == nil {
 			continue
 		}
-		ac, ok := peppolStatusActionCodes[a.Key]
-		if !ok {
-			return fmt.Errorf("peppol invoice response does not support action %q", a.Key)
+		if ac := peppolStatusActionCodes[a.Key]; ac != "" {
+			resp.Status = append(resp.Status, peppolStatus(peppolStatusActionListID, ac, a.Description))
 		}
-		resp.Status = append(resp.Status, peppolStatus(peppolStatusActionListID, ac, a.Description))
 	}
-	if peppolClarificationCodes[code] && len(resp.Status) == 0 {
-		return fmt.Errorf("peppol invoice response with status %q requires a reason or action clarification", code)
+	if dr.DocumentReference != nil {
+		docType := documentTypeCodeInvoice
+		if line.Doc != nil && line.Doc.Type == bill.InvoiceTypeCreditNote {
+			docType = documentTypeCodeCreditNote
+		}
+		listID := documentTypeCodeListID
+		dr.DocumentReference.DocumentTypeCode = &IDType{ListID: &listID, Value: docType}
 	}
-
-	// The Peppol Invoice Response requires a DocumentReference with a mandatory
-	// DocumentTypeCode (UNCL1001: 380 invoice, 381 credit note).
-	if dr.DocumentReference == nil {
-		return fmt.Errorf("peppol invoice response requires a referenced document")
-	}
-	docType := documentTypeCodeInvoice
-	if line.Doc != nil && line.Doc.Type == bill.InvoiceTypeCreditNote {
-		docType = documentTypeCodeCreditNote
-	}
-	listID := documentTypeCodeListID
-	dr.DocumentReference.DocumentTypeCode = &IDType{ListID: &listID, Value: docType}
-
-	return nil
-}
-
-// peppolClarificationCodes are the response codes for which the Peppol Invoice
-// Response requires at least one clarification (UQ, RE, CA). CA is never emitted
-// by the converter (accepted maps to AP) but is kept here for completeness.
-var peppolClarificationCodes = map[string]bool{
-	"UQ": true,
-	"RE": true,
-	"CA": true,
 }
 
 func peppolStatus(listID, code, reason string) *Status {

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -80,13 +80,18 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 	}
 	line := st.Lines[0]
 
-	// The response travels from the responder (customer, or an intermediary
-	// issuer) to the originating party (supplier, or its recipient).
-	sender := st.Customer
+	// SenderParty is who sends the response, ReceiverParty who receives it. The
+	// base supplier/customer roles flip with the status type (a response travels
+	// customer->supplier, an update supplier->customer, e.g. towards a tax agency
+	// held as the recipient); the issuer is the sender-side intermediary and the
+	// recipient the receiver-side one.
+	sender, receiver := st.Customer, st.Supplier
+	if st.Type == bill.StatusTypeUpdate {
+		sender, receiver = st.Supplier, st.Customer
+	}
 	if st.Issuer != nil {
 		sender = st.Issuer
 	}
-	receiver := st.Supplier
 	if st.Recipient != nil {
 		receiver = st.Recipient
 	}

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -1,0 +1,158 @@
+package ubl
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strconv"
+
+	"github.com/invopop/gobl/bill"
+)
+
+// NamespaceUBLApplicationResponse is the UBL 2.1 ApplicationResponse root namespace.
+const NamespaceUBLApplicationResponse = "urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+
+// ApplicationResponse represents a UBL 2.1 ApplicationResponse document, used to
+// return a response (accept or reject) for a previously received document such
+// as an invoice.
+type ApplicationResponse struct {
+	XMLName      xml.Name
+	CACNamespace string `xml:"xmlns:cac,attr"`
+	CBCNamespace string `xml:"xmlns:cbc,attr"`
+	UBLNamespace string `xml:"xmlns,attr"`
+
+	UBLVersionID    string  `xml:"cbc:UBLVersionID,omitempty"`
+	CustomizationID string  `xml:"cbc:CustomizationID,omitempty"`
+	ProfileID       *IDType `xml:"cbc:ProfileID,omitempty"`
+	ID              string  `xml:"cbc:ID"`
+	UUID            string  `xml:"cbc:UUID,omitempty"`
+	IssueDate       string  `xml:"cbc:IssueDate"`
+	IssueTime       string  `xml:"cbc:IssueTime,omitempty"`
+
+	Note []string `xml:"cbc:Note,omitempty"`
+
+	SenderParty      *Party            `xml:"cac:SenderParty"`
+	ReceiverParty    *Party            `xml:"cac:ReceiverParty"`
+	DocumentResponse *DocumentResponse `xml:"cac:DocumentResponse"`
+}
+
+// DocumentResponse couples a response with the document it concerns. It is
+// modelled as a single response, which is all the supported profiles need.
+type DocumentResponse struct {
+	Response          *Response                  `xml:"cac:Response"`
+	DocumentReference *ResponseDocumentReference `xml:"cac:DocumentReference"`
+}
+
+// Response carries the response code and an optional human description. The
+// ResponseCode value and its code-list attributes are profile-specific and are
+// stamped by the matching context.
+type Response struct {
+	ReferenceID   string   `xml:"cbc:ReferenceID"`
+	ResponseCode  *IDType  `xml:"cbc:ResponseCode"`
+	Description   []string `xml:"cbc:Description,omitempty"`
+	EffectiveDate string   `xml:"cbc:EffectiveDate,omitempty"`
+}
+
+// ResponseDocumentReference identifies the document being responded to. The
+// DocumentTypeCode is profile-specific and is stamped by the matching context.
+type ResponseDocumentReference struct {
+	ID               string  `xml:"cbc:ID"`
+	UUID             string  `xml:"cbc:UUID,omitempty"`
+	IssueDate        string  `xml:"cbc:IssueDate,omitempty"`
+	DocumentTypeCode *IDType `xml:"cbc:DocumentTypeCode"`
+}
+
+// ublApplicationResponse builds the generic UBL 2.1 ApplicationResponse skeleton
+// from a GOBL bill.Status. The profile-specific values (the response code and
+// its code-list attributes, the document-type code, profile identifiers and any
+// regional party formatting) are stamped afterwards by the matching context.
+func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, error) {
+	if len(st.Lines) != 1 {
+		return nil, fmt.Errorf("ApplicationResponse requires a single document response, got %d", len(st.Lines))
+	}
+	line := st.Lines[0]
+
+	// The response travels from the responder (customer, or an intermediary
+	// issuer) to the originating party (supplier, or its recipient).
+	sender := st.Customer
+	if st.Issuer != nil {
+		sender = st.Issuer
+	}
+	receiver := st.Supplier
+	if st.Recipient != nil {
+		receiver = st.Recipient
+	}
+
+	out := &ApplicationResponse{
+		XMLName:         xml.Name{Local: "ApplicationResponse"},
+		CACNamespace:    NamespaceCAC,
+		CBCNamespace:    NamespaceCBC,
+		UBLNamespace:    NamespaceUBLApplicationResponse,
+		UBLVersionID:    Version,
+		CustomizationID: o.context.CustomizationID,
+		ProfileID:       &IDType{Value: o.context.ProfileID},
+		ID:              invoiceNumber(st.Series, st.Code),
+		IssueDate:       formatDate(st.IssueDate),
+		SenderParty:     newParty(sender),
+		ReceiverParty:   newParty(receiver),
+	}
+	if !st.UUID.IsZero() {
+		out.UUID = st.UUID.String()
+	}
+	if st.IssueTime != nil {
+		out.IssueTime = st.IssueTime.String()
+	}
+	for _, n := range st.Notes {
+		if n != nil && n.Text != "" {
+			out.Note = append(out.Note, n.Text)
+		}
+	}
+
+	out.DocumentResponse = &DocumentResponse{
+		Response: &Response{
+			ReferenceID: strconv.Itoa(responseReferenceID(line.Index)),
+		},
+	}
+	if desc := responseDescription(line); desc != "" {
+		out.DocumentResponse.Response.Description = []string{desc}
+	}
+	if line.Date != nil {
+		out.DocumentResponse.Response.EffectiveDate = formatDate(*line.Date)
+	}
+	if line.Doc != nil {
+		ref := &ResponseDocumentReference{
+			ID: invoiceNumber(line.Doc.Series, line.Doc.Code),
+		}
+		if !line.Doc.UUID.IsZero() {
+			ref.UUID = line.Doc.UUID.String()
+		}
+		if line.Doc.IssueDate != nil {
+			ref.IssueDate = formatDate(*line.Doc.IssueDate)
+		}
+		out.DocumentResponse.DocumentReference = ref
+	}
+
+	return out, nil
+}
+
+// responseReferenceID returns a 1-based reference for the Response, as the
+// UBL ApplicationResponse requires a non-empty ReferenceID.
+func responseReferenceID(index int) int {
+	if index < 1 {
+		return 1
+	}
+	return index
+}
+
+// responseDescription prefers the line description and falls back to the first
+// reason's description.
+func responseDescription(line *bill.StatusLine) string {
+	if line.Description != "" {
+		return line.Description
+	}
+	for _, r := range line.Reasons {
+		if r != nil && r.Description != "" {
+			return r.Description
+		}
+	}
+	return ""
+}

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -71,9 +71,7 @@ type ResponseDocumentReference struct {
 }
 
 // ublApplicationResponse builds the generic UBL 2.1 ApplicationResponse skeleton
-// from a GOBL bill.Status. The profile-specific values (the response code and
-// its code-list attributes, the document-type code, profile identifiers and any
-// regional party formatting) are stamped afterwards by the matching context.
+// from a GOBL bill.Status.
 func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, error) {
 	// Generic UBL allows one DocumentResponse per status line (cac:DocumentResponse
 	// is [0..*]); the Peppol Invoice Response is constrained to one per message.
@@ -84,8 +82,7 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 	// SenderParty is who sends the response, ReceiverParty who receives it. The
 	// base supplier/customer roles flip with the status type (a response travels
 	// customer->supplier, an update supplier->customer, e.g. towards a tax agency
-	// held as the recipient); the issuer is the sender-side intermediary and the
-	// recipient the receiver-side one.
+	// held as the recipient);
 	sender, receiver := st.Customer, st.Supplier
 	if st.Type == bill.StatusTypeUpdate {
 		sender, receiver = st.Supplier, st.Customer

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -101,11 +101,13 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 		UBLNamespace:    NamespaceUBLApplicationResponse,
 		UBLVersionID:    Version,
 		CustomizationID: o.context.CustomizationID,
-		ProfileID:       &IDType{Value: o.context.ProfileID},
 		ID:              invoiceNumber(st.Series, st.Code),
 		IssueDate:       formatDate(st.IssueDate),
 		SenderParty:     newParty(sender),
 		ReceiverParty:   newParty(receiver),
+	}
+	if o.context.ProfileID != "" {
+		out.ProfileID = &IDType{Value: o.context.ProfileID}
 	}
 	if !st.UUID.IsZero() {
 		out.UUID = st.UUID.String()

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 )
 
 // NamespaceUBLApplicationResponse is the UBL 2.1 ApplicationResponse root namespace.
@@ -46,10 +47,18 @@ type DocumentResponse struct {
 // ResponseCode value and its code-list attributes are profile-specific and are
 // stamped by the matching context.
 type Response struct {
-	ReferenceID   string   `xml:"cbc:ReferenceID"`
-	ResponseCode  *IDType  `xml:"cbc:ResponseCode"`
-	Description   []string `xml:"cbc:Description,omitempty"`
-	EffectiveDate string   `xml:"cbc:EffectiveDate,omitempty"`
+	ReferenceID   string    `xml:"cbc:ReferenceID"`
+	ResponseCode  *IDType   `xml:"cbc:ResponseCode"`
+	Description   []string  `xml:"cbc:Description,omitempty"`
+	EffectiveDate string    `xml:"cbc:EffectiveDate,omitempty"`
+	Status        []*Status `xml:"cac:Status,omitempty"`
+}
+
+// Status carries a coded clarification within a Response. The code list it draws
+// from is identified by the StatusReasonCode listID and is profile-specific.
+type Status struct {
+	StatusReasonCode *IDType  `xml:"cbc:StatusReasonCode,omitempty"`
+	StatusReason     []string `xml:"cbc:StatusReason,omitempty"`
 }
 
 // ResponseDocumentReference identifies the document being responded to. The
@@ -131,6 +140,12 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 		out.DocumentResponse.DocumentReference = ref
 	}
 
+	if o.context.Is(ContextPeppolInvoiceResponse) {
+		if err := applyPeppolApplicationResponse(out, line); err != nil {
+			return nil, err
+		}
+	}
+
 	return out, nil
 }
 
@@ -155,4 +170,115 @@ func responseDescription(line *bill.StatusLine) string {
 		}
 	}
 	return ""
+}
+
+// Peppol BIS Invoice Response specifics follow.
+
+// Peppol Invoice Response code-list identifiers for the StatusReasonCode.
+const (
+	peppolStatusReasonListID = "OPStatusReason"
+	peppolStatusActionListID = "OPStatusAction"
+)
+
+// peppolResponseCodes maps GOBL status events to the Peppol Invoice Response
+// status codes (UNCL4343 subset, transaction T111). A technical "error" properly
+// belongs in the Message Level Response (T71), but the Invoice Response has no
+// technical-reject code, so it falls back to RE with the detail carried in the
+// status clarification. "issued" is a pre-response state with no code.
+var peppolResponseCodes = map[cbc.Key]string{
+	bill.StatusEventAcknowledged: "AB",
+	bill.StatusEventProcessing:   "IP",
+	bill.StatusEventQuerying:     "UQ",
+	bill.StatusEventRejected:     "RE",
+	bill.StatusEventAccepted:     "AP",
+	bill.StatusEventPaid:         "PD",
+	bill.StatusEventError:        "RE",
+}
+
+// peppolResponseEvents reverses peppolResponseCodes for parsing. RE maps back to
+// the business rejection (the error fallback is send-side only); CA
+// (conditionally accepted) normalizes to accepted, with the conditions carried
+// in the status line's reasons and actions.
+var peppolResponseEvents = map[string]cbc.Key{
+	"AB": bill.StatusEventAcknowledged,
+	"IP": bill.StatusEventProcessing,
+	"UQ": bill.StatusEventQuerying,
+	"RE": bill.StatusEventRejected,
+	"AP": bill.StatusEventAccepted,
+	"PD": bill.StatusEventPaid,
+	"CA": bill.StatusEventAccepted,
+}
+
+// peppolStatusReasonCodes maps GOBL reason keys to OPStatusReason codes.
+var peppolStatusReasonCodes = map[cbc.Key]string{
+	bill.ReasonKeyNone:            "NON",
+	bill.ReasonKeyReferences:      "REF",
+	bill.ReasonKeyLegal:           "LEG",
+	bill.ReasonKeyUnknownReceiver: "REC",
+	bill.ReasonKeyQuality:         "QUA",
+	bill.ReasonKeyDelivery:        "DEL",
+	bill.ReasonKeyPrices:          "PRI",
+	bill.ReasonKeyQuantity:        "QTY",
+	bill.ReasonKeyItems:           "ITM",
+	bill.ReasonKeyPaymentTerms:    "PAY",
+	bill.ReasonKeyNotRecognized:   "UNR",
+	bill.ReasonKeyFinanceTerms:    "FIN",
+	bill.ReasonKeyPartial:         "PPD",
+	bill.ReasonKeyOther:           "OTH",
+}
+
+// peppolStatusActionCodes maps GOBL action keys to OPStatusAction codes.
+var peppolStatusActionCodes = map[cbc.Key]string{
+	bill.ActionKeyNone:          "NOA",
+	bill.ActionKeyProvide:       "PIN",
+	bill.ActionKeyReissue:       "NIN",
+	bill.ActionKeyCreditFull:    "CNF",
+	bill.ActionKeyCreditPartial: "CNP",
+	bill.ActionKeyCreditAmount:  "CNA",
+	bill.ActionKeyOther:         "OTH",
+}
+
+// applyPeppolApplicationResponse stamps the Peppol Invoice Response specifics:
+// the UNCL4343 response code, and one cac:Status per reason and action carrying
+// the OPStatusReason / OPStatusAction coded clarification.
+func applyPeppolApplicationResponse(out *ApplicationResponse, line *bill.StatusLine) error {
+	code, ok := peppolResponseCodes[line.Key]
+	if !ok {
+		return fmt.Errorf("peppol invoice response does not support status event %q", line.Key)
+	}
+	resp := out.DocumentResponse.Response
+	resp.ResponseCode = &IDType{Value: code}
+	for _, r := range line.Reasons {
+		if r == nil {
+			continue
+		}
+		resp.Status = append(resp.Status, peppolStatus(peppolStatusReasonListID, peppolStatusReasonCodes[r.Key], r.Description))
+	}
+	for _, a := range line.Actions {
+		if a == nil {
+			continue
+		}
+		resp.Status = append(resp.Status, peppolStatus(peppolStatusActionListID, peppolStatusActionCodes[a.Key], a.Description))
+	}
+	if peppolClarificationCodes[code] && len(resp.Status) == 0 {
+		return fmt.Errorf("peppol invoice response with status %q requires a reason or action clarification", code)
+	}
+	return nil
+}
+
+// peppolClarificationCodes are the response codes for which the Peppol Invoice
+// Response requires at least one clarification (UQ, RE, CA). CA is never emitted
+// by the converter (accepted maps to AP) but is kept here for completeness.
+var peppolClarificationCodes = map[string]bool{
+	"UQ": true,
+	"RE": true,
+	"CA": true,
+}
+
+func peppolStatus(listID, code, reason string) *Status {
+	s := &Status{StatusReasonCode: &IDType{ListID: &listID, Value: code}}
+	if reason != "" {
+		s.StatusReason = []string{reason}
+	}
+	return s
 }

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -11,8 +11,7 @@ import (
 const NamespaceUBLApplicationResponse = "urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
 
 // ApplicationResponse represents a UBL 2.1 ApplicationResponse document, used to
-// return a response (accept or reject) for a previously received document such
-// as an invoice.
+// return a response (accept or reject) for a previously received document.
 type ApplicationResponse struct {
 	XMLName      xml.Name
 	CACNamespace string `xml:"xmlns:cac,attr"`
@@ -70,8 +69,6 @@ type ResponseDocumentReference struct {
 	DocumentTypeCode *IDType `xml:"cbc:DocumentTypeCode"`
 }
 
-// ublApplicationResponse builds the generic UBL 2.1 ApplicationResponse skeleton
-// from a GOBL bill.Status.
 func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
 	// SenderParty is who sends the response, ReceiverParty who receives it. The
 	// base supplier/customer roles flip with the status type (a response travels

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -261,13 +261,21 @@ func applyPeppolDocumentResponse(dr *DocumentResponse, line *bill.StatusLine) er
 		if r == nil {
 			continue
 		}
-		resp.Status = append(resp.Status, peppolStatus(peppolStatusReasonListID, peppolStatusReasonCodes[r.Key], r.Description))
+		rc, ok := peppolStatusReasonCodes[r.Key]
+		if !ok {
+			return fmt.Errorf("peppol invoice response does not support reason %q", r.Key)
+		}
+		resp.Status = append(resp.Status, peppolStatus(peppolStatusReasonListID, rc, r.Description))
 	}
 	for _, a := range line.Actions {
 		if a == nil {
 			continue
 		}
-		resp.Status = append(resp.Status, peppolStatus(peppolStatusActionListID, peppolStatusActionCodes[a.Key], a.Description))
+		ac, ok := peppolStatusActionCodes[a.Key]
+		if !ok {
+			return fmt.Errorf("peppol invoice response does not support action %q", a.Key)
+		}
+		resp.Status = append(resp.Status, peppolStatus(peppolStatusActionListID, ac, a.Description))
 	}
 	if peppolClarificationCodes[code] && len(resp.Status) == 0 {
 		return fmt.Errorf("peppol invoice response with status %q requires a reason or action clarification", code)

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -3,7 +3,6 @@ package ubl
 import (
 	"encoding/xml"
 	"fmt"
-	"strconv"
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
@@ -47,7 +46,7 @@ type DocumentResponse struct {
 // ResponseCode value and its code-list attributes are profile-specific and are
 // stamped by the matching context.
 type Response struct {
-	ReferenceID   string    `xml:"cbc:ReferenceID"`
+	ReferenceID   string    `xml:"cbc:ReferenceID,omitempty"`
 	ResponseCode  *IDType   `xml:"cbc:ResponseCode"`
 	Description   []string  `xml:"cbc:Description,omitempty"`
 	EffectiveDate string    `xml:"cbc:EffectiveDate,omitempty"`
@@ -62,7 +61,8 @@ type Status struct {
 }
 
 // ResponseDocumentReference identifies the document being responded to. The
-// DocumentTypeCode is profile-specific and is stamped by the matching context.
+// DocumentTypeCode is profile-specific (drawn from a profile's code list) and is
+// stamped by the matching context; the generic mapping leaves it unset.
 type ResponseDocumentReference struct {
 	ID               string  `xml:"cbc:ID"`
 	UUID             string  `xml:"cbc:UUID,omitempty"`
@@ -122,13 +122,13 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 	}
 
 	for _, line := range st.Lines {
-		dr := &DocumentResponse{
-			Response: &Response{
-				ReferenceID: strconv.Itoa(responseReferenceID(line.Index)),
-			},
-		}
-		if desc := responseDescription(line); desc != "" {
-			dr.Response.Description = []string{desc}
+		dr := &DocumentResponse{Response: &Response{}}
+		// ReferenceID and Description are valid generic UBL but are not part of the
+		// Peppol Invoice Response Response, so they are only emitted off-profile.
+		if !o.context.Is(ContextPeppolInvoiceResponse) {
+			if desc := responseDescription(line); desc != "" {
+				dr.Response.Description = []string{desc}
+			}
 		}
 		if line.Date != nil {
 			dr.Response.EffectiveDate = formatDate(*line.Date)
@@ -158,15 +158,6 @@ func ublApplicationResponse(st *bill.Status, o *options) (*ApplicationResponse, 
 	return out, nil
 }
 
-// responseReferenceID returns a 1-based reference for the Response, as the
-// UBL ApplicationResponse requires a non-empty ReferenceID.
-func responseReferenceID(index int) int {
-	if index < 1 {
-		return 1
-	}
-	return index
-}
-
 // responseDescription prefers the line description and falls back to the first
 // reason's description.
 func responseDescription(line *bill.StatusLine) string {
@@ -187,6 +178,14 @@ func responseDescription(line *bill.StatusLine) string {
 const (
 	peppolStatusReasonListID = "OPStatusReason"
 	peppolStatusActionListID = "OPStatusAction"
+)
+
+// Peppol Invoice Response document-type codes (UNCL1001) for the referenced
+// document; DocumentTypeCode is mandatory under T111.
+const (
+	documentTypeCodeListID     = "UNCL1001"
+	documentTypeCodeInvoice    = "380"
+	documentTypeCodeCreditNote = "381"
 )
 
 // peppolResponseCodes maps GOBL status events to the Peppol Invoice Response
@@ -280,6 +279,19 @@ func applyPeppolDocumentResponse(dr *DocumentResponse, line *bill.StatusLine) er
 	if peppolClarificationCodes[code] && len(resp.Status) == 0 {
 		return fmt.Errorf("peppol invoice response with status %q requires a reason or action clarification", code)
 	}
+
+	// The Peppol Invoice Response requires a DocumentReference with a mandatory
+	// DocumentTypeCode (UNCL1001: 380 invoice, 381 credit note).
+	if dr.DocumentReference == nil {
+		return fmt.Errorf("peppol invoice response requires a referenced document")
+	}
+	docType := documentTypeCodeInvoice
+	if line.Doc != nil && line.Doc.Type == bill.InvoiceTypeCreditNote {
+		docType = documentTypeCodeCreditNote
+	}
+	listID := documentTypeCodeListID
+	dr.DocumentReference.DocumentTypeCode = &IDType{ListID: &listID, Value: docType}
+
 	return nil
 }
 

--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -70,19 +70,11 @@ type ResponseDocumentReference struct {
 }
 
 func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
-	// SenderParty is who sends the response, ReceiverParty who receives it. The
-	// base supplier/customer roles flip with the status type (a response travels
-	// customer->supplier, an update supplier->customer, e.g. towards a tax agency
-	// held as the recipient);
+	// SenderParty is who sends the response, ReceiverParty who receives it: a
+	// response travels customer->supplier, an update supplier->customer.
 	sender, receiver := st.Customer, st.Supplier
 	if st.Type == bill.StatusTypeUpdate {
 		sender, receiver = st.Supplier, st.Customer
-	}
-	if st.Issuer != nil {
-		sender = st.Issuer
-	}
-	if st.Recipient != nil {
-		receiver = st.Recipient
 	}
 
 	out := &ApplicationResponse{
@@ -94,8 +86,8 @@ func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
 		CustomizationID: o.context.CustomizationID,
 		ID:              invoiceNumber(st.Series, st.Code),
 		IssueDate:       formatDate(st.IssueDate),
-		SenderParty:     newParty(sender),
-		ReceiverParty:   newParty(receiver),
+		SenderParty:     newParty(sender, o.context),
+		ReceiverParty:   newParty(receiver, o.context),
 	}
 	if o.context.ProfileID != "" {
 		out.ProfileID = &IDType{Value: o.context.ProfileID}
@@ -191,13 +183,13 @@ const (
 // technical-reject code, so it falls back to RE with the detail carried in the
 // status clarification. "issued" is a pre-response state with no code.
 var peppolResponseCodes = map[cbc.Key]string{
-	bill.StatusEventAcknowledged: "AB",
-	bill.StatusEventProcessing:   "IP",
-	bill.StatusEventQuerying:     "UQ",
-	bill.StatusEventRejected:     "RE",
-	bill.StatusEventAccepted:     "AP",
-	bill.StatusEventPaid:         "PD",
-	bill.StatusEventError:        "RE",
+	bill.StatusLineAcknowledged: "AB",
+	bill.StatusLineProcessing:   "IP",
+	bill.StatusLineQuerying:     "UQ",
+	bill.StatusLineRejected:     "RE",
+	bill.StatusLineAccepted:     "AP",
+	bill.StatusLinePaid:         "PD",
+	bill.StatusLineError:        "RE",
 }
 
 // peppolResponseEvents reverses peppolResponseCodes for parsing. RE maps back to
@@ -205,13 +197,13 @@ var peppolResponseCodes = map[cbc.Key]string{
 // (conditionally accepted) normalizes to accepted, with the conditions carried
 // in the status line's reasons and actions.
 var peppolResponseEvents = map[string]cbc.Key{
-	"AB": bill.StatusEventAcknowledged,
-	"IP": bill.StatusEventProcessing,
-	"UQ": bill.StatusEventQuerying,
-	"RE": bill.StatusEventRejected,
-	"AP": bill.StatusEventAccepted,
-	"PD": bill.StatusEventPaid,
-	"CA": bill.StatusEventAccepted,
+	"AB": bill.StatusLineAcknowledged,
+	"IP": bill.StatusLineProcessing,
+	"UQ": bill.StatusLineQuerying,
+	"RE": bill.StatusLineRejected,
+	"AP": bill.StatusLineAccepted,
+	"PD": bill.StatusLinePaid,
+	"CA": bill.StatusLineAccepted,
 }
 
 // peppolStatusReasonCodes maps GOBL reason keys to OPStatusReason codes.

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -145,20 +145,20 @@ func applyPeppolStatusLine(line *bill.StatusLine, dr *DocumentResponse) {
 		}
 		switch listID {
 		case peppolStatusReasonListID:
-			if k := keyForCode(peppolStatusReasonCodes, s.StatusReasonCode.Value); k != "" {
-				line.Reasons = append(line.Reasons, &bill.Reason{
-					Key:         k,
-					Description: desc,
-				})
+			if key := keyForCode(peppolStatusReasonCodes, s.StatusReasonCode.Value); key != "" {
+				line.Reasons = append(line.Reasons, &bill.Reason{Key: key, Description: desc})
 			}
 		case peppolStatusActionListID:
-			if k := keyForCode(peppolStatusActionCodes, s.StatusReasonCode.Value); k != "" {
-				line.Actions = append(line.Actions, &bill.Action{
-					Key:         k,
-					Description: desc,
-				})
+			if key := keyForCode(peppolStatusActionCodes, s.StatusReasonCode.Value); key != "" {
+				line.Actions = append(line.Actions, &bill.Action{Key: key, Description: desc})
 			}
 		}
+	}
+
+	// Map the mandatory DocumentTypeCode back to the referenced document type.
+	if ref := dr.DocumentReference; ref != nil && line.Doc != nil &&
+		ref.DocumentTypeCode != nil && ref.DocumentTypeCode.Value == documentTypeCodeCreditNote {
+		line.Doc.Type = bill.InvoiceTypeCreditNote
 	}
 }
 

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -75,8 +75,7 @@ func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
 }
 
 // goblStatusLine maps the generic parts of a single UBL DocumentResponse. The
-// response code and the status clarifications are profile-specific and are
-// mapped back by the matching context.
+// response code and the status clarifications are context specific.
 func goblStatusLine(dr *DocumentResponse, o *options) (*bill.StatusLine, error) {
 	line := new(bill.StatusLine)
 	if dr == nil {

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -63,7 +63,7 @@ func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
 		out.Notes = append(out.Notes, &org.Note{Text: n})
 	}
 
-	line, err := ar.goblStatusLine()
+	line, err := ar.goblStatusLine(o)
 	if err != nil {
 		return nil, err
 	}
@@ -73,9 +73,9 @@ func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
 }
 
 // goblStatusLine maps the generic parts of a UBL DocumentResponse. The response
-// code and the document-type code are profile-specific and are mapped back by
+// code and the status clarifications are profile-specific and are mapped back by
 // the matching context.
-func (ar *ApplicationResponse) goblStatusLine() (*bill.StatusLine, error) {
+func (ar *ApplicationResponse) goblStatusLine(o *options) (*bill.StatusLine, error) {
 	line := new(bill.StatusLine)
 	dr := ar.DocumentResponse
 	if dr == nil {
@@ -112,5 +112,58 @@ func (ar *ApplicationResponse) goblStatusLine() (*bill.StatusLine, error) {
 		line.Doc = doc
 	}
 
+	if o.context.Is(ContextPeppolInvoiceResponse) {
+		applyPeppolStatusLine(line, dr)
+	}
+
 	return line, nil
+}
+
+// applyPeppolStatusLine maps the Peppol Invoice Response codes back to GOBL: the
+// UNCL4343 response code to a status event, and each OPStatusReason /
+// OPStatusAction cac:Status clarification to a reason or action.
+func applyPeppolStatusLine(line *bill.StatusLine, dr *DocumentResponse) {
+	r := dr.Response
+	if r == nil {
+		return
+	}
+	if r.ResponseCode != nil {
+		line.Key = peppolResponseEvents[r.ResponseCode.Value]
+	}
+	for _, s := range r.Status {
+		if s == nil || s.StatusReasonCode == nil {
+			continue
+		}
+		listID := ""
+		if s.StatusReasonCode.ListID != nil {
+			listID = *s.StatusReasonCode.ListID
+		}
+		desc := ""
+		if len(s.StatusReason) > 0 {
+			desc = s.StatusReason[0]
+		}
+		switch listID {
+		case peppolStatusReasonListID:
+			line.Reasons = append(line.Reasons, &bill.Reason{
+				Key:         keyForCode(peppolStatusReasonCodes, s.StatusReasonCode.Value),
+				Description: desc,
+			})
+		case peppolStatusActionListID:
+			line.Actions = append(line.Actions, &bill.Action{
+				Key:         keyForCode(peppolStatusActionCodes, s.StatusReasonCode.Value),
+				Description: desc,
+			})
+		}
+	}
+}
+
+// keyForCode returns the GOBL key mapped to the given code in m, or empty if
+// none matches.
+func keyForCode(m map[cbc.Key]string, code string) cbc.Key {
+	for k, v := range m {
+		if v == code {
+			return k
+		}
+	}
+	return ""
 }

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -1,0 +1,116 @@
+package ubl
+
+import (
+	"cloud.google.com/go/civil"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+)
+
+// Convert turns a parsed UBL ApplicationResponse into a GOBL envelope wrapping a
+// bill.Status.
+func (ar *ApplicationResponse) Convert() (*gobl.Envelope, error) {
+	o := new(options)
+	profileID := ""
+	if ar.ProfileID != nil {
+		profileID = ar.ProfileID.Value
+	}
+	if ctx := FindContext(ar.CustomizationID, profileID); ctx != nil {
+		o.context = *ctx
+	}
+
+	st, err := ar.goblStatus(o)
+	if err != nil {
+		return nil, err
+	}
+
+	env := gobl.NewEnvelope()
+	if err := env.Insert(st); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
+	out := &bill.Status{
+		Addons:   tax.Addons{List: o.context.Addons},
+		Type:     bill.StatusTypeResponse,
+		Code:     cbc.Code(ar.ID),
+		Supplier: goblParty(ar.ReceiverParty),
+		Customer: goblParty(ar.SenderParty),
+	}
+
+	issueDate, err := parseDate(ar.IssueDate)
+	if err != nil {
+		return nil, err
+	}
+	out.IssueDate = issueDate
+
+	if ar.IssueTime != "" {
+		ct, err := civil.ParseTime(ar.IssueTime)
+		if err != nil {
+			return nil, err
+		}
+		out.IssueTime = &cal.Time{Time: ct}
+	}
+
+	for _, n := range ar.Note {
+		out.Notes = append(out.Notes, &org.Note{Text: n})
+	}
+
+	line, err := ar.goblStatusLine()
+	if err != nil {
+		return nil, err
+	}
+	out.Lines = []*bill.StatusLine{line}
+
+	return out, nil
+}
+
+// goblStatusLine maps the generic parts of a UBL DocumentResponse. The response
+// code and the document-type code are profile-specific and are mapped back by
+// the matching context.
+func (ar *ApplicationResponse) goblStatusLine() (*bill.StatusLine, error) {
+	line := new(bill.StatusLine)
+	dr := ar.DocumentResponse
+	if dr == nil {
+		return line, nil
+	}
+
+	if r := dr.Response; r != nil {
+		if len(r.Description) > 0 {
+			line.Description = r.Description[0]
+		}
+		if r.EffectiveDate != "" {
+			d, err := parseDate(r.EffectiveDate)
+			if err != nil {
+				return nil, err
+			}
+			line.Date = &d
+		}
+	}
+
+	if ref := dr.DocumentReference; ref != nil {
+		doc := &org.DocumentRef{
+			Code: cbc.Code(ref.ID),
+		}
+		if ref.UUID != "" {
+			doc.UUID = uuid.UUID(ref.UUID)
+		}
+		if ref.IssueDate != "" {
+			d, err := parseDate(ref.IssueDate)
+			if err != nil {
+				return nil, err
+			}
+			doc.IssueDate = &d
+		}
+		line.Doc = doc
+	}
+
+	return line, nil
+}

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -63,21 +63,22 @@ func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
 		out.Notes = append(out.Notes, &org.Note{Text: n})
 	}
 
-	line, err := ar.goblStatusLine(o)
-	if err != nil {
-		return nil, err
+	for _, dr := range ar.DocumentResponse {
+		line, err := goblStatusLine(dr, o)
+		if err != nil {
+			return nil, err
+		}
+		out.Lines = append(out.Lines, line)
 	}
-	out.Lines = []*bill.StatusLine{line}
 
 	return out, nil
 }
 
-// goblStatusLine maps the generic parts of a UBL DocumentResponse. The response
-// code and the status clarifications are profile-specific and are mapped back by
-// the matching context.
-func (ar *ApplicationResponse) goblStatusLine(o *options) (*bill.StatusLine, error) {
+// goblStatusLine maps the generic parts of a single UBL DocumentResponse. The
+// response code and the status clarifications are profile-specific and are
+// mapped back by the matching context.
+func goblStatusLine(dr *DocumentResponse, o *options) (*bill.StatusLine, error) {
 	line := new(bill.StatusLine)
-	dr := ar.DocumentResponse
 	if dr == nil {
 		return line, nil
 	}

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -145,15 +145,19 @@ func applyPeppolStatusLine(line *bill.StatusLine, dr *DocumentResponse) {
 		}
 		switch listID {
 		case peppolStatusReasonListID:
-			line.Reasons = append(line.Reasons, &bill.Reason{
-				Key:         keyForCode(peppolStatusReasonCodes, s.StatusReasonCode.Value),
-				Description: desc,
-			})
+			if k := keyForCode(peppolStatusReasonCodes, s.StatusReasonCode.Value); k != "" {
+				line.Reasons = append(line.Reasons, &bill.Reason{
+					Key:         k,
+					Description: desc,
+				})
+			}
 		case peppolStatusActionListID:
-			line.Actions = append(line.Actions, &bill.Action{
-				Key:         keyForCode(peppolStatusActionCodes, s.StatusReasonCode.Value),
-				Description: desc,
-			})
+			if k := keyForCode(peppolStatusActionCodes, s.StatusReasonCode.Value); k != "" {
+				line.Actions = append(line.Actions, &bill.Action{
+					Key:         k,
+					Description: desc,
+				})
+			}
 		}
 	}
 }

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -41,8 +41,8 @@ func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
 		Addons:   tax.Addons{List: o.context.Addons},
 		Type:     bill.StatusTypeResponse,
 		Code:     cbc.Code(ar.ID),
-		Supplier: goblParty(ar.ReceiverParty),
-		Customer: goblParty(ar.SenderParty),
+		Supplier: goblParty(ar.ReceiverParty, o),
+		Customer: goblParty(ar.SenderParty, o),
 	}
 
 	issueDate, err := parseDate(ar.IssueDate)

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -1,6 +1,8 @@
 package ubl_test
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/invopop/gobl"
@@ -9,8 +11,11 @@ import (
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/phive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const sampleApplicationResponse = `<?xml version="1.0" encoding="UTF-8"?>
@@ -127,6 +132,46 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 	// stamped by the generic conversion.
 	assert.Nil(t, dr.Response.ResponseCode)
 	assert.Nil(t, dr.DocumentReference.DocumentTypeCode)
+}
+
+func TestConvertPeppolInvoiceResponseValidate(t *testing.T) {
+	if !*validate {
+		t.Skip("phive validation not requested (use -validate)")
+	}
+	conn, err := grpc.NewClient("127.0.0.1:9091", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+	pc := phive.NewValidationServiceClient(conn)
+
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-1",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co", Inboxes: []*org.Inbox{{Scheme: "9920", Code: "B98602642"}}},
+		Customer:  &org.Party{Name: "Buyer Co", Inboxes: []*org.Inbox{{Scheme: "9920", Code: "A39200019"}}},
+		Lines: []*bill.StatusLine{
+			{
+				Index:   1,
+				Key:     bill.StatusEventRejected,
+				Doc:     &org.DocumentRef{Code: "INV-9"},
+				Reasons: []*bill.Reason{{Key: bill.ReasonKeyReferences, Description: "missing PO"}},
+			},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	doc, err := ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.NoError(t, err)
+	data, err := ubl.Bytes(doc)
+	require.NoError(t, err)
+
+	vesid := ubl.ContextPeppolInvoiceResponse.VESIDs.ApplicationResponse
+	resp, err := pc.ValidateXml(context.Background(), &phive.ValidateXmlRequest{Vesid: vesid, XmlContent: data})
+	require.NoError(t, err)
+	results, err := json.MarshalIndent(resp.Results, "", "  ")
+	require.NoError(t, err)
+	require.True(t, resp.Success, "Peppol Invoice Response should validate for %s: %s", vesid, string(results))
 }
 
 func TestConvertApplicationResponseFansOutLines(t *testing.T) {

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -103,6 +103,8 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 	assert.Equal(t, "RESP-1", ar.ID)
 	assert.Equal(t, ubl.Version, ar.UBLVersionID)
 	assert.Equal(t, []string{"Processed automatically"}, ar.Note)
+	// EN16931 has no ProfileID, so the element is omitted rather than emitted empty.
+	assert.Nil(t, ar.ProfileID)
 
 	// Customer maps to SenderParty, Supplier to ReceiverParty.
 	require.NotNil(t, ar.SenderParty)
@@ -115,7 +117,7 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 	require.Len(t, ar.DocumentResponse, 1)
 	dr := ar.DocumentResponse[0]
 	require.NotNil(t, dr.Response)
-	assert.Equal(t, "1", dr.Response.ReferenceID)
+	assert.Empty(t, dr.Response.ReferenceID)
 	assert.Equal(t, []string{"All good"}, dr.Response.Description)
 	assert.Equal(t, "2026-05-28", dr.Response.EffectiveDate)
 	require.NotNil(t, dr.DocumentReference)
@@ -233,9 +235,14 @@ func TestConvertPeppolInvoiceResponse(t *testing.T) {
 	assert.Equal(t, "urn:fdc:peppol.eu:poacc:bis:invoice_response:3", ar.ProfileID.Value)
 
 	require.Len(t, ar.DocumentResponse, 1)
-	resp := ar.DocumentResponse[0].Response
+	dr := ar.DocumentResponse[0]
+	resp := dr.Response
 	require.NotNil(t, resp.ResponseCode)
 	assert.Equal(t, "RE", resp.ResponseCode.Value)
+
+	// ReferenceID and Description are not part of the Peppol Response.
+	assert.Empty(t, resp.ReferenceID)
+	assert.Empty(t, resp.Description)
 
 	require.Len(t, resp.Status, 2)
 	require.NotNil(t, resp.Status[0].StatusReasonCode.ListID)
@@ -245,6 +252,12 @@ func TestConvertPeppolInvoiceResponse(t *testing.T) {
 	assert.Equal(t, "OPStatusAction", *resp.Status[1].StatusReasonCode.ListID)
 	assert.Equal(t, "NIN", resp.Status[1].StatusReasonCode.Value)
 	assert.Equal(t, []string{"please reissue"}, resp.Status[1].StatusReason)
+
+	// DocumentTypeCode is mandatory in T111 (UNCL1001; 380 for an invoice).
+	require.NotNil(t, dr.DocumentReference.DocumentTypeCode)
+	require.NotNil(t, dr.DocumentReference.DocumentTypeCode.ListID)
+	assert.Equal(t, "UNCL1001", *dr.DocumentReference.DocumentTypeCode.ListID)
+	assert.Equal(t, "380", dr.DocumentReference.DocumentTypeCode.Value)
 }
 
 func TestConvertPeppolInvoiceResponseErrorMapsToRejected(t *testing.T) {
@@ -516,6 +529,7 @@ func TestPeppolStatusActionRoundTrip(t *testing.T) {
 func TestPeppolInvoiceResponseRoundTripFull(t *testing.T) {
 	st := basePeppolStatus()
 	st.Lines[0].Key = bill.StatusEventRejected
+	st.Lines[0].Doc.Type = bill.InvoiceTypeCreditNote
 	st.Lines[0].Reasons = []*bill.Reason{{Key: bill.ReasonKeyPrices, Description: "price off"}}
 	st.Lines[0].Actions = []*bill.Action{{Key: bill.ActionKeyReissue, Description: "redo"}}
 
@@ -524,6 +538,9 @@ func TestPeppolInvoiceResponseRoundTripFull(t *testing.T) {
 	require.Len(t, out.Lines, 1)
 	l := out.Lines[0]
 	assert.Equal(t, bill.StatusEventRejected, l.Key)
+	// The credit-note document type round-trips via DocumentTypeCode 381.
+	require.NotNil(t, l.Doc)
+	assert.Equal(t, bill.InvoiceTypeCreditNote, l.Doc.Type)
 	require.Len(t, l.Reasons, 1)
 	assert.Equal(t, bill.ReasonKeyPrices, l.Reasons[0].Key)
 	assert.Equal(t, "price off", l.Reasons[0].Description)

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -7,6 +7,7 @@ import (
 	ubl "github.com/invopop/gobl.ubl"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -399,4 +400,169 @@ func TestParsePeppolInvoiceResponse(t *testing.T) {
 	require.Len(t, st.Lines[0].Actions, 1)
 	assert.Equal(t, bill.ActionKeyReissue, st.Lines[0].Actions[0].Key)
 	assert.Equal(t, "please reissue", st.Lines[0].Actions[0].Description)
+}
+
+// basePeppolStatus returns a minimal valid response status with a single line.
+func basePeppolStatus() *bill.Status {
+	return &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-RT",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines:     []*bill.StatusLine{{Index: 1, Doc: &org.DocumentRef{Code: "INV-RT"}}},
+	}
+}
+
+// peppolRoundTrip converts a status to a Peppol Invoice Response, serialises it,
+// parses it back, and returns the resulting status.
+func peppolRoundTrip(t *testing.T, st *bill.Status) *bill.Status {
+	t.Helper()
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+	doc, err := ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.NoError(t, err)
+	data, err := ubl.Bytes(doc)
+	require.NoError(t, err)
+	parsed, err := ubl.Parse(data)
+	require.NoError(t, err)
+	ar, ok := parsed.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+	env2, err := ar.Convert()
+	require.NoError(t, err)
+	out, ok := env2.Extract().(*bill.Status)
+	require.True(t, ok)
+	return out
+}
+
+func TestPeppolResponseCodeRoundTrip(t *testing.T) {
+	// Every status event with a Peppol Invoice Response code must round-trip.
+	events := []cbc.Key{
+		bill.StatusEventAcknowledged,
+		bill.StatusEventProcessing,
+		bill.StatusEventQuerying,
+		bill.StatusEventRejected,
+		bill.StatusEventAccepted,
+		bill.StatusEventPaid,
+	}
+	for _, ev := range events {
+		t.Run(ev.String(), func(t *testing.T) {
+			st := basePeppolStatus()
+			st.Lines[0].Key = ev
+			// UQ/RE require a clarification; harmless for the others.
+			st.Lines[0].Reasons = []*bill.Reason{{Key: bill.ReasonKeyOther, Description: "x"}}
+			out := peppolRoundTrip(t, st)
+			require.Len(t, out.Lines, 1)
+			assert.Equal(t, ev, out.Lines[0].Key)
+		})
+	}
+}
+
+func TestPeppolStatusReasonRoundTrip(t *testing.T) {
+	// Every reason key must round-trip through its OPStatusReason code.
+	reasons := []cbc.Key{
+		bill.ReasonKeyNone,
+		bill.ReasonKeyReferences,
+		bill.ReasonKeyLegal,
+		bill.ReasonKeyUnknownReceiver,
+		bill.ReasonKeyQuality,
+		bill.ReasonKeyDelivery,
+		bill.ReasonKeyPrices,
+		bill.ReasonKeyQuantity,
+		bill.ReasonKeyItems,
+		bill.ReasonKeyPaymentTerms,
+		bill.ReasonKeyNotRecognized,
+		bill.ReasonKeyFinanceTerms,
+		bill.ReasonKeyPartial,
+		bill.ReasonKeyOther,
+	}
+	for _, rk := range reasons {
+		t.Run(rk.String(), func(t *testing.T) {
+			st := basePeppolStatus()
+			st.Lines[0].Key = bill.StatusEventRejected
+			st.Lines[0].Reasons = []*bill.Reason{{Key: rk, Description: "d"}}
+			out := peppolRoundTrip(t, st)
+			require.Len(t, out.Lines, 1)
+			require.Len(t, out.Lines[0].Reasons, 1)
+			assert.Equal(t, rk, out.Lines[0].Reasons[0].Key)
+		})
+	}
+}
+
+func TestPeppolStatusActionRoundTrip(t *testing.T) {
+	// Every action key must round-trip through its OPStatusAction code.
+	actions := []cbc.Key{
+		bill.ActionKeyNone,
+		bill.ActionKeyProvide,
+		bill.ActionKeyReissue,
+		bill.ActionKeyCreditFull,
+		bill.ActionKeyCreditPartial,
+		bill.ActionKeyCreditAmount,
+		bill.ActionKeyOther,
+	}
+	for _, ak := range actions {
+		t.Run(ak.String(), func(t *testing.T) {
+			st := basePeppolStatus()
+			st.Lines[0].Key = bill.StatusEventRejected
+			st.Lines[0].Actions = []*bill.Action{{Key: ak, Description: "d"}}
+			out := peppolRoundTrip(t, st)
+			require.Len(t, out.Lines, 1)
+			require.Len(t, out.Lines[0].Actions, 1)
+			assert.Equal(t, ak, out.Lines[0].Actions[0].Key)
+		})
+	}
+}
+
+func TestPeppolInvoiceResponseRoundTripFull(t *testing.T) {
+	st := basePeppolStatus()
+	st.Lines[0].Key = bill.StatusEventRejected
+	st.Lines[0].Reasons = []*bill.Reason{{Key: bill.ReasonKeyPrices, Description: "price off"}}
+	st.Lines[0].Actions = []*bill.Action{{Key: bill.ActionKeyReissue, Description: "redo"}}
+
+	out := peppolRoundTrip(t, st)
+
+	require.Len(t, out.Lines, 1)
+	l := out.Lines[0]
+	assert.Equal(t, bill.StatusEventRejected, l.Key)
+	require.Len(t, l.Reasons, 1)
+	assert.Equal(t, bill.ReasonKeyPrices, l.Reasons[0].Key)
+	assert.Equal(t, "price off", l.Reasons[0].Description)
+	require.Len(t, l.Actions, 1)
+	assert.Equal(t, bill.ActionKeyReissue, l.Actions[0].Key)
+	assert.Equal(t, "redo", l.Actions[0].Description)
+}
+
+const sampleGenericMultiResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:ID>RESP-MULTI</cbc:ID>
+  <cbc:IssueDate>2026-05-29</cbc:IssueDate>
+  <cac:SenderParty><cac:PartyName><cbc:Name>Buyer Co</cbc:Name></cac:PartyName></cac:SenderParty>
+  <cac:ReceiverParty><cac:PartyName><cbc:Name>Seller Co</cbc:Name></cac:PartyName></cac:ReceiverParty>
+  <cac:DocumentResponse>
+    <cac:Response><cbc:ReferenceID>1</cbc:ReferenceID></cac:Response>
+    <cac:DocumentReference><cbc:ID>INV-1</cbc:ID></cac:DocumentReference>
+  </cac:DocumentResponse>
+  <cac:DocumentResponse>
+    <cac:Response><cbc:ReferenceID>2</cbc:ReferenceID></cac:Response>
+    <cac:DocumentReference><cbc:ID>INV-2</cbc:ID></cac:DocumentReference>
+  </cac:DocumentResponse>
+</ApplicationResponse>`
+
+func TestParseApplicationResponseFansOutLines(t *testing.T) {
+	doc, err := ubl.Parse([]byte(sampleGenericMultiResponse))
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	env, err := ar.Convert()
+	require.NoError(t, err)
+	st, ok := env.Extract().(*bill.Status)
+	require.True(t, ok)
+
+	// Each DocumentResponse maps back to its own status line.
+	require.Len(t, st.Lines, 2)
+	require.NotNil(t, st.Lines[0].Doc)
+	assert.Equal(t, "INV-1", st.Lines[0].Doc.Code.String())
+	require.NotNil(t, st.Lines[1].Doc)
+	assert.Equal(t, "INV-2", st.Lines[1].Doc.Code.String())
 }

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -111,18 +111,65 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 	require.NotNil(t, ar.ReceiverParty.PartyName)
 	assert.Equal(t, "Seller Co", ar.ReceiverParty.PartyName.Name)
 
-	require.NotNil(t, ar.DocumentResponse)
-	require.NotNil(t, ar.DocumentResponse.Response)
-	assert.Equal(t, "1", ar.DocumentResponse.Response.ReferenceID)
-	assert.Equal(t, []string{"All good"}, ar.DocumentResponse.Response.Description)
-	assert.Equal(t, "2026-05-28", ar.DocumentResponse.Response.EffectiveDate)
-	require.NotNil(t, ar.DocumentResponse.DocumentReference)
-	assert.Equal(t, "INV-42", ar.DocumentResponse.DocumentReference.ID)
+	require.Len(t, ar.DocumentResponse, 1)
+	dr := ar.DocumentResponse[0]
+	require.NotNil(t, dr.Response)
+	assert.Equal(t, "1", dr.Response.ReferenceID)
+	assert.Equal(t, []string{"All good"}, dr.Response.Description)
+	assert.Equal(t, "2026-05-28", dr.Response.EffectiveDate)
+	require.NotNil(t, dr.DocumentReference)
+	assert.Equal(t, "INV-42", dr.DocumentReference.ID)
 
 	// The response code and document-type code are profile-specific and are not
 	// stamped by the generic conversion.
-	assert.Nil(t, ar.DocumentResponse.Response.ResponseCode)
-	assert.Nil(t, ar.DocumentResponse.DocumentReference.DocumentTypeCode)
+	assert.Nil(t, dr.Response.ResponseCode)
+	assert.Nil(t, dr.DocumentReference.DocumentTypeCode)
+}
+
+func TestConvertApplicationResponseFansOutLines(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-MULTI",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{Index: 1, Doc: &org.DocumentRef{Code: "INV-1"}},
+			{Index: 2, Doc: &org.DocumentRef{Code: "INV-2"}},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	// Generic UBL fans every line into its own DocumentResponse in one response.
+	doc, err := ubl.Convert(env)
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	require.Len(t, ar.DocumentResponse, 2)
+	assert.Equal(t, "INV-1", ar.DocumentResponse[0].DocumentReference.ID)
+	assert.Equal(t, "INV-2", ar.DocumentResponse[1].DocumentReference.ID)
+}
+
+func TestConvertPeppolInvoiceResponseRejectsMultipleLines(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-MULTI",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{Index: 1, Key: bill.StatusEventAccepted, Doc: &org.DocumentRef{Code: "INV-1"}},
+			{Index: 2, Key: bill.StatusEventAccepted, Doc: &org.DocumentRef{Code: "INV-2"}},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	// Peppol allows only one DocumentResponse per message.
+	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.Error(t, err)
 }
 
 func TestConvertApplicationResponseUpdateFlipsDirection(t *testing.T) {
@@ -184,7 +231,8 @@ func TestConvertPeppolInvoiceResponse(t *testing.T) {
 	require.NotNil(t, ar.ProfileID)
 	assert.Equal(t, "urn:fdc:peppol.eu:poacc:bis:invoice_response:3", ar.ProfileID.Value)
 
-	resp := ar.DocumentResponse.Response
+	require.Len(t, ar.DocumentResponse, 1)
+	resp := ar.DocumentResponse[0].Response
 	require.NotNil(t, resp.ResponseCode)
 	assert.Equal(t, "RE", resp.ResponseCode.Value)
 
@@ -223,8 +271,9 @@ func TestConvertPeppolInvoiceResponseErrorMapsToRejected(t *testing.T) {
 	require.True(t, ok)
 
 	// A technical error has no Invoice Response code, so it falls back to RE.
-	require.NotNil(t, ar.DocumentResponse.Response.ResponseCode)
-	assert.Equal(t, "RE", ar.DocumentResponse.Response.ResponseCode.Value)
+	require.Len(t, ar.DocumentResponse, 1)
+	require.NotNil(t, ar.DocumentResponse[0].Response.ResponseCode)
+	assert.Equal(t, "RE", ar.DocumentResponse[0].Response.ResponseCode.Value)
 }
 
 func TestConvertPeppolInvoiceResponseRequiresClarification(t *testing.T) {

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -155,26 +155,6 @@ func TestConvertApplicationResponseFansOutLines(t *testing.T) {
 	assert.Equal(t, "INV-2", ar.DocumentResponse[1].DocumentReference.ID)
 }
 
-func TestConvertPeppolInvoiceResponseRejectsMultipleLines(t *testing.T) {
-	st := &bill.Status{
-		Type:      bill.StatusTypeResponse,
-		Code:      "RESP-MULTI",
-		IssueDate: cal.MakeDate(2026, 5, 29),
-		Supplier:  &org.Party{Name: "Seller Co"},
-		Customer:  &org.Party{Name: "Buyer Co"},
-		Lines: []*bill.StatusLine{
-			{Index: 1, Key: bill.StatusEventAccepted, Doc: &org.DocumentRef{Code: "INV-1"}},
-			{Index: 2, Key: bill.StatusEventAccepted, Doc: &org.DocumentRef{Code: "INV-2"}},
-		},
-	}
-	env, err := gobl.Envelop(st)
-	require.NoError(t, err)
-
-	// Peppol allows only one DocumentResponse per message.
-	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
-	require.Error(t, err)
-}
-
 func TestConvertApplicationResponseUpdateFlipsDirection(t *testing.T) {
 	st := &bill.Status{
 		Type:      bill.StatusTypeUpdate,
@@ -288,45 +268,6 @@ func TestConvertPeppolInvoiceResponseErrorMapsToRejected(t *testing.T) {
 	require.Len(t, ar.DocumentResponse, 1)
 	require.NotNil(t, ar.DocumentResponse[0].Response.ResponseCode)
 	assert.Equal(t, "RE", ar.DocumentResponse[0].Response.ResponseCode.Value)
-}
-
-func TestConvertPeppolInvoiceResponseRequiresClarification(t *testing.T) {
-	st := &bill.Status{
-		Type:      bill.StatusTypeResponse,
-		Code:      "RESP-R",
-		IssueDate: cal.MakeDate(2026, 5, 29),
-		Supplier:  &org.Party{Name: "Seller Co"},
-		Customer:  &org.Party{Name: "Buyer Co"},
-		Lines: []*bill.StatusLine{
-			{Index: 1, Key: bill.StatusEventRejected, Doc: &org.DocumentRef{Code: "INV-R"}},
-		},
-	}
-	env, err := gobl.Envelop(st)
-	require.NoError(t, err)
-
-	// Rejecting without any reason or action is invalid for Peppol.
-	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
-	require.Error(t, err)
-}
-
-func TestConvertPeppolInvoiceResponseRejectsUnmappedEvent(t *testing.T) {
-	st := &bill.Status{
-		Type:      bill.StatusTypeResponse,
-		Code:      "RESP-I",
-		IssueDate: cal.MakeDate(2026, 5, 29),
-		Supplier:  &org.Party{Name: "Seller Co"},
-		Customer:  &org.Party{Name: "Buyer Co"},
-		Lines: []*bill.StatusLine{
-			{Index: 1, Key: bill.StatusEventIssued, Doc: &org.DocumentRef{Code: "INV-I"}},
-		},
-	}
-	env, err := gobl.Envelop(st)
-	require.NoError(t, err)
-
-	// "issued" has no Invoice Response code; rather than emit a document missing
-	// the mandatory ResponseCode, conversion fails.
-	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
-	require.Error(t, err)
 }
 
 const samplePeppolInvoiceResponse = `<?xml version="1.0" encoding="UTF-8"?>

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -124,3 +124,204 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 	assert.Nil(t, ar.DocumentResponse.Response.ResponseCode)
 	assert.Nil(t, ar.DocumentResponse.DocumentReference.DocumentTypeCode)
 }
+
+func TestConvertPeppolInvoiceResponse(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-9",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{
+				Index: 1,
+				Key:   bill.StatusEventRejected,
+				Doc:   &org.DocumentRef{Code: "INV-9"},
+				Reasons: []*bill.Reason{
+					{Key: bill.ReasonKeyReferences, Description: "missing PO"},
+				},
+				Actions: []*bill.Action{
+					{Key: bill.ActionKeyReissue, Description: "please reissue"},
+				},
+			},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	doc, err := ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	assert.Equal(t, "urn:fdc:peppol.eu:poacc:trns:invoice_response:3", ar.CustomizationID)
+	require.NotNil(t, ar.ProfileID)
+	assert.Equal(t, "urn:fdc:peppol.eu:poacc:bis:invoice_response:3", ar.ProfileID.Value)
+
+	resp := ar.DocumentResponse.Response
+	require.NotNil(t, resp.ResponseCode)
+	assert.Equal(t, "RE", resp.ResponseCode.Value)
+
+	require.Len(t, resp.Status, 2)
+	require.NotNil(t, resp.Status[0].StatusReasonCode.ListID)
+	assert.Equal(t, "OPStatusReason", *resp.Status[0].StatusReasonCode.ListID)
+	assert.Equal(t, "REF", resp.Status[0].StatusReasonCode.Value)
+	assert.Equal(t, []string{"missing PO"}, resp.Status[0].StatusReason)
+	assert.Equal(t, "OPStatusAction", *resp.Status[1].StatusReasonCode.ListID)
+	assert.Equal(t, "NIN", resp.Status[1].StatusReasonCode.Value)
+	assert.Equal(t, []string{"please reissue"}, resp.Status[1].StatusReason)
+}
+
+func TestConvertPeppolInvoiceResponseErrorMapsToRejected(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-E",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{
+				Index:   1,
+				Key:     bill.StatusEventError,
+				Doc:     &org.DocumentRef{Code: "INV-E"},
+				Reasons: []*bill.Reason{{Key: bill.ReasonKeyOther, Description: "system failure"}},
+			},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	doc, err := ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	// A technical error has no Invoice Response code, so it falls back to RE.
+	require.NotNil(t, ar.DocumentResponse.Response.ResponseCode)
+	assert.Equal(t, "RE", ar.DocumentResponse.Response.ResponseCode.Value)
+}
+
+func TestConvertPeppolInvoiceResponseRequiresClarification(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-R",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{Index: 1, Key: bill.StatusEventRejected, Doc: &org.DocumentRef{Code: "INV-R"}},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	// Rejecting without any reason or action is invalid for Peppol.
+	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.Error(t, err)
+}
+
+func TestConvertPeppolInvoiceResponseRejectsUnmappedEvent(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-I",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{Index: 1, Key: bill.StatusEventIssued, Doc: &org.DocumentRef{Code: "INV-I"}},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	// "issued" has no Invoice Response code; rather than emit a document missing
+	// the mandatory ResponseCode, conversion fails.
+	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextPeppolInvoiceResponse))
+	require.Error(t, err)
+}
+
+const samplePeppolInvoiceResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:invoice_response:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:invoice_response:3</cbc:ProfileID>
+  <cbc:ID>RESP-9</cbc:ID>
+  <cbc:IssueDate>2026-05-29</cbc:IssueDate>
+  <cac:SenderParty><cac:PartyName><cbc:Name>Buyer Co</cbc:Name></cac:PartyName></cac:SenderParty>
+  <cac:ReceiverParty><cac:PartyName><cbc:Name>Seller Co</cbc:Name></cac:PartyName></cac:ReceiverParty>
+  <cac:DocumentResponse>
+    <cac:Response>
+      <cbc:ResponseCode>RE</cbc:ResponseCode>
+      <cac:Status>
+        <cbc:StatusReasonCode listID="OPStatusReason">REF</cbc:StatusReasonCode>
+        <cbc:StatusReason>missing PO</cbc:StatusReason>
+      </cac:Status>
+      <cac:Status>
+        <cbc:StatusReasonCode listID="OPStatusAction">NIN</cbc:StatusReasonCode>
+        <cbc:StatusReason>please reissue</cbc:StatusReason>
+      </cac:Status>
+    </cac:Response>
+    <cac:DocumentReference><cbc:ID>INV-9</cbc:ID></cac:DocumentReference>
+  </cac:DocumentResponse>
+</ApplicationResponse>`
+
+const samplePeppolConditionallyAccepted = `<?xml version="1.0" encoding="UTF-8"?>
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:invoice_response:3</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:invoice_response:3</cbc:ProfileID>
+  <cbc:ID>RESP-CA</cbc:ID>
+  <cbc:IssueDate>2026-05-29</cbc:IssueDate>
+  <cac:SenderParty><cac:PartyName><cbc:Name>Buyer Co</cbc:Name></cac:PartyName></cac:SenderParty>
+  <cac:ReceiverParty><cac:PartyName><cbc:Name>Seller Co</cbc:Name></cac:PartyName></cac:ReceiverParty>
+  <cac:DocumentResponse>
+    <cac:Response>
+      <cbc:ResponseCode>CA</cbc:ResponseCode>
+      <cac:Status>
+        <cbc:StatusReasonCode listID="OPStatusReason">PRI</cbc:StatusReasonCode>
+        <cbc:StatusReason>price to be confirmed</cbc:StatusReason>
+      </cac:Status>
+    </cac:Response>
+    <cac:DocumentReference><cbc:ID>INV-CA</cbc:ID></cac:DocumentReference>
+  </cac:DocumentResponse>
+</ApplicationResponse>`
+
+func TestParsePeppolConditionallyAccepted(t *testing.T) {
+	doc, err := ubl.Parse([]byte(samplePeppolConditionallyAccepted))
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	env, err := ar.Convert()
+	require.NoError(t, err)
+	st, ok := env.Extract().(*bill.Status)
+	require.True(t, ok)
+
+	require.Len(t, st.Lines, 1)
+	// CA normalizes to accepted, carrying the conditions as reasons.
+	assert.Equal(t, bill.StatusEventAccepted, st.Lines[0].Key)
+	require.Len(t, st.Lines[0].Reasons, 1)
+	assert.Equal(t, bill.ReasonKeyPrices, st.Lines[0].Reasons[0].Key)
+	assert.Equal(t, "price to be confirmed", st.Lines[0].Reasons[0].Description)
+}
+
+func TestParsePeppolInvoiceResponse(t *testing.T) {
+	doc, err := ubl.Parse([]byte(samplePeppolInvoiceResponse))
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	env, err := ar.Convert()
+	require.NoError(t, err)
+	st, ok := env.Extract().(*bill.Status)
+	require.True(t, ok)
+
+	require.Len(t, st.Lines, 1)
+	assert.Equal(t, bill.StatusEventRejected, st.Lines[0].Key)
+
+	require.Len(t, st.Lines[0].Reasons, 1)
+	assert.Equal(t, bill.ReasonKeyReferences, st.Lines[0].Reasons[0].Key)
+	assert.Equal(t, "missing PO", st.Lines[0].Reasons[0].Description)
+
+	require.Len(t, st.Lines[0].Actions, 1)
+	assert.Equal(t, bill.ActionKeyReissue, st.Lines[0].Actions[0].Key)
+	assert.Equal(t, "please reissue", st.Lines[0].Actions[0].Description)
+}

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -125,6 +125,32 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 	assert.Nil(t, ar.DocumentResponse.DocumentReference.DocumentTypeCode)
 }
 
+func TestConvertApplicationResponseUpdateFlipsDirection(t *testing.T) {
+	st := &bill.Status{
+		Type:      bill.StatusTypeUpdate,
+		Code:      "UPD-1",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Lines: []*bill.StatusLine{
+			{Index: 1, Key: bill.StatusEventPaid, Doc: &org.DocumentRef{Code: "INV-1"}},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	doc, err := ubl.Convert(env)
+	require.NoError(t, err)
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok)
+
+	// An update travels supplier -> customer, the reverse of a response.
+	require.NotNil(t, ar.SenderParty)
+	assert.Equal(t, "Seller Co", ar.SenderParty.PartyName.Name)
+	require.NotNil(t, ar.ReceiverParty)
+	assert.Equal(t, "Buyer Co", ar.ReceiverParty.PartyName.Name)
+}
+
 func TestConvertPeppolInvoiceResponse(t *testing.T) {
 	st := &bill.Status{
 		Type:      bill.StatusTypeResponse,

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -1,0 +1,126 @@
+package ubl_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl"
+	ubl "github.com/invopop/gobl.ubl"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/org"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleApplicationResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:ID>RESP-1</cbc:ID>
+  <cbc:IssueDate>2026-05-29</cbc:IssueDate>
+  <cbc:Note>Processed automatically</cbc:Note>
+  <cac:SenderParty><cac:PartyName><cbc:Name>Buyer Co</cbc:Name></cac:PartyName></cac:SenderParty>
+  <cac:ReceiverParty><cac:PartyName><cbc:Name>Seller Co</cbc:Name></cac:PartyName></cac:ReceiverParty>
+  <cac:DocumentResponse>
+    <cac:Response>
+      <cbc:ReferenceID>1</cbc:ReferenceID>
+      <cbc:ResponseCode>BusinessAccept</cbc:ResponseCode>
+      <cbc:Description>All good</cbc:Description>
+      <cbc:EffectiveDate>2026-05-28</cbc:EffectiveDate>
+    </cac:Response>
+    <cac:DocumentReference>
+      <cbc:ID>INV-42</cbc:ID>
+      <cbc:IssueDate>2026-05-20</cbc:IssueDate>
+    </cac:DocumentReference>
+  </cac:DocumentResponse>
+</ApplicationResponse>`
+
+func TestParseApplicationResponse(t *testing.T) {
+	doc, err := ubl.Parse([]byte(sampleApplicationResponse))
+	require.NoError(t, err)
+
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok, "parsed document should be an ApplicationResponse")
+
+	env, err := ar.Convert()
+	require.NoError(t, err)
+
+	st, ok := env.Extract().(*bill.Status)
+	require.True(t, ok, "converted document should be a bill.Status")
+
+	assert.Equal(t, bill.StatusTypeResponse, st.Type)
+	assert.Equal(t, "RESP-1", st.Code.String())
+
+	// SenderParty maps to the customer (the responder), ReceiverParty to the
+	// supplier (the originator).
+	require.NotNil(t, st.Customer)
+	assert.Equal(t, "Buyer Co", st.Customer.Name)
+	require.NotNil(t, st.Supplier)
+	assert.Equal(t, "Seller Co", st.Supplier.Name)
+
+	require.Len(t, st.Notes, 1)
+	assert.Equal(t, "Processed automatically", st.Notes[0].Text)
+
+	require.Len(t, st.Lines, 1)
+	assert.Equal(t, "All good", st.Lines[0].Description)
+	require.NotNil(t, st.Lines[0].Date)
+	assert.Equal(t, "2026-05-28", st.Lines[0].Date.String())
+	require.NotNil(t, st.Lines[0].Doc)
+	assert.Equal(t, "INV-42", st.Lines[0].Doc.Code.String())
+
+	// The response code -> status event mapping is profile-specific and is not
+	// applied by the generic mapping.
+	assert.Empty(t, st.Lines[0].Key)
+}
+
+func TestConvertApplicationResponseSkeleton(t *testing.T) {
+	effDate := cal.MakeDate(2026, 5, 28)
+	st := &bill.Status{
+		Type:      bill.StatusTypeResponse,
+		Code:      "RESP-1",
+		IssueDate: cal.MakeDate(2026, 5, 29),
+		Supplier:  &org.Party{Name: "Seller Co"},
+		Customer:  &org.Party{Name: "Buyer Co"},
+		Notes:     []*org.Note{{Text: "Processed automatically"}},
+		Lines: []*bill.StatusLine{
+			{
+				Index:       1,
+				Key:         bill.StatusEventAccepted,
+				Date:        &effDate,
+				Description: "All good",
+				Doc:         &org.DocumentRef{Code: "INV-42"},
+			},
+		},
+	}
+	env, err := gobl.Envelop(st)
+	require.NoError(t, err)
+
+	doc, err := ubl.Convert(env)
+	require.NoError(t, err)
+
+	ar, ok := doc.(*ubl.ApplicationResponse)
+	require.True(t, ok, "converted document should be an ApplicationResponse")
+
+	assert.Equal(t, "RESP-1", ar.ID)
+	assert.Equal(t, ubl.Version, ar.UBLVersionID)
+	assert.Equal(t, []string{"Processed automatically"}, ar.Note)
+
+	// Customer maps to SenderParty, Supplier to ReceiverParty.
+	require.NotNil(t, ar.SenderParty)
+	require.NotNil(t, ar.SenderParty.PartyName)
+	assert.Equal(t, "Buyer Co", ar.SenderParty.PartyName.Name)
+	require.NotNil(t, ar.ReceiverParty)
+	require.NotNil(t, ar.ReceiverParty.PartyName)
+	assert.Equal(t, "Seller Co", ar.ReceiverParty.PartyName.Name)
+
+	require.NotNil(t, ar.DocumentResponse)
+	require.NotNil(t, ar.DocumentResponse.Response)
+	assert.Equal(t, "1", ar.DocumentResponse.Response.ReferenceID)
+	assert.Equal(t, []string{"All good"}, ar.DocumentResponse.Response.Description)
+	assert.Equal(t, "2026-05-28", ar.DocumentResponse.Response.EffectiveDate)
+	require.NotNil(t, ar.DocumentResponse.DocumentReference)
+	assert.Equal(t, "INV-42", ar.DocumentResponse.DocumentReference.ID)
+
+	// The response code and document-type code are profile-specific and are not
+	// stamped by the generic conversion.
+	assert.Nil(t, ar.DocumentResponse.Response.ResponseCode)
+	assert.Nil(t, ar.DocumentResponse.DocumentReference.DocumentTypeCode)
+}

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -166,7 +166,7 @@ func TestConvertPeppolInvoiceResponseValidate(t *testing.T) {
 	data, err := ubl.Bytes(doc)
 	require.NoError(t, err)
 
-	vesid := ubl.ContextPeppolInvoiceResponse.VESIDs.ApplicationResponse
+	vesid := ubl.ContextPeppolInvoiceResponse.VESIDs.Status
 	resp, err := pc.ValidateXml(context.Background(), &phive.ValidateXmlRequest{Vesid: vesid, XmlContent: data})
 	require.NoError(t, err)
 	results, err := json.MarshalIndent(resp.Results, "", "  ")

--- a/applicationresponse_test.go
+++ b/applicationresponse_test.go
@@ -89,7 +89,7 @@ func TestConvertApplicationResponseSkeleton(t *testing.T) {
 		Lines: []*bill.StatusLine{
 			{
 				Index:       1,
-				Key:         bill.StatusEventAccepted,
+				Key:         bill.StatusLineAccepted,
 				Date:        &effDate,
 				Description: "All good",
 				Doc:         &org.DocumentRef{Code: "INV-42"},
@@ -152,7 +152,7 @@ func TestConvertPeppolInvoiceResponseValidate(t *testing.T) {
 		Lines: []*bill.StatusLine{
 			{
 				Index:   1,
-				Key:     bill.StatusEventRejected,
+				Key:     bill.StatusLineRejected,
 				Doc:     &org.DocumentRef{Code: "INV-9"},
 				Reasons: []*bill.Reason{{Key: bill.ReasonKeyReferences, Description: "missing PO"}},
 			},
@@ -208,7 +208,7 @@ func TestConvertApplicationResponseUpdateFlipsDirection(t *testing.T) {
 		Supplier:  &org.Party{Name: "Seller Co"},
 		Customer:  &org.Party{Name: "Buyer Co"},
 		Lines: []*bill.StatusLine{
-			{Index: 1, Key: bill.StatusEventPaid, Doc: &org.DocumentRef{Code: "INV-1"}},
+			{Index: 1, Key: bill.StatusLinePaid, Doc: &org.DocumentRef{Code: "INV-1"}},
 		},
 	}
 	env, err := gobl.Envelop(st)
@@ -236,7 +236,7 @@ func TestConvertPeppolInvoiceResponse(t *testing.T) {
 		Lines: []*bill.StatusLine{
 			{
 				Index: 1,
-				Key:   bill.StatusEventRejected,
+				Key:   bill.StatusLineRejected,
 				Doc:   &org.DocumentRef{Code: "INV-9"},
 				Reasons: []*bill.Reason{
 					{Key: bill.ReasonKeyReferences, Description: "missing PO"},
@@ -295,7 +295,7 @@ func TestConvertPeppolInvoiceResponseErrorMapsToRejected(t *testing.T) {
 		Lines: []*bill.StatusLine{
 			{
 				Index:   1,
-				Key:     bill.StatusEventError,
+				Key:     bill.StatusLineError,
 				Doc:     &org.DocumentRef{Code: "INV-E"},
 				Reasons: []*bill.Reason{{Key: bill.ReasonKeyOther, Description: "system failure"}},
 			},
@@ -372,7 +372,7 @@ func TestParsePeppolConditionallyAccepted(t *testing.T) {
 
 	require.Len(t, st.Lines, 1)
 	// CA normalizes to accepted, carrying the conditions as reasons.
-	assert.Equal(t, bill.StatusEventAccepted, st.Lines[0].Key)
+	assert.Equal(t, bill.StatusLineAccepted, st.Lines[0].Key)
 	require.Len(t, st.Lines[0].Reasons, 1)
 	assert.Equal(t, bill.ReasonKeyPrices, st.Lines[0].Reasons[0].Key)
 	assert.Equal(t, "price to be confirmed", st.Lines[0].Reasons[0].Description)
@@ -390,7 +390,7 @@ func TestParsePeppolInvoiceResponse(t *testing.T) {
 	require.True(t, ok)
 
 	require.Len(t, st.Lines, 1)
-	assert.Equal(t, bill.StatusEventRejected, st.Lines[0].Key)
+	assert.Equal(t, bill.StatusLineRejected, st.Lines[0].Key)
 
 	require.Len(t, st.Lines[0].Reasons, 1)
 	assert.Equal(t, bill.ReasonKeyReferences, st.Lines[0].Reasons[0].Key)
@@ -437,12 +437,12 @@ func peppolRoundTrip(t *testing.T, st *bill.Status) *bill.Status {
 func TestPeppolResponseCodeRoundTrip(t *testing.T) {
 	// Every status event with a Peppol Invoice Response code must round-trip.
 	events := []cbc.Key{
-		bill.StatusEventAcknowledged,
-		bill.StatusEventProcessing,
-		bill.StatusEventQuerying,
-		bill.StatusEventRejected,
-		bill.StatusEventAccepted,
-		bill.StatusEventPaid,
+		bill.StatusLineAcknowledged,
+		bill.StatusLineProcessing,
+		bill.StatusLineQuerying,
+		bill.StatusLineRejected,
+		bill.StatusLineAccepted,
+		bill.StatusLinePaid,
 	}
 	for _, ev := range events {
 		t.Run(ev.String(), func(t *testing.T) {
@@ -478,7 +478,7 @@ func TestPeppolStatusReasonRoundTrip(t *testing.T) {
 	for _, rk := range reasons {
 		t.Run(rk.String(), func(t *testing.T) {
 			st := basePeppolStatus()
-			st.Lines[0].Key = bill.StatusEventRejected
+			st.Lines[0].Key = bill.StatusLineRejected
 			st.Lines[0].Reasons = []*bill.Reason{{Key: rk, Description: "d"}}
 			out := peppolRoundTrip(t, st)
 			require.Len(t, out.Lines, 1)
@@ -502,7 +502,7 @@ func TestPeppolStatusActionRoundTrip(t *testing.T) {
 	for _, ak := range actions {
 		t.Run(ak.String(), func(t *testing.T) {
 			st := basePeppolStatus()
-			st.Lines[0].Key = bill.StatusEventRejected
+			st.Lines[0].Key = bill.StatusLineRejected
 			st.Lines[0].Actions = []*bill.Action{{Key: ak, Description: "d"}}
 			out := peppolRoundTrip(t, st)
 			require.Len(t, out.Lines, 1)
@@ -514,7 +514,7 @@ func TestPeppolStatusActionRoundTrip(t *testing.T) {
 
 func TestPeppolInvoiceResponseRoundTripFull(t *testing.T) {
 	st := basePeppolStatus()
-	st.Lines[0].Key = bill.StatusEventRejected
+	st.Lines[0].Key = bill.StatusLineRejected
 	st.Lines[0].Doc.Type = bill.InvoiceTypeCreditNote
 	st.Lines[0].Reasons = []*bill.Reason{{Key: bill.ReasonKeyPrices, Description: "price off"}}
 	st.Lines[0].Actions = []*bill.Action{{Key: bill.ActionKeyReissue, Description: "redo"}}
@@ -523,7 +523,7 @@ func TestPeppolInvoiceResponseRoundTripFull(t *testing.T) {
 
 	require.Len(t, out.Lines, 1)
 	l := out.Lines[0]
-	assert.Equal(t, bill.StatusEventRejected, l.Key)
+	assert.Equal(t, bill.StatusLineRejected, l.Key)
 	// The credit-note document type round-trips via DocumentTypeCode 381.
 	require.NotNil(t, l.Doc)
 	assert.Equal(t, bill.InvoiceTypeCreditNote, l.Doc.Type)

--- a/context.go
+++ b/context.go
@@ -241,8 +241,9 @@ var ContextZATCA = Context{
 }
 
 // ContextPeppolInvoiceResponse defines the Peppol BIS Invoice Response context.
-// It is a distinct customization from the billing invoice/credit-note context
-// (ContextPeppol), so it is registered as its own context.
+// It is its own context (separate from the billing ContextPeppol) because the
+// Invoice Response declares a different CustomizationID, which is what
+// FindContext matches a parsed document against.
 var ContextPeppolInvoiceResponse = Context{
 	CustomizationID: "urn:fdc:peppol.eu:poacc:trns:invoice_response:3",
 	ProfileID:       "urn:fdc:peppol.eu:poacc:bis:invoice_response:3",

--- a/context.go
+++ b/context.go
@@ -247,6 +247,9 @@ var ContextZATCA = Context{
 var ContextPeppolInvoiceResponse = Context{
 	CustomizationID: "urn:fdc:peppol.eu:poacc:trns:invoice_response:3",
 	ProfileID:       "urn:fdc:peppol.eu:poacc:bis:invoice_response:3",
+	VESIDs: VESIDMapping{
+		ApplicationResponse: "eu.peppol.bis3:invoice-message-response:2025.5",
+	},
 }
 
 // contexts is used internally for reverse lookups during parsing.

--- a/context.go
+++ b/context.go
@@ -27,6 +27,8 @@ type VESIDMapping struct {
 	Invoice string
 	// CreditNote is the VESID for credit notes
 	CreditNote string
+	// ApplicationResponse is the VESID for application responses
+	ApplicationResponse string
 }
 
 // Context is used to ensure that the generated UBL document

--- a/context.go
+++ b/context.go
@@ -240,6 +240,14 @@ var ContextZATCA = Context{
 	},
 }
 
+// ContextPeppolInvoiceResponse defines the Peppol BIS Invoice Response context.
+// It is a distinct customization from the billing invoice/credit-note context
+// (ContextPeppol), so it is registered as its own context.
+var ContextPeppolInvoiceResponse = Context{
+	CustomizationID: "urn:fdc:peppol.eu:poacc:trns:invoice_response:3",
+	ProfileID:       "urn:fdc:peppol.eu:poacc:bis:invoice_response:3",
+}
+
 // contexts is used internally for reverse lookups during parsing.
 // When adding new contexts, remember to add them here AND as exported variables above.
-var contexts = []Context{ContextEN16931, ContextPeppol, ContextPeppolSelfBilled, ContextXRechnung, ContextPeppolFranceCIUS, ContextPeppolFranceExtended, ContextZATCA}
+var contexts = []Context{ContextEN16931, ContextPeppol, ContextPeppolSelfBilled, ContextXRechnung, ContextPeppolFranceCIUS, ContextPeppolFranceExtended, ContextZATCA, ContextPeppolInvoiceResponse}

--- a/context.go
+++ b/context.go
@@ -248,7 +248,7 @@ var ContextPeppolInvoiceResponse = Context{
 	CustomizationID: "urn:fdc:peppol.eu:poacc:trns:invoice_response:3",
 	ProfileID:       "urn:fdc:peppol.eu:poacc:bis:invoice_response:3",
 	VESIDs: VESIDMapping{
-		ApplicationResponse: "eu.peppol.bis3:invoice-message-response:2025.5",
+		ApplicationResponse: "eu.peppol.bis3:invoice-message-response:2026.5",
 	},
 }
 

--- a/context.go
+++ b/context.go
@@ -27,8 +27,8 @@ type VESIDMapping struct {
 	Invoice string
 	// CreditNote is the VESID for credit notes
 	CreditNote string
-	// ApplicationResponse is the VESID for application responses
-	ApplicationResponse string
+	// Status is the VESID for status documents (UBL ApplicationResponses)
+	Status string
 }
 
 // Context is used to ensure that the generated UBL document
@@ -248,7 +248,7 @@ var ContextPeppolInvoiceResponse = Context{
 	CustomizationID: "urn:fdc:peppol.eu:poacc:trns:invoice_response:3",
 	ProfileID:       "urn:fdc:peppol.eu:poacc:bis:invoice_response:3",
 	VESIDs: VESIDMapping{
-		ApplicationResponse: "eu.peppol.bis3:invoice-message-response:2026.5",
+		Status: "eu.peppol.bis3:invoice-message-response:2026.5",
 	},
 }
 

--- a/ubl.go
+++ b/ubl.go
@@ -80,6 +80,17 @@ func Parse(data []byte) (any, error) {
 		}
 		return in, nil
 
+	case NamespaceUBLApplicationResponse:
+		ar := new(ApplicationResponse)
+		if err := xmlctx.Unmarshal(data, ar, xmlctx.WithNamespaces(map[string]string{
+			"":    ns,
+			"cbc": NamespaceCBC,
+			"cac": NamespaceCAC,
+		})); err != nil {
+			return nil, err
+		}
+		return ar, nil
+
 	// Future document types can be added here
 	// case NamespaceUBLOrder:
 	//     order := new(Order)
@@ -114,18 +125,19 @@ func Convert(env *gobl.Envelope, opts ...Option) (any, error) {
 		opt(o)
 	}
 
-	// Check and add missing addons
-	if err := ensureAddons(env, o.context.Addons); err != nil {
-		return nil, err
-	}
-
 	switch doc := env.Extract().(type) {
 	case *bill.Invoice:
+		// Check and add missing addons
+		if err := ensureAddons(env, o.context.Addons); err != nil {
+			return nil, err
+		}
 		// Removes included taxes as they are not supported in UBL
 		if err := doc.RemoveIncludedTaxes(); err != nil {
 			return nil, fmt.Errorf("cannot convert invoice with included taxes: %w", err)
 		}
 		return ublInvoice(doc, o)
+	case *bill.Status:
+		return ublApplicationResponse(doc, o)
 	default:
 		return nil, ErrUnsupportedDocumentType
 	}

--- a/ubl.go
+++ b/ubl.go
@@ -137,7 +137,7 @@ func Convert(env *gobl.Envelope, opts ...Option) (any, error) {
 		}
 		return ublInvoice(doc, o)
 	case *bill.Status:
-		return ublApplicationResponse(doc, o)
+		return ublApplicationResponse(doc, o), nil
 	default:
 		return nil, ErrUnsupportedDocumentType
 	}

--- a/ubl_test.go
+++ b/ubl_test.go
@@ -167,15 +167,14 @@ func TestConvertUnsupportedDocumentType(t *testing.T) {
 	assert.ErrorIs(t, err, ubl.ErrUnsupportedDocumentType)
 }
 
-func TestConvertRejectsNonInvoiceWhenAddonsRequired(t *testing.T) {
-	// When the context declares required addons, ensureAddons must
-	// fail fast on a non-invoice payload rather than reaching the type switch.
+func TestConvertRejectsUnsupportedDocument(t *testing.T) {
+	// A document type with no UBL mapping is rejected as unsupported.
 	env, err := gobl.Envelop(&note.Message{Content: "hello"})
 	require.NoError(t, err)
 
 	_, err = ubl.Convert(env, ubl.WithContext(ubl.ContextEN16931))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "expected bill.Invoice")
+	assert.ErrorIs(t, err, ubl.ErrUnsupportedDocumentType)
 }
 
 func TestBytes(t *testing.T) {


### PR DESCRIPTION
## Context

GOBL's `bill.Status` carries document lifecycle messages — a recipient accepting, rejecting or querying an invoice. UBL's vehicle for those is the `ApplicationResponse`, and the profile in live use on the Peppol network is the BIS Invoice Response (transaction T111). This PR teaches gobl.ubl both: the generic document type, and the T111 profile on top.

## Changes

- Add the UBL 2.1 `ApplicationResponse` structs and the generic two-way mapping with `bill.Status`: parties, dates, notes, document reference and description convert in both directions.
- Leave response codes and document-type codes to contexts — each profile brings its own code lists, so the generic mapping emits none.
- Add `ContextPeppolInvoiceResponse`, stamping the T111 specifics: UNCL4343 response codes, `OPStatusReason`/`OPStatusAction` clarifications, the mandatory UNCL1001 document-type code, and the party trimming the CIUS requires.
- Wire `ApplicationResponse` into `Parse` and `Convert`; `ensureAddons` moves inside the invoice case so a `bill.Status` reaches the type switch.
- Add an `ApplicationResponse` VESID to the context mapping, pinned to `eu.peppol.bis3:invoice-message-response:2026.5`.
- Cover with round-trip and code-list completeness tests, plus an opt-in phive validation test (`-validate`).

## Next

Profile rules for other ApplicationResponse dialects (e.g. OIOUBL's) live in their own modules on top of the generic mapping, following the invoice pattern.