### PR TITLE
Gate BT-6 on a matching exchange rate to satisfy BR-53

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -144,9 +144,8 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		AccountingCustomerParty: CustomerParty{Party: newParty(inv.Customer, o.context)},
 	}
 
-	// PEPPOL-EN16931-R005 / BR-53: only emit BT-6 (TaxCurrencyCode) when a
-	// matching exchange rate is available. BT-111 (the VAT total in accounting
-	// currency) is only added in that case (see totals.go), and BR-53 requires
+	// PEPPOL-EN16931-R005 / BR-53: only map BT-6 when a matching exchange rate
+	// is available. BT-111 is only added in that case and BR-53 requires
 	// BT-111 whenever BT-6 is present, so the two must be gated identically.
 	if taxCurrency := inv.RegimeDef().Currency; taxCurrency != inv.Currency &&
 		cur.MatchExchangeRate(inv.ExchangeRates, inv.Currency, taxCurrency) != nil {

--- a/invoice.go
+++ b/invoice.go
@@ -148,10 +148,9 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 	// matching exchange rate is available. BT-111 (the VAT total in accounting
 	// currency) is only added in that case (see totals.go), and BR-53 requires
 	// BT-111 whenever BT-6 is present, so the two must be gated identically.
-	if taxCurrency := inv.RegimeDef().Currency; taxCurrency != inv.Currency {
-		if cur.MatchExchangeRate(inv.ExchangeRates, inv.Currency, taxCurrency) != nil {
-			out.TaxCurrencyCode = string(taxCurrency)
-		}
+	if taxCurrency := inv.RegimeDef().Currency; taxCurrency != inv.Currency &&
+		cur.MatchExchangeRate(inv.ExchangeRates, inv.Currency, taxCurrency) != nil {
+		out.TaxCurrencyCode = string(taxCurrency)
 	}
 
 	docType := inv.Type

--- a/invoice.go
+++ b/invoice.go
@@ -10,6 +10,7 @@ import (
 	zatca "github.com/invopop/gobl.sa.zatca/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	cur "github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/tax"
 )
 
@@ -143,9 +144,14 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		AccountingCustomerParty: CustomerParty{Party: newParty(inv.Customer, o.context)},
 	}
 
-	// PEPPOL-EN16931-R005
+	// PEPPOL-EN16931-R005 / BR-53: only emit BT-6 (TaxCurrencyCode) when a
+	// matching exchange rate is available. BT-111 (the VAT total in accounting
+	// currency) is only added in that case (see totals.go), and BR-53 requires
+	// BT-111 whenever BT-6 is present, so the two must be gated identically.
 	if taxCurrency := inv.RegimeDef().Currency; taxCurrency != inv.Currency {
-		out.TaxCurrencyCode = string(taxCurrency)
+		if cur.MatchExchangeRate(inv.ExchangeRates, inv.Currency, taxCurrency) != nil {
+			out.TaxCurrencyCode = string(taxCurrency)
+		}
 	}
 
 	docType := inv.Type

--- a/test/data/convert/peppol/invoice-dk.json
+++ b/test/data/convert/peppol/invoice-dk.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "60bc70aedef820940eb64acaff65c0b3afcf2a944c488beae8f3a862142a290b"
+			"val": "dd732440a514f0007fc0c730ff6709e1cbaed47e5b830a4564bf20319b913c04"
 		},
