### PR TITLE
Address review comments on the OIOUBL converter

### DIFF
--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -35,8 +35,8 @@ type ApplicationResponse struct {
 	DocumentResponse []*DocumentResponse `xml:"cac:DocumentResponse"`
 }
 
-// DocumentResponse pairs one Response with the document it concerns. An
-// ApplicationResponse may carry one per status line (OIOUBL restricts it to one).
+// DocumentResponse pairs one Response with the document it concerns; an
+// ApplicationResponse carries one per status line.
 type DocumentResponse struct {
 	Response          *Response                  `xml:"cac:Response"`
 	DocumentReference *ResponseDocumentReference `xml:"cac:DocumentReference"`
@@ -110,6 +110,8 @@ func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
 		applyOIOUBL21ResponseProfile(out, st)
 	}
 
+	// One DocumentResponse per status line: its response (description, effective
+	// date) plus a reference to the document being responded to.
 	for _, line := range st.Lines {
 		dr := &DocumentResponse{Response: &Response{}}
 		if desc := responseDescription(line); desc != "" {
@@ -168,10 +170,12 @@ const (
 	oioublProfileSchemeID    = "urn:oioubl:id:profileid-1.4"
 	oioublProfileTechnicalID = "Procurement-TecRes-1.0"
 	oioublCodeListAgencyID   = "320"
-	// oioublUBLVersion is the UBLVersionID OIOUBL 2.1 documents declare on the
-	// wire: real NemHandel traffic carries "2.0" (the OIOUBL element model
-	// derives from UBL 2.0), even though the documents validate against the
-	// UBL 2.1 schema. F-LIB001 accepts both; "2.0" matches production.
+	// oioublUBLVersion is the UBLVersionID OIOUBL declares on the wire. "OIOUBL 2.1"
+	// is the profile (cbc:CustomizationID); the UBL syntax version is separate, and
+	// we emit "2.0" to match the documents Unimaze produces. The element model is
+	// UBL 2.1 regardless.
+	// FLAGGED: F-LIB001 permits "2.1" too, so this OIOUBL-only override could be
+	// dropped for a uniform 2.1 once a Unimaze re-send confirms 2.1 is accepted.
 	oioublUBLVersion = "2.0"
 )
 
@@ -225,10 +229,8 @@ func applyOIOUBL21DocumentResponse(dr *DocumentResponse, line *bill.StatusLine) 
 	}
 }
 
