### PR TITLE
Guard the OIOUBL payment-terms amount against a nil payable total

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -120,7 +120,7 @@ func (ui *Invoice) addPayment(inv *bill.Invoice, ctx Context) error {
 	if ctx.Is(ContextOIOUBL21) {
 		applyOIOUBL21PaymentMeans(ui)
 		// F-INV134: the payment terms carry the payable amount in OIOUBL.
-		if ui.PaymentTerms != nil && ui.PaymentTerms.Amount == nil {
+		if ui.PaymentTerms != nil && ui.PaymentTerms.Amount == nil && ui.LegalMonetaryTotal.PayableAmount != nil {
 			ui.PaymentTerms.Amount = &Amount{
 				Value:      ui.LegalMonetaryTotal.PayableAmount.Value,
 				CurrencyID: ui.LegalMonetaryTotal.PayableAmount.CurrencyID,


### PR DESCRIPTION
F-INV134 copies `LegalMonetaryTotal.PayableAmount` into `PaymentTerms.Amount`, but `PayableAmount` is a nilable pointer and was dereferenced unconditionally — a panic when absent. Skip the copy when there's no payable amount.

From the #73 review (mapper-not-enforcer pass): the F-INV134 derivation itself is kept (it fills a required UBL slot from the payable total — structural mapping, gated to OIOUBL); this fixes only the nil-deref. The one genuine fabrication, DK:CVR legal-id (party.go:336), is queued to move into a gobl.dk.oioubl normalizer with the #853 repin.