-		"from": "iso6523-actorid-upis::0184:11421210",
-		"to": "iso6523-actorid-upis::0088:6777420277858"
+		"from": "iso6523-actorid-upis::0184:10000009",
+		"to": "iso6523-actorid-upis::0088:5790000000005"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -29,16 +29,16 @@
 		},
 		"supplier": {
 			"uuid": "e096fcc8-d810-443e-948e-85331d4680c3",
-			"name": "Hotel E2E Copenhagen Company",
+			"name": "Example Hotel ApS",
 			"tax_id": {
 				"country": "DK",
-				"code": "11421210"
+				"code": "10000009"
 			},
 			"identities": [
 				{
 					"scope": "legal",
 					"type": "CVR",
-					"code": "11421210",
+					"code": "10000009",
 					"ext": {
 						"iso-scheme-id": "0184"
 					}
@@ -47,25 +47,25 @@
 			"people": [
 				{
 					"name": {
-						"given": "E4XDV2ULZH-DC-5ER2DRIGGU8RV40D744T"
+						"given": "Jens Hansen"
 					}
 				}
 			],
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::0184:11421210"
+					"uri": "iso6523-actorid-upis::0184:10000009"
 				}
 			],
 			"inboxes": [
 				{
 					"key": "peppol",
 					"scheme": "0184",
-					"code": "11421210"
+					"code": "10000009"
 				}
 			],
 			"addresses": [
 				{
-					"street": "Rådhuspladsen 1",
+					"street": "Eksempelvej 1",
 					"locality": "København",
 					"code": "1550",
 					"country": "DK"
@@ -84,31 +84,31 @@
 			],
 			"telephones": [
 				{
-					"num": "+4912471842187"
+					"num": "+4512345678"
 				}
 			]
 		},
 		"customer": {
-			"name": "Blixen Hoteller ApS",
+			"name": "Example Customer ApS",
 			"tax_id": {
 				"country": "DK",
 				"code": "22222228"
 			},
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::0088:6777420277858"
+					"uri": "iso6523-actorid-upis::0088:5790000000005"
 				}
 			],
 			"inboxes": [
 				{
 					"key": "peppol",
 					"scheme": "0088",
-					"code": "6777420277858"
+					"code": "5790000000005"
 				}
 			],
 			"addresses": [
 				{
-					"street": "Strøget 12",
+					"street": "Eksempelvej 2",
 					"locality": "København",
 					"code": "1160",
 					"country": "DK"

--- a/test/data/convert/peppol/invoice-dk.json
+++ b/test/data/convert/peppol/invoice-dk.json
@@ -1,0 +1,190 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "60bc70aedef820940eb64acaff65c0b3afcf2a944c488beae8f3a862142a290b"
+		},
+		"from": "iso6523-actorid-upis::0184:11421210",
+		"to": "iso6523-actorid-upis::0088:6777420277858"
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"code": "20260600000001",
+		"issue_date": "2026-06-22",
+		"issue_time": "13:29:04",
+		"currency": "EUR",
+		"tax": {
+			"rounding": "currency",
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"uuid": "e096fcc8-d810-443e-948e-85331d4680c3",
+			"name": "Hotel E2E Copenhagen Company",
+			"tax_id": {
+				"country": "DK",
+				"code": "11421210"
+			},
+			"identities": [
+				{
+					"scope": "legal",
+					"type": "CVR",
+					"code": "11421210",
+					"ext": {
+						"iso-scheme-id": "0184"
+					}
+				}
+			],
+			"people": [
+				{
+					"name": {
+						"given": "E4XDV2ULZH-DC-5ER2DRIGGU8RV40D744T"
+					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0184:11421210"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0184",
+					"code": "11421210"
+				}
+			],
+			"addresses": [
+				{
+					"street": "Rådhuspladsen 1",
+					"locality": "København",
+					"code": "1550",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "admin@example.com"
+				},
+				{
+					"addr": "support@example.com"
+				},
+				{
+					"addr": "billing@example.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "+4912471842187"
+				}
+			]
+		},
+		"customer": {
+			"name": "Blixen Hoteller ApS",
+			"tax_id": {
+				"country": "DK",
+				"code": "22222228"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0088:6777420277858"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0088",
+					"code": "6777420277858"
+				}
+			],
+			"addresses": [
+				{
+					"street": "Strøget 12",
+					"locality": "København",
+					"code": "1160",
+					"country": "DK"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"key": "services",
+					"name": "double room",
+					"price": "88.00",
+					"unit": "service"
+				},
+				"sum": "88.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "25.0%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "88.00"
+			}
+		],
+		"ordering": {
+			"code": "No information provided"
+		},
+		"payment": {
+			"advances": [
+				{
+					"description": "CreditCard",
+					"amount": "110.00"
+				}
+			],
+			"instructions": {
+				"key": "any",
+				"ext": {
+					"untdid-payment-means": "1"
+				}
+			}
+		},
+		"totals": {
+			"sum": "88.00",
+			"total": "88.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "88.00",
+								"percent": "25.0%",
+								"amount": "22.00"
+							}
+						],
+						"amount": "22.00"
+					}
+				],
+				"sum": "22.00"
+			},
+			"tax": "22.00",
+			"total_with_tax": "110.00",
+			"payable": "110.00",
+			"advance": "110.00",
+			"due": "0.00"
+		}
+	}
+}

