### PR TITLE
Appending the MVA suffix to Norwegian VAT numbers

### DIFF
--- a/party.go
+++ b/party.go
@@ -3,9 +3,11 @@ package ubl
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 )
 
@@ -142,6 +144,11 @@ func newParty(party *org.Party) *Party { //nolint:gocyclo
 
 	if tID := party.TaxID; tID != nil && party.TaxID.Code != "" {
 		code := party.TaxID.String()
+		// Norwegian VAT numbers require the MVA suffix on the wire
+		// (PEPPOL-EN16931 NO-R-001), which GOBL normalization may strip.
+		if tID.Country.Code() == l10n.NO && !strings.HasSuffix(code, "MVA") {
+			code += "MVA"
+		}
 		id := tID.GetScheme()
 		if id == cbc.CodeEmpty {
 			// Peppol default

--- a/party_test.go
+++ b/party_test.go
@@ -69,4 +69,24 @@ func TestNewParty(t *testing.T) {
 		require.NotNil(t, doc.PayeeParty.PartyLegalEntity.CompanyID.SchemeID)
 		assert.Equal(t, "0088", *doc.PayeeParty.PartyLegalEntity.CompanyID.SchemeID)
 	})
+
+	t.Run("norwegian VAT numbers carry the MVA suffix", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-complete.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Supplier.TaxID = &tax.Identity{Country: "NO", Code: "923456783"}
+		require.NoError(t, env.Calculate())
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, doc.AccountingSupplierParty.Party.PartyTaxScheme)
+		assert.Equal(t, "NO923456783MVA", *doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID)
+
+		// An already-suffixed code must not be doubled.
+		inv.Supplier.TaxID.Code = "923456783MVA"
+		doc, err = ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+		assert.Equal(t, "NO923456783MVA", *doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID)
+	})
 }


### PR DESCRIPTION
Norwegian VAT numbers must carry the MVA suffix on the wire (NO<orgnr>MVA, PEPPOL-EN16931 rule NO-R-001), but GOBL's normalization may strip it depending on the pinned version. This appends the suffix in the converter when writing the PartyTaxScheme/CompanyID for an NO tax identity, so output is correct regardless of the GOBL pin.

The change is idempotent: once invopop/gobl#857 is released and re-pinned here, codes arrive already suffixed and this becomes a no-op.