### PR TITLE
Omit empty payment mandate when direct debit has no reference

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -130,8 +130,11 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 		ui.PaymentMeans[0].PayeeFinancialAccount = newCreditTransferAccount(instr.CreditTransfer[0])
 	}
 	if instr.DirectDebit != nil {
-		ui.PaymentMeans[0].PaymentMandate = &PaymentMandate{
-			ID: IDType{Value: instr.DirectDebit.Ref},
+		// Skip the mandate without a reference; an empty <cbc:ID/> is rejected by Peppol.
+		if instr.DirectDebit.Ref != "" {
+			ui.PaymentMeans[0].PaymentMandate = &PaymentMandate{
+				ID: IDType{Value: instr.DirectDebit.Ref},
+			}
 		}
 		if instr.DirectDebit.Account != "" {
 			ui.PaymentMeans[0].PayerFinancialAccount = &FinancialAccount{

--- a/payment_test.go
+++ b/payment_test.go
@@ -5,8 +5,10 @@ import (
 
 	ubl "github.com/invopop/gobl.ubl"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPayment(t *testing.T) {
@@ -32,6 +34,40 @@ func TestNewPayment(t *testing.T) {
 		assert.Equal(t, "123456789", *doc.PaymentMeans[0].PayeeFinancialAccount.ID)
 		assert.Equal(t, "Test Bank Account", *doc.PaymentMeans[0].PayeeFinancialAccount.Name)
 		assert.Equal(t, "DNBANOKK", *doc.PaymentMeans[0].PayeeFinancialAccount.FinancialInstitutionBranch.ID)
+	})
+
+	t.Run("direct debit without mandate reference omits the mandate", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-minimal.json")
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Payment.Instructions.CreditTransfer = nil
+		inv.Payment.Instructions.DirectDebit = &pay.DirectDebit{Account: "0667"}
+
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc.PaymentMeans)
+
+		// No reference means no mandate element, otherwise we emit an empty <cbc:ID/>.
+		assert.Nil(t, doc.PaymentMeans[0].PaymentMandate)
+		assert.Equal(t, "0667", *doc.PaymentMeans[0].PayerFinancialAccount.ID)
+	})
+
+	t.Run("direct debit with mandate reference includes the mandate", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-minimal.json")
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Payment.Instructions.CreditTransfer = nil
+		inv.Payment.Instructions.DirectDebit = &pay.DirectDebit{Ref: "MANDATE-123", Account: "0667"}
+
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc.PaymentMeans)
+		require.NotNil(t, doc.PaymentMeans[0].PaymentMandate)
+		assert.Equal(t, "MANDATE-123", doc.PaymentMeans[0].PaymentMandate.ID.Value)
 	})
 
 	t.Run("document type extension", func(t *testing.T) {


### PR DESCRIPTION
## Context

A Peppol send for a Belgian invoice was failing UBL validation with:

```
Document MUST not contain empty elements.
```

The invoice pays by direct debit, but the source data carries no mandate reference (`payment.instructions.direct_debit.ref` is empty). We were emitting the mandate element anyway:

```xml
<cac:PaymentMandate>
  <cbc:ID></cbc:ID>
</cac:PaymentMandate>
```

That empty `cbc:ID` is what trips the validator. It sits in a pincer between two Peppol rules: `PEPPOL-EN16931-R061` only checks that `cac:PaymentMandate/cbc:ID` *exists* (so the empty tag accidentally satisfied it), while the generic "no empty elements" rule rejects it for being blank.

## Changes

`payment.go` now only emits `PaymentMandate` when `DirectDebit.Ref` is non-empty — matching the pattern already used for the creditor ID a few lines up. A direct debit that genuinely lacks a mandate reference now fails with the clear `R061` message instead of the confusing "empty element" one, which surfaces it as the data problem it is.

Added two regression tests in `payment_test.go`: one asserting no mandate element when the reference is missing, one asserting the mandate is emitted when it's present.

## Note

GOBL's `eu-en16931` validation doesn't currently reject a direct debit without a mandate reference at build time, so the error only shows up at the UBL generation step. Worth considering as a separate follow-up.
