### PR TITLE
Trim dead code from OIOUBL 2.1 work (ponytail cleanup)

### DIFF
--- a/lines.go
+++ b/lines.go
@@ -401,8 +401,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 			},
 		}
 		if s := ch.Ext.Get(untdid.ExtKeyCharge).String(); s != "" {
-			e := s
-			ac.AllowanceChargeReasonCode = &e
+			ac.AllowanceChargeReasonCode = &s
 		}
 		if ch.Reason != "" {
 			ac.AllowanceChargeReason = &ch.Reason
@@ -428,8 +427,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 			},
 		}
 		if s := d.Ext.Get(untdid.ExtKeyAllowance).String(); s != "" {
-			e := s
-			ac.AllowanceChargeReasonCode = &e
+			ac.AllowanceChargeReasonCode = &s
 		}
 		if d.Reason != "" {
 			ac.AllowanceChargeReason = &d.Reason

--- a/party.go
+++ b/party.go
@@ -40,9 +40,8 @@ type Party struct {
 
 // EndpointID represents an endpoint identifier
 type EndpointID struct {
-	SchemeAgencyID *string `xml:"schemeAgencyID,attr"`
-	SchemeID       string  `xml:"schemeID,attr"`
-	Value          string  `xml:",chardata"`
+	SchemeID string `xml:"schemeID,attr"`
+	Value    string `xml:",chardata"`
 }
 
 // Identification represents an identification


### PR DESCRIPTION
Small over-engineering cleanup of the `add-oioubl-21-context` branch, found via a ponytail-style review. Purely internal, no behavior change. Build, vet, and the full test suite pass.

## Changes

- **`party.go`** — removed `EndpointID.SchemeAgencyID`. It's never set when emitting (the three `EndpointID{...}` construction sites build only `SchemeID`+`Value`), never read on parse, and has no consumer; a real OIOUBL `cbc:EndpointID` carries a bare `schemeID`. The field only ever captured an attribute that was then dropped.
- **`lines.go`** — dropped the `e := s` copy in the two allowance/charge reason-code blocks. The `if`-scoped `s` is address-safe, so `ac.AllowanceChargeReasonCode = &s` is equivalent.

Net: -3 lines.

## Considered but deliberately NOT changed

- **`context.go` `VESIDMapping.ApplicationResponse` / `.Reminder`** — these *look* unused within `gobl.ubl`, but `VESIDMapping` is exported and consumed cross-repo by `ubl` (`internal/domain/outgoing.go` reads `.Invoice`/`.CreditNote`; `validation.go` runs Phive validation). They're staged for the `ubl` validation harness to cover the ApplicationResponse/Reminder docs this branch now emits — a deliberate API surface, not dead code.
- `isNumericICDScheme` rune loop (idiomatic already), `oioublResponseDocType` / `responseReferenceID` (readable, document OIOUBL code-list rules / the intentional 1-based fallback), and the CLI context aliases in `convert.go` (removing accepted inputs is a behavior change) — all left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)