--- a/test/data/convert/peppol/out/invoice-dk.xml
+++ b/test/data/convert/peppol/out/invoice-dk.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>20260600000001</cbc:ID>
+  <cbc:IssueDate>2026-06-22</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>No information provided</cbc:BuyerReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0184">11421210</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Hotel E2E Copenhagen Company</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rådhuspladsen 1</cbc:StreetName>
+        <cbc:CityName>København</cbc:CityName>
+        <cbc:PostalZone>1550</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>DK11421210</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Hotel E2E Copenhagen Company</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0184">11421210</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>E4XDV2ULZH-DC-5ER2DRIGGU8RV40D744T</cbc:Name>
+        <cbc:Telephone>+4912471842187</cbc:Telephone>
+        <cbc:ElectronicMail>admin@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">6777420277858</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Blixen Hoteller ApS</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Strøget 12</cbc:StreetName>
+        <cbc:CityName>København</cbc:CityName>
+        <cbc:PostalZone>1160</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>DK22222228</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Blixen Hoteller ApS</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>1</cbc:PaymentMeansCode>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">22.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">88.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">22.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">88.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">88.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">110.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">110.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">0.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="E48">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">88.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>double room</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">88.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/convert/peppol/out/invoice-dk.xml
+++ b/test/data/convert/peppol/out/invoice-dk.xml
@@ -9,12 +9,12 @@
   <cbc:BuyerReference>No information provided</cbc:BuyerReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">11421210</cbc:EndpointID>
+      <cbc:EndpointID schemeID="0184">10000009</cbc:EndpointID>
       <cac:PartyName>
-        <cbc:Name>Hotel E2E Copenhagen Company</cbc:Name>
+        <cbc:Name>Example Hotel ApS</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>Rådhuspladsen 1</cbc:StreetName>
+        <cbc:StreetName>Eksempelvej 1</cbc:StreetName>
         <cbc:CityName>København</cbc:CityName>
         <cbc:PostalZone>1550</cbc:PostalZone>
         <cac:Country>
@@ -22,30 +22,30 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>DK11421210</cbc:CompanyID>
+        <cbc:CompanyID>DK10000009</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Hotel E2E Copenhagen Company</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0184">11421210</cbc:CompanyID>
+        <cbc:RegistrationName>Example Hotel ApS</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0184">10000009</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:Name>E4XDV2ULZH-DC-5ER2DRIGGU8RV40D744T</cbc:Name>
-        <cbc:Telephone>+4912471842187</cbc:Telephone>
+        <cbc:Name>Jens Hansen</cbc:Name>
+        <cbc:Telephone>+4512345678</cbc:Telephone>
         <cbc:ElectronicMail>admin@example.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0088">6777420277858</cbc:EndpointID>
+      <cbc:EndpointID schemeID="0088">5790000000005</cbc:EndpointID>
       <cac:PartyName>
-        <cbc:Name>Blixen Hoteller ApS</cbc:Name>
+        <cbc:Name>Example Customer ApS</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>Strøget 12</cbc:StreetName>
+        <cbc:StreetName>Eksempelvej 2</cbc:StreetName>
         <cbc:CityName>København</cbc:CityName>
         <cbc:PostalZone>1160</cbc:PostalZone>
         <cac:Country>
@@ -59,7 +59,7 @@
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Blixen Hoteller ApS</cbc:RegistrationName>
+        <cbc:RegistrationName>Example Customer ApS</cbc:RegistrationName>
       </cac:PartyLegalEntity>
     </cac:Party>
   </cac:AccountingCustomerParty>


### PR DESCRIPTION
Emit BT-6 (TaxCurrencyCode) only when a matching exchange rate is available, so it's always paired with BT-111 as EN16931 BR-53 requires.

Changes:
- Gate `TaxCurrencyCode` on `cur.MatchExchangeRate(...)` in `invoice.go`, mirroring the existing BT-111 gate in `totals.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)