-// responseReferenceID returns the 1-based line reference for the Response. The
-// StatusLine index is 1-based once calculated; an unset (zero) index falls back
-// to 1 so the emitted ReferenceID is always a valid line pointer rather than the
-// meaningless "0". The schematron also requires it to be non-empty (F-APR016).
+// responseReferenceID returns the 1-based line reference for the Response,
+// falling back to 1 for an unset index (F-APR016 requires a non-empty value).
 func responseReferenceID(index int) int {
 	if index < 1 {
 		return 1

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -62,7 +62,7 @@ func (ar *ApplicationResponse) goblStatus(o *options) (*bill.Status, error) {
 	out.IssueDate = issueDate
 
 	if ar.IssueTime != "" {
-		ct, err := civil.ParseTime(trimTimeZone(ar.IssueTime))
+		ct, err := civil.ParseTime(ar.IssueTime)
 		if err != nil {
 			return nil, err
 		}

--- a/charges_parse.go
+++ b/charges_parse.go
@@ -12,20 +12,16 @@ import (
 )
 
 // goblAddCharges adds the invoice charges to the gobl output.
-func (ui *Invoice) goblAddCharges(out *bill.Invoice) error {
+func (ui *Invoice) goblAddCharges(out *bill.Invoice, ctx Context) error {
 	var charges []*bill.Charge
 	var discounts []*bill.Discount
 
 	// Build tax category map from TaxTotal
 	taxCategoryMap := ui.buildTaxCategoryMap()
 
-	// OIOUBL emits MultiplierFactorNumeric as the decimal factor (0.05 for 5%)
-	// rather than the percent number (5) used by other profiles.
-	oioubl := ui.CustomizationID == ContextOIOUBL21.CustomizationID
-
 	for _, allowanceCharge := range ui.AllowanceCharge {
 		if allowanceCharge.ChargeIndicator {
-			charge, err := goblCharge(&allowanceCharge, taxCategoryMap, oioubl)
+			charge, err := goblCharge(&allowanceCharge, taxCategoryMap, ctx)
 			if err != nil {
 				return err
 			}
@@ -34,7 +30,7 @@ func (ui *Invoice) goblAddCharges(out *bill.Invoice) error {
 			}
 			charges = append(charges, charge)
 		} else {
-			discount, err := goblDiscount(&allowanceCharge, taxCategoryMap, oioubl)
+			discount, err := goblDiscount(&allowanceCharge, taxCategoryMap, ctx)
 			if err != nil {
 				return err
 			}
@@ -57,12 +53,12 @@ func (ui *Invoice) goblAddCharges(out *bill.Invoice) error {
 // GOBL percentage, or returns nil when none is present. OIOUBL stores the
 // decimal factor (0.05 = 5%), which PercentageFromString reads directly; other
 // profiles store the percent number (5), which needs the % suffix.
-func goblAllowancePercent(ac *AllowanceCharge, oioubl bool) (*num.Percentage, error) {
+func goblAllowancePercent(ac *AllowanceCharge, ctx Context) (*num.Percentage, error) {
 	if ac.MultiplierFactorNumeric == nil {
 		return nil, nil
 	}
 	multiplier := normalizeNumericString(*ac.MultiplierFactorNumeric)
-	if !oioubl && !strings.HasSuffix(multiplier, "%") {
+	if !ctx.Is(ContextOIOUBL21) && !strings.HasSuffix(multiplier, "%") {
 		multiplier += "%"
 	}
 	p, err := num.PercentageFromString(multiplier)
@@ -72,7 +68,7 @@ func goblAllowancePercent(ac *AllowanceCharge, oioubl bool) (*num.Percentage, er
 	return &p, nil
 }
 
-func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo, oioubl bool) (*bill.Charge, error) {
+func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo, ctx Context) (*bill.Charge, error) {
 	ch := &bill.Charge{}
 	if ac.AllowanceChargeReason != nil {
 		ch.Reason = *ac.AllowanceChargeReason
@@ -96,7 +92,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo,
 		}
 		ch.Base = &b
 	}
-	pct, err := goblAllowancePercent(ac, oioubl)
+	pct, err := goblAllowancePercent(ac, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +146,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo,
 	return ch, nil
 }
 
-func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo, oioubl bool) (*bill.Discount, error) {
+func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo, ctx Context) (*bill.Discount, error) {
 	d := &bill.Discount{}
 	if ac.AllowanceChargeReason != nil {
 		d.Reason = *ac.AllowanceChargeReason
@@ -174,7 +170,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 		}
 		d.Base = &b
 	}
-	pct, err := goblAllowancePercent(ac, oioubl)
+	pct, err := goblAllowancePercent(ac, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +224,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 	return d, nil
 }
 
-func goblLineCharge(ac *AllowanceCharge, oioubl bool) (*bill.LineCharge, error) {
+func goblLineCharge(ac *AllowanceCharge, ctx Context) (*bill.LineCharge, error) {
 	amount, err := num.AmountFromString(normalizeNumericString(ac.Amount.Value))
 	if err != nil {
 		return nil, err
@@ -244,7 +240,7 @@ func goblLineCharge(ac *AllowanceCharge, oioubl bool) (*bill.LineCharge, error) 
 	if ac.AllowanceChargeReason != nil {
 		ch.Reason = *ac.AllowanceChargeReason
 	}
-	pct, err := goblAllowancePercent(ac, oioubl)
+	pct, err := goblAllowancePercent(ac, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +259,7 @@ func goblLineCharge(ac *AllowanceCharge, oioubl bool) (*bill.LineCharge, error) 
 	return ch, nil
 }
 
-func goblLineDiscount(ac *AllowanceCharge, oioubl bool) (*bill.LineDiscount, error) {
+func goblLineDiscount(ac *AllowanceCharge, ctx Context) (*bill.LineDiscount, error) {
 	a, err := num.AmountFromString(normalizeNumericString(ac.Amount.Value))
 	if err != nil {
 		return nil, err
@@ -279,7 +275,7 @@ func goblLineDiscount(ac *AllowanceCharge, oioubl bool) (*bill.LineDiscount, err
 	if ac.AllowanceChargeReason != nil {
 		d.Reason = *ac.AllowanceChargeReason
 	}
-	pct, err := goblAllowancePercent(ac, oioubl)
+	pct, err := goblAllowancePercent(ac, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/date.go
+++ b/date.go
@@ -1,7 +1,6 @@
 package ubl
 
 import (
-	"strings"
 	"time"
 
 	"github.com/invopop/gobl/cal"
@@ -15,28 +14,12 @@ func formatDate(date cal.Date) string {
 	return t.Format("2006-01-02")
 }
 
-// parseDate converts a date string to a cal.Date. UBL xsd:date permits an
-// optional timezone (e.g. "...Z", "...+01:00"); NemHandel traffic is unzoned,
-// so the zoned layout is only a fallback for conformant-but-zoned senders.
+// parseDate converts a date string to a cal.Date.
 func parseDate(date string) (cal.Date, error) {
 	t, err := time.Parse("2006-01-02", date)
 	if err != nil {
-		t, err = time.Parse("2006-01-02Z07:00", date)
-		if err != nil {
-			return cal.Date{}, err
-		}
+		return cal.Date{}, err
 	}
 
 	return cal.MakeDate(t.Year(), t.Month(), t.Day()), nil
-}
-
-// trimTimeZone strips an optional XSD timezone designator ("Z" or "±HH:MM")
-// from a time-of-day value. civil.ParseTime rejects a zone, but UBL xsd:time
-// permits one; a time value otherwise contains only digits, ':' and '.', so
-// the first zone marker is unambiguous.
-func trimTimeZone(t string) string {
-	if i := strings.IndexAny(t, "Zz+-"); i >= 0 {
-		return t[:i]
-	}
-	return t
 }

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -90,7 +90,7 @@ func (ui *Invoice) goblInvoice(o *options) (*bill.Invoice, error) {
 	}
 	ui.applyExchangeRates(out)
 
-	if err := ui.goblAddLines(out); err != nil {
+	if err := ui.goblAddLines(out, o.context); err != nil {
 		return nil, err
 	}
 	if err := ui.goblAddPayment(out, o); err != nil {
@@ -112,7 +112,7 @@ func (ui *Invoice) goblInvoice(o *options) (*bill.Invoice, error) {
 	ui.applyTaxRepresentative(out, o)
 
 	if len(ui.AllowanceCharge) > 0 {
-		if err := ui.goblAddCharges(out); err != nil {
+		if err := ui.goblAddCharges(out, o.context); err != nil {
 			return nil, err
 		}
 	}

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -140,9 +140,8 @@ func (ui *Invoice) resolveInvoiceType(out *bill.Invoice, o *options) {
 	if typeCode == nil {
 		typeCode = ui.CreditNoteTypeCode
 	}
-	if typeCode == nil && ui.XMLName.Local == rootNameCreditNote {
-		// A CreditNote document carries no mandatory type code (OIOUBL's
-		// samples omit it entirely); the root element is authoritative.
+	if typeCode == nil && o.context.Is(ContextOIOUBL21) && ui.XMLName.Local == rootNameCreditNote {
+		// OIOUBL omits the credit-note type code; the root element is authoritative.
 		out.Type = bill.InvoiceTypeCreditNote
 		return
 	}
@@ -161,7 +160,7 @@ func (ui *Invoice) parseInvoiceDates(out *bill.Invoice) error {
 	out.IssueDate = issueDate
 
 	if ui.IssueTime != "" {
-		ct, err := civil.ParseTime(trimTimeZone(ui.IssueTime))
+		ct, err := civil.ParseTime(ui.IssueTime)
 		if err != nil {
 			return err
 		}

--- a/lines.go
+++ b/lines.go
@@ -177,10 +177,6 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 					p := "0"
 					it.ClassifiedTaxCategory.Percent = &p
 				}
-
-				if s := oioubl21TaxCategoryID(l.Taxes[0].Ext); s != "" {
-					it.ClassifiedTaxCategory.ID = &IDType{Value: s}
-				}
 			}
 
 			if len(l.Item.Identities) > 0 {
@@ -204,8 +200,10 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 						break
 					}
 
+					s := id.Ext.Get(iso.ExtKeySchemeID).String()
+
 					// Map first identity without extension to BuyersItemIdentification
-					if id.Ext.Get(iso.ExtKeySchemeID).String() == "" {
+					if s == "" {
 						if it.BuyersItemIdentification == nil {
 							it.BuyersItemIdentification = &ItemIdentification{
 								ID: &IDType{
@@ -218,7 +216,6 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 
 					// Map first identity with extension to StandardItemIdentification
 					if it.StandardItemIdentification == nil {
-						s := id.Ext.Get(iso.ExtKeySchemeID).String()
 						it.StandardItemIdentification = &ItemIdentification{
 							ID: &IDType{
 								SchemeID: &s,
@@ -400,8 +397,8 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 				CurrencyID: &ccy,
 			},
 		}
-		if s := ch.Ext.Get(untdid.ExtKeyCharge).String(); s != "" {
-			ac.AllowanceChargeReasonCode = &s
+		if e := ch.Ext.Get(untdid.ExtKeyCharge).String(); e != "" {
+			ac.AllowanceChargeReasonCode = &e
 		}
 		if ch.Reason != "" {
 			ac.AllowanceChargeReason = &ch.Reason
@@ -426,8 +423,8 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 				CurrencyID: &ccy,
 			},
 		}
-		if s := d.Ext.Get(untdid.ExtKeyAllowance).String(); s != "" {
-			ac.AllowanceChargeReasonCode = &s
+		if e := d.Ext.Get(untdid.ExtKeyAllowance).String(); e != "" {
+			ac.AllowanceChargeReasonCode = &e
 		}
 		if d.Reason != "" {
 			ac.AllowanceChargeReason = &d.Reason

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -71,7 +71,7 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 	}
 	if di := docLine.Item; di != nil {
 		goblConvertLineItem(di, line.Item)
-		goblConvertLineItemTaxes(di, line, taxCategoryMap)
+		goblConvertLineItemTaxes(di, line, taxCategoryMap, ctx)
 	}
 
 	notes := make([]*org.Note, 0)
@@ -191,7 +191,7 @@ func goblConvertLineItem(di *Item, item *org.Item) {
 	}
 }
 
-func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[string]*taxCategoryInfo) {
+func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[string]*taxCategoryInfo, ctx Context) {
 	ctc := di.ClassifiedTaxCategory
 	if ctc == nil || ctc.TaxScheme == nil {
 		return
@@ -205,10 +205,11 @@ func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[stri
 	if ctc.ID != nil {
 		line.Taxes[0].Ext = line.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, goblTaxCategoryCode(ctc.ID.Value))
 
-		if ctc.TaxExemptionReasonCode != nil {
+		// OIOUBL carries the exemption reason on the line; other profiles source
+		// it from the document-level TaxTotal subtotal.
+		if ctx.Is(ContextOIOUBL21) && ctc.TaxExemptionReasonCode != nil {
 			line.Taxes[0].Ext = line.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(*ctc.TaxExemptionReasonCode))
 		} else {
-			// Try to get exemption code from TaxTotal
 			key := buildTaxCategoryKey(ctc.TaxScheme.ID.Value, ctc.ID.Value, ctc.Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				line.Taxes[0].Ext = line.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -15,7 +15,7 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-func (ui *Invoice) goblAddLines(out *bill.Invoice) error {
+func (ui *Invoice) goblAddLines(out *bill.Invoice, ctx Context) error {
 	items := ui.InvoiceLines
 	if len(ui.CreditNoteLines) > 0 {
 		items = ui.CreditNoteLines
@@ -26,12 +26,8 @@ func (ui *Invoice) goblAddLines(out *bill.Invoice) error {
 	// Build tax category map from TaxTotal
 	taxCategoryMap := ui.buildTaxCategoryMap()
 
-	// OIOUBL emits MultiplierFactorNumeric as the decimal factor (0.05 for 5%)
-	// rather than the percent number (5) used by other profiles.
-	oioubl := ui.CustomizationID == ContextOIOUBL21.CustomizationID
-
 	for _, docLine := range items {
-		line, err := goblConvertLine(&docLine, taxCategoryMap, oioubl)
+		line, err := goblConvertLine(&docLine, taxCategoryMap, ctx)
 		if err != nil {
 			return err
 		}
@@ -43,7 +39,7 @@ func (ui *Invoice) goblAddLines(out *bill.Invoice) error {
 	return nil
 }
 
-func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategoryInfo, oioubl bool) (*bill.Line, error) {
+func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategoryInfo, ctx Context) (*bill.Line, error) {
 	if docLine.Price == nil {
 		// skip this line
 		return nil, nil
@@ -134,7 +130,7 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 	}
 
 	if docLine.AllowanceCharge != nil {
-		line, err = goblLineCharges(docLine.AllowanceCharge, line, oioubl)
+		line, err = goblLineCharges(docLine.AllowanceCharge, line, ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -296,10 +292,10 @@ func goblIdentity(id *IDType) *org.Identity {
 	return identity
 }
 
-func goblLineCharges(allowances []*AllowanceCharge, line *bill.Line, oioubl bool) (*bill.Line, error) {
+func goblLineCharges(allowances []*AllowanceCharge, line *bill.Line, ctx Context) (*bill.Line, error) {
 	for _, ac := range allowances {
 		if ac.ChargeIndicator {
-			charge, err := goblLineCharge(ac, oioubl)
+			charge, err := goblLineCharge(ac, ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -308,7 +304,7 @@ func goblLineCharges(allowances []*AllowanceCharge, line *bill.Line, oioubl bool
 			}
 			line.Charges = append(line.Charges, charge)
 		} else {
-			discount, err := goblLineDiscount(ac, oioubl)
+			discount, err := goblLineDiscount(ac, ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/test/data/parse/en16931/out/credit-note1.json
+++ b/test/data/parse/en16931/out/credit-note1.json
@@ -4,14 +4,14 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9542c7ed6a2d7bb55ec1198c78cb252a8e1ebe06c9514513a68d3ddf7aaafd38"
+			"val": "9a859176b4b7400632a42a3805b0feada387215cd1a96760c6483ca0aa6aa72e"
 		}
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
 		"$regime": "GB",
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
-		"type": "credit-note",
+		"type": "other",
 		"code": "CN758494",
 		"issue_date": "2005-06-25",
 		"value_date": "2005-06-21",

--- a/test/data/parse/en16931/out/custom-namespace-prefixes.json
+++ b/test/data/parse/en16931/out/custom-namespace-prefixes.json
@@ -4,14 +4,14 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9542c7ed6a2d7bb55ec1198c78cb252a8e1ebe06c9514513a68d3ddf7aaafd38"
+			"val": "9a859176b4b7400632a42a3805b0feada387215cd1a96760c6483ca0aa6aa72e"
 		}
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
 		"$regime": "GB",
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
-		"type": "credit-note",
+		"type": "other",
 		"code": "CN758494",
 		"issue_date": "2005-06-25",
 		"value_date": "2005-06-21",


### PR DESCRIPTION
Addresses review feedback on #73 (behaviour-preserving cleanup).

- Gate the CreditNote root-element type fallback behind ContextOIOUBL21 — the en16931 parse goldens revert to their original `other` (answers the 'why are these docs edited?' comments).
- Revert the speculative, untested timezone handling in date.go.
- Thread Context through the line/charge parse instead of the `oioubl` boolean (reusable for other contexts; behaviour-neutral).
- Gate the line-level TaxExemptionReasonCode precedence to OIOUBL so other profiles keep the document-level source.
- lines.go churn: drop a duplicate assignment, single scheme-id lookup, revert e->s renames.
- DRY the ApplicationResponse comments + correct/flag the UBLVersion note.

Deferred to a separate gobl.dk.oioubl PR + repin (mapper-not-enforcer): payment-terms amount (F-INV134), payment-means 30->31, DK:CVR legal-id fabrication, party endpoint scheme map, AR single-DocumentResponse.