### PR TITLE
Emitting Procurement-BilSim-1.0 as the OIOUBL Reminder profile

### DIFF
--- a/reminder.go
+++ b/reminder.go
@@ -250,10 +250,14 @@ func reminderDocumentReference(doc *org.DocumentRef) *Reference {
 
 // OIOUBL 2.1 Reminder specifics follow.
 
-// Reminders ride the same profile5:ver2.0 / profileid-1.2 profile as invoices.
+// Reminders ride the billing-only Procurement-BilSim-1.0 profile (profileid-1.2),
+// NOT the profile5 invoices use: the OIOUBL Reminder belongs to the billing
+// process, and the billing-only profile avoids advertising the order documents
+// that the OrdSim-BilSim profiles carry.
 const (
-	reminderTypeCodeListID = "urn:oioubl:codelist:remindertypecode-1.1"
-	oioublProfileSchemeV12 = "urn:oioubl:id:profileid-1.2"
+	reminderTypeCodeListID  = "urn:oioubl:codelist:remindertypecode-1.1"
+	oioublProfileSchemeV12  = "urn:oioubl:id:profileid-1.2"
+	oioublReminderProfileID = "Procurement-BilSim-1.0"
 )
 
 // applyOIOUBL21Reminder stamps the OIOUBL specifics: party formatting, the
@@ -270,12 +274,14 @@ func applyOIOUBL21Reminder(out *Reminder, pmt *bill.Payment) {
 		stampOIOUBL21PaymentChannel(&out.PaymentMeans[i])
 	}
 
-	if out.ProfileID != nil {
-		schemeID := oioublProfileSchemeV12
-		agencyID := oioublCodeListAgencyID
-		out.ProfileID.SchemeID = &schemeID
-		out.ProfileID.SchemeAgencyID = &agencyID
+	if out.ProfileID == nil {
+		out.ProfileID = &IDType{}
 	}
+	schemeID := oioublProfileSchemeV12
+	agencyID := oioublCodeListAgencyID
+	out.ProfileID.SchemeID = &schemeID
+	out.ProfileID.SchemeAgencyID = &agencyID
+	out.ProfileID.Value = oioublReminderProfileID
 
 	if code := pmt.Ext.Get(oioubl.ExtKeyReminderType); code != "" {
 		agencyID := oioublCodeListAgencyID

--- a/test/data/convert/oioubl21-reminder/out/reminder-basic.xml
+++ b/test/data/convert/oioubl21-reminder/out/reminder-basic.xml
@@ -2,7 +2,7 @@
 <Reminder xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2">
   <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
-  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">Procurement-BilSim-1.0</cbc:ProfileID>
   <cbc:ID>2026-R-1000</cbc:ID>
   <cbc:UUID>019ed096-350c-73bc-9695-b103e1d03b93</cbc:UUID>
   <cbc:IssueDate>2026-01-15</cbc:IssueDate>

--- a/test/data/convert/oioubl21-reminder/out/reminder-fik.xml
+++ b/test/data/convert/oioubl21-reminder/out/reminder-fik.xml
@@ -2,7 +2,7 @@
 <Reminder xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2">
   <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
-  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">Procurement-BilSim-1.0</cbc:ProfileID>
   <cbc:ID>2026-R-1000</cbc:ID>
   <cbc:UUID>019ed096-350c-73bc-9695-b103e1d03b93</cbc:UUID>
   <cbc:IssueDate>2026-01-15</cbc:IssueDate>

--- a/test/data/parse/oioubl21-reminder/reminder-basic.xml
+++ b/test/data/parse/oioubl21-reminder/reminder-basic.xml
@@ -2,7 +2,7 @@
 <Reminder xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2">
   <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
-  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">Procurement-BilSim-1.0</cbc:ProfileID>
   <cbc:ID>2026-R-1000</cbc:ID>
   <cbc:UUID>019ed096-350c-73bc-9695-b103e1d03b93</cbc:UUID>
   <cbc:IssueDate>2026-01-15</cbc:IssueDate>

--- a/test/data/parse/oioubl21-reminder/reminder-fik.xml
+++ b/test/data/parse/oioubl21-reminder/reminder-fik.xml
@@ -2,7 +2,7 @@
 <Reminder xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2">
   <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
-  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">Procurement-BilSim-1.0</cbc:ProfileID>
   <cbc:ID>2026-R-1000</cbc:ID>
   <cbc:UUID>019ed096-350c-73bc-9695-b103e1d03b93</cbc:UUID>
   <cbc:IssueDate>2026-01-15</cbc:IssueDate>


### PR DESCRIPTION
A Reminder is a billing-process document, so it carries the billing-only Procurement-BilSim-1.0 profile rather than the profile5 invoices use (which it inherited from the OIOUBL context). Confirmed against the Unimaze sandbox: the SubmitPaymentReminder transaction is registered under profileId Procurement-BilSim-1.0, and the billing-only profile avoids advertising the order documents the OrdSim-BilSim profiles carry.

Regenerates the reminder convert goldens and aligns the parse fixtures.