### PR TITLE
Map the OIOUBL party legal identity instead of fabricating it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
-	github.com/invopop/gobl.dk.oioubl v0.0.0-20260625162428-e48b20ade6c4
+	github.com/invopop/gobl.dk.oioubl v0.0.0-20260625163930-d76ee753d032
 	github.com/invopop/gobl.fr.ctc v0.0.4
 	github.com/invopop/gobl.sa.zatca v0.0.2
 	github.com/invopop/phive v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
-	github.com/invopop/gobl.dk.oioubl v0.0.0-20260625163930-d76ee753d032
+	github.com/invopop/gobl.dk.oioubl v0.0.0-20260626085027-b52a11b0b281
 	github.com/invopop/gobl.fr.ctc v0.0.4
 	github.com/invopop/gobl.sa.zatca v0.0.2
 	github.com/invopop/phive v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
-	github.com/invopop/gobl.dk.oioubl v0.0.0-20260616144006-86071bcc7a52
+	github.com/invopop/gobl.dk.oioubl v0.0.0-20260625162428-e48b20ade6c4
 	github.com/invopop/gobl.fr.ctc v0.0.4
 	github.com/invopop/gobl.sa.zatca v0.0.2
 	github.com/invopop/phive v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267 h1:JESDuqkaOexIBJQ9AQOxaSSbQADO1s+HtRnNsCNWvaA=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267/go.mod h1:EGDHHuPbF8JxRfct0q/s9t7ei2gjkOwjH3SytjB3aS0=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260625163930-d76ee753d032 h1:Mg/D1/8R3bpene+A6K9Kpci01gquHVzlL3GGfULyRnc=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260625163930-d76ee753d032/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260626085027-b52a11b0b281 h1:LQHXIPd46MelMc8wuZAHVF/Gd6tjfawpEm4/39X+CRw=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260626085027-b52a11b0b281/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
 github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
 github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/gobl.sa.zatca v0.0.2 h1:qU2Y0LP+4mjvZkuG1TOUp/Zs0XxRAzkzQFHy3WOVFEU=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267 h1:JESDuqkaOexIBJQ9AQOxaSSbQADO1s+HtRnNsCNWvaA=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267/go.mod h1:EGDHHuPbF8JxRfct0q/s9t7ei2gjkOwjH3SytjB3aS0=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260616144006-86071bcc7a52 h1:mbS8Uyp0h5vy/PBT+UHboslQmatkLu06xGiNoBX8/i4=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260616144006-86071bcc7a52/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260625162428-e48b20ade6c4 h1:0tFlNLj0KuXRxq/Ij2JZ2qRtsybiGVwuRHY5fJNkXc8=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260625162428-e48b20ade6c4/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
 github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
 github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/gobl.sa.zatca v0.0.2 h1:qU2Y0LP+4mjvZkuG1TOUp/Zs0XxRAzkzQFHy3WOVFEU=

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267 h1:JESDuqkaOexIBJQ9AQOxaSSbQADO1s+HtRnNsCNWvaA=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267/go.mod h1:EGDHHuPbF8JxRfct0q/s9t7ei2gjkOwjH3SytjB3aS0=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260625162428-e48b20ade6c4 h1:0tFlNLj0KuXRxq/Ij2JZ2qRtsybiGVwuRHY5fJNkXc8=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260625162428-e48b20ade6c4/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260625163930-d76ee753d032 h1:Mg/D1/8R3bpene+A6K9Kpci01gquHVzlL3GGfULyRnc=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260625163930-d76ee753d032/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
 github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
 github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/gobl.sa.zatca v0.0.2 h1:qU2Y0LP+4mjvZkuG1TOUp/Zs0XxRAzkzQFHy3WOVFEU=

--- a/party.go
+++ b/party.go
@@ -230,7 +230,7 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 		if ep := party.Endpoint(iso6523EndpointScheme); ep != nil {
 			if icd, code, ok := splitISO6523Endpoint(ep.URI); ok {
 				p.EndpointID = &EndpointID{
-					SchemeID: normalizeEndpointScheme(icd),
+					SchemeID: icd,
 					Value:    code,
 				}
 			}
@@ -244,14 +244,18 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 				Value:    ib.Email,
 			}
 		} else if ib.Scheme != "" {
-			scheme := ib.Scheme.String()
-			if ctx.Is(ContextOIOUBL21) {
-				scheme = normalizeEndpointScheme(scheme)
-			}
 			p.EndpointID = &EndpointID{
-				SchemeID: scheme,
+				SchemeID: ib.Scheme.String(),
 				Value:    ib.Code.String(),
 			}
+		}
+	}
+	// An explicit OIOUBL identifier scheme overrides the derived one: the manual
+	// path for a foreign participant whose scheme is not in the Danish derivation
+	// applied by applyOIOUBL21Party. Email endpoints keep their EM scheme.
+	if ctx.Is(ContextOIOUBL21) && p.EndpointID != nil && p.EndpointID.SchemeID != SchemeIDEmail {
+		if s := party.Ext.Get(oioubl21AddressSchemeKey).String(); s != "" {
+			p.EndpointID.SchemeID = s
 		}
 	}
 
@@ -469,15 +473,6 @@ func splitISO6523Endpoint(uri cbc.URI) (string, string, bool) {
 	return icd, code, true
 }
 
-func normalizeEndpointScheme(s string) string {
-	switch strings.ToUpper(s) {
-	case oioubl21SchemeGLN:
-		return icdGLN
-	default:
-		return s
-	}
-}
-
 // oioubl21AddressFormatCode returns an OIOUBL AddressFormatCode (codelist
 // addressformatcode-1.1), required on every address (F-LIB025). The value
 // defaults to StructuredLax, which imposes no mandatory sub-fields and matches
@@ -501,6 +496,9 @@ const (
 	oioubl21AddressFormatKey   cbc.Key = "dk-oioubl-address-format"
 	oioubl21AddressIDKey       cbc.Key = "dk-oioubl-address-id"
 	oioubl21AddressDistrictKey cbc.Key = "dk-oioubl-address-district"
+	// oioubl21AddressSchemeKey overrides the derived EndpointID/PartyIdentification
+	// symbolic scheme (F-LIB179/F-LIB183) for a foreign participant; see newParty.
+	oioubl21AddressSchemeKey cbc.Key = "dk-oioubl-address-scheme"
 
 	oioubl21AddressStructuredLax    = "StructuredLax"
 	oioubl21AddressUnstructured     = "Unstructured"
@@ -707,22 +705,20 @@ func contactName(n *org.Name) string {
 const (
 	oioubl21SchemeDKCVR = oioubl.SchemeDKCVR
 	oioubl21SchemeDKSE  = oioubl.SchemeDKSE
-	oioubl21SchemeGLN   = oioubl.SchemeGLN
 	oioubl21SchemeZZZ   = oioubl.SchemeZZZ
-	icdGLN              = "0088"
-	icdDKCVR            = "0184"
 	icdDKSE             = "0198"
 )
 
-// oioubl21EndpointSchemes maps ISO 6523 ICDs / Peppol EAS codes to the
-// symbolic OIOUBL EndpointID schemeID codelist (F-LIB179) — numeric scheme
-// IDs are rejected on the NemHandel wire. Only codes with an unambiguous
-// symbolic counterpart are mapped; anything else passes through numerically.
+// oioubl21EndpointSchemes maps the Danish ISO 6523 ICDs to their symbolic
+// OIOUBL EndpointID schemeID (F-LIB179) — numeric scheme IDs are rejected on
+// the NemHandel wire. Danish ICDs are derived; a foreign participant supplies
+// its scheme via the dk-oioubl-address-scheme extension (see newParty), which
+// already passes through here. An unmapped value passes through unchanged.
 var oioubl21EndpointSchemes = oioubl.EndpointSchemes
 
 // oioubl21EndpointICDs restores wire EndpointIDs to ISO 6523 endpoints on
-// parse. Inverse of oioubl21EndpointSchemes; symbolic schemes fed by several
-// codes restore to the lowest (canonical, non-legacy) one.
+// parse. Inverse of oioubl21EndpointSchemes (the Danish schemes); a foreign
+// symbolic scheme has no ICD here and is restored as an inbox instead.
 var oioubl21EndpointICDs = func() map[string]string {
 	m := make(map[string]string, len(oioubl21EndpointSchemes))
 	for icd, scheme := range oioubl21EndpointSchemes {
@@ -741,10 +737,9 @@ func applyOIOUBL21Party(p *Party) {
 		return
 	}
 	if p.EndpointID != nil {
-		if mapped, ok := oioubl21EndpointSchemes[p.EndpointID.SchemeID]; ok {
-			p.EndpointID.SchemeID = mapped
-		}
-		// OIOUBL CVR endpoints must carry the DK-prefixed form (F-LIB180).
+		// The schemeID is the dk-oioubl-address-scheme extension value (set in
+		// newParty), emitted 1:1. OIOUBL CVR endpoints must carry the DK-prefixed
+		// form (F-LIB180).
 		if p.EndpointID.SchemeID == oioubl21SchemeDKCVR && !strings.HasPrefix(p.EndpointID.Value, "DK") {
 			p.EndpointID.Value = "DK" + p.EndpointID.Value
 		}

--- a/party.go
+++ b/party.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	oioubl "github.com/invopop/gobl.dk.oioubl/addon"
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
@@ -701,84 +702,23 @@ func contactName(n *org.Name) string {
 }
 
 // OIOUBL symbolic EndpointID schemes (F-LIB179) and the ISO 6523 ICDs they
-// correspond to.
+// correspond to. The symbolic schemes are defined by the dk-oioubl addon (the
+// single source of truth, shared with the ICD->scheme map below).
 const (
-	oioubl21SchemeDKCVR = "DK:CVR"
-	oioubl21SchemeDKSE  = "DK:SE"
-	oioubl21SchemeGLN   = "GLN"
-	// oioubl21SchemeZZZ is the OIOUBL "other" company-ID scheme, the only
-	// PartyTaxScheme/PartyLegalEntity scheme valid for a non-Danish identifier
-	// (F-LIB195 allows {DK:SE, ZZZ}; F-LIB189 allows {DK:CVR, DK:CPR, ZZZ}).
-	oioubl21SchemeZZZ = "ZZZ"
-	icdGLN            = "0088"
-	icdDKCVR          = "0184"
-	icdDKSE           = "0198"
+	oioubl21SchemeDKCVR = oioubl.SchemeDKCVR
+	oioubl21SchemeDKSE  = oioubl.SchemeDKSE
+	oioubl21SchemeGLN   = oioubl.SchemeGLN
+	oioubl21SchemeZZZ   = oioubl.SchemeZZZ
+	icdGLN              = "0088"
+	icdDKCVR            = "0184"
+	icdDKSE             = "0198"
 )
 
 // oioubl21EndpointSchemes maps ISO 6523 ICDs / Peppol EAS codes to the
 // symbolic OIOUBL EndpointID schemeID codelist (F-LIB179) — numeric scheme
 // IDs are rejected on the NemHandel wire. Only codes with an unambiguous
 // symbolic counterpart are mapped; anything else passes through numerically.
-var oioubl21EndpointSchemes = map[string]string{
-	"0007":   "SE:ORGNR",
-	"0009":   "FR:SIRET",
-	"0037":   "FI:OVT",
-	"0060":   "DUNS",
-	icdGLN:   oioubl21SchemeGLN,
-	"0096":   "DK:P",
-	icdDKCVR: oioubl21SchemeDKCVR,
-	"0192":   "NO:ORGNR",
-	"0196":   "IS:KT",
-	icdDKSE:  oioubl21SchemeDKSE,
-	"0212":   "FI:ORGNR",
-	"0213":   "FI:VAT",
-	"9902":   oioubl21SchemeDKCVR, // legacy EAS for DK:CVR
-	"9906":   "IT:VAT",
-	"9907":   "IT:CF",
-	"9909":   "NO:VAT",
-	"9910":   "HU:VAT",
-	"9912":   "EU:VAT",
-	"9913":   "EU:REID",
-	"9914":   "AT:VAT",
-	"9915":   "AT:GOV",
-	"9917":   "IS:KT", // legacy EAS for IS:KT
-	"9918":   "IBAN",
-	"9919":   "AT:KUR",
-	"9920":   "ES:VAT",
-	"9922":   "AD:VAT",
-	"9923":   "AL:VAT",
-	"9924":   "BA:VAT",
-	"9925":   "BE:VAT",
-	"9926":   "BG:VAT",
-	"9927":   "CH:VAT",
-	"9928":   "CY:VAT",
-	"9929":   "CZ:VAT",
-	"9930":   "DE:VAT",
-	"9931":   "EE:VAT",
-	"9932":   "GB:VAT",
-	"9933":   "GR:VAT",
-	"9934":   "HR:VAT",
-	"9935":   "IE:VAT",
-	"9936":   "LI:VAT",
-	"9937":   "LT:VAT",
-	"9938":   "LU:VAT",
-	"9939":   "LV:VAT",
-	"9940":   "MC:VAT",
-	"9941":   "ME:VAT",
-	"9942":   "MK:VAT",
-	"9943":   "MT:VAT",
-	"9944":   "NL:VAT",
-	"9945":   "PL:VAT",
-	"9946":   "PT:VAT",
-	"9947":   "RO:VAT",
-	"9948":   "RS:VAT",
-	"9949":   "SI:VAT",
-	"9950":   "SK:VAT",
-	"9951":   "SM:VAT",
-	"9952":   "TR:VAT",
-	"9953":   "VA:VAT",
-	"9955":   "SE:VAT",
-}
+var oioubl21EndpointSchemes = oioubl.EndpointSchemes
 
 // oioubl21EndpointICDs restores wire EndpointIDs to ISO 6523 endpoints on
 // parse. Inverse of oioubl21EndpointSchemes; symbolic schemes fed by several

--- a/party.go
+++ b/party.go
@@ -330,16 +330,6 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 		}
 	}
 
-	// Fabricating a DK:CVR (0184) PartyLegalEntity/CompanyID from the tax ID is
-	// OIOUBL-specific; under other contexts the legal identity should come from
-	// real data, not the tax number.
-	if ctx.Is(ContextOIOUBL21) && p.PartyLegalEntity != nil && p.PartyLegalEntity.CompanyID == nil && party.TaxID != nil && string(party.TaxID.Country) == "DK" {
-		s := icdDKCVR
-		p.PartyLegalEntity.CompanyID = &IDType{
-			SchemeID: &s,
-			Value:    party.TaxID.Code.String(),
-		}
-	}
 	return p
 }
 

--- a/party_parse.go
+++ b/party_parse.go
@@ -106,7 +106,7 @@ func goblParty(party *Party, o *options) *org.Party {
 		}
 	}
 
-	handleLegalEntityIdentity(party, p, o)
+	handleLegalEntityIdentity(party, p)
 	handlePartyTaxSchemes(party, p, o)
 	handlePartyIdentifications(party, p, o)
 
@@ -235,17 +235,10 @@ func applyOIOUBL21AddressFormatParse(address *PostalAddress, p *org.Party) {
 	p.Ext = tax.ExtensionsOf(exts)
 }
 
-func handleLegalEntityIdentity(party *Party, p *org.Party, o *options) {
+func handleLegalEntityIdentity(party *Party, p *org.Party) {
 	if party.PartyLegalEntity == nil || party.PartyLegalEntity.CompanyID == nil {
 		return
 	}
-	// Under OIOUBL the PartyLegalEntity/CompanyID is fabricated from the DK tax ID
-	// (see newParty), so don't restore it as a separate legal identity the source
-	// document never carried.
-	if o.context.Is(ContextOIOUBL21) && oioublFabricatedLegalID(party) {
-		return
-	}
-
 	if p.Identities == nil {
 		p.Identities = make([]*org.Identity, 0)
 	}
@@ -259,24 +252,6 @@ func handleLegalEntityIdentity(party *Party, p *org.Party, o *options) {
 		})
 	}
 	p.Identities = append(p.Identities, identity)
-}
-
-// oioublFabricatedLegalID reports whether the PartyLegalEntity/CompanyID is the
-// DK:CVR value the converter fabricates from the DK tax ID — a DK:CVR scheme whose
-// CVR matches a PartyTaxScheme CompanyID. Such an id duplicates the tax identity
-// and is not a distinct legal identity.
-func oioublFabricatedLegalID(party *Party) bool {
-	le := party.PartyLegalEntity.CompanyID
-	if le.SchemeID == nil || *le.SchemeID != oioubl21SchemeDKCVR {
-		return false
-	}
-	cvr := strings.TrimPrefix(le.Value, "DK")
-	for _, pts := range party.PartyTaxScheme {
-		if pts.CompanyID != nil && strings.TrimPrefix(pts.CompanyID.Value, "DK") == cvr {
-			return true
-		}
-	}
-	return false
 }
 
 func handlePartyTaxSchemes(party *Party, p *org.Party, o *options) {

--- a/test/data/convert/oioubl21/foreign-party.json
+++ b/test/data/convert/oioubl21/foreign-party.json
@@ -57,6 +57,9 @@
 		},
 		"customer": {
 			"name": "Beispiel GmbH",
+			"ext": {
+				"dk-oioubl-address-scheme": "DE:VAT"
+			},
 			"tax_id": {
 				"country": "DE",
 				"code": "282741168"

--- a/test/data/parse/oioubl21-reminder/out/reminder-basic.json
+++ b/test/data/parse/oioubl21-reminder/out/reminder-basic.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "96ed0c45da7676de06295553ff1692510c72d56128858ea489046dc1d7b7566c"
+			"val": "2ad2e98e58cea2169620b7067569967b2fb4648476b15afe44f662c15292fded"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -53,7 +53,10 @@
 					"code": "1000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"customer": {
 			"name": "Kunde ApS",
@@ -90,7 +93,10 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21-reminder/out/reminder-basic.json
+++ b/test/data/parse/oioubl21-reminder/out/reminder-basic.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "53165a08fbbc237e8c19440d3e7ae9580a95ef23299db368a23c41c0672b7c53"
+			"val": "96ed0c45da7676de06295553ff1692510c72d56128858ea489046dc1d7b7566c"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -31,6 +31,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -52,6 +61,15 @@
 				"country": "DK",
 				"code": "88146328"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK88146328",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21-reminder/out/reminder-fik.json
+++ b/test/data/parse/oioubl21-reminder/out/reminder-fik.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "d9abb345b55f74477bae9c2f7348c2e15850dedaa0c5a995fb8c3b3ed3a4b0fe"
+			"val": "0010ccec3efdd536acabaaebb6831dd1191b8fa7722173345231c60920c549e7"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -31,6 +31,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -52,6 +61,15 @@
 				"country": "DK",
 				"code": "88146328"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK88146328",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21-reminder/out/reminder-fik.json
+++ b/test/data/parse/oioubl21-reminder/out/reminder-fik.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0010ccec3efdd536acabaaebb6831dd1191b8fa7722173345231c60920c549e7"
+			"val": "8fbe51c4a63e7c9ca07d97a08b88ad9633fb415834bd8500ac7b084a918f3c5e"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -53,7 +53,10 @@
 					"code": "1000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"customer": {
 			"name": "Kunde ApS",
@@ -90,7 +93,10 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21-response/out/invoice-accepted.json
+++ b/test/data/parse/oioubl21-response/out/invoice-accepted.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "c4a111920820102911bf4e371ab5c088e86d5c2cdca9275d881c0cb0b9904960"
+			"val": "b83c590a64c73eec4b3070a7242a8c06b1382df087829fa50de6b8d8c6fb498c"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -50,7 +50,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -83,7 +84,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21-response/out/invoice-accepted.json
+++ b/test/data/parse/oioubl21-response/out/invoice-accepted.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fe1a18c44670f263a67c7116055b4c3697c30421d077da4ce79426dd995a08ab"
+			"val": "c4a111920820102911bf4e371ab5c088e86d5c2cdca9275d881c0cb0b9904960"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -26,6 +26,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -50,6 +59,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:76543216"

--- a/test/data/parse/oioubl21-response/out/invoice-acknowledged.json
+++ b/test/data/parse/oioubl21-response/out/invoice-acknowledged.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6a530cdb29ce9b3e0fe2d798777c96063396429211a0c610ed68ae08fa31392a"
+			"val": "47dee8c2f8c7a171e00b205706390fcdc635927eaeb1dae39995a4a190bca423"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -50,7 +50,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -83,7 +84,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21-response/out/invoice-acknowledged.json
+++ b/test/data/parse/oioubl21-response/out/invoice-acknowledged.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "05bfa0f8cd86d824e1aea6ba4dcd3f68d518a868444951690e3dd755d3d671d7"
+			"val": "6a530cdb29ce9b3e0fe2d798777c96063396429211a0c610ed68ae08fa31392a"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -26,6 +26,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -50,6 +59,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:76543216"

--- a/test/data/parse/oioubl21-response/out/invoice-errored.json
+++ b/test/data/parse/oioubl21-response/out/invoice-errored.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "643ec51f0a49082f661570e89db23d78646f0b64ed48c9c83040df6da595b99e"
+			"val": "58733cccebd0c3b67fe8d1556b9c206560577ae8fcc38ed5d8facb53cb51fd03"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -26,6 +26,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -50,6 +59,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:76543216"

--- a/test/data/parse/oioubl21-response/out/invoice-errored.json
+++ b/test/data/parse/oioubl21-response/out/invoice-errored.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "58733cccebd0c3b67fe8d1556b9c206560577ae8fcc38ed5d8facb53cb51fd03"
+			"val": "0e526e0eb8bc3a676414aa8451822a809b02fb483fabffb85acbfc9ba0b0cd60"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -50,7 +50,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -83,7 +84,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21-response/out/invoice-rejected.json
+++ b/test/data/parse/oioubl21-response/out/invoice-rejected.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bd4b7dba439d400034f899c36911cc8399e07fca9c11e3693e309e7de458a5be"
+			"val": "77ad5eb6caab2af0faa0bc6515838d07a7ee0935ecc4a7ac2cf0b95c27d46849"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -50,7 +50,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -83,7 +84,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21-response/out/invoice-rejected.json
+++ b/test/data/parse/oioubl21-response/out/invoice-rejected.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "ee31530c5bec0e5abf8fe78b81f75d8b7814ddee0ec36188ddd9d83dddc96cfe"
+			"val": "bd4b7dba439d400034f899c36911cc8399e07fca9c11e3693e309e7de458a5be"
 		},
 		"from": "iso6523-actorid-upis::0184:76543216",
 		"to": "iso6523-actorid-upis::0184:12345674"
@@ -26,6 +26,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -50,6 +59,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:76543216"

--- a/test/data/parse/oioubl21/out/address-structured-dk.json
+++ b/test/data/parse/oioubl21/out/address-structured-dk.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e24576365f58e561d8799d66c8076efacc389c76560bbc13588d5e98b6736361"
+			"val": "32a1171ad54a7b67e9d68ea5a502aae8873f68558f8dc2df83a96683c46527c8"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -57,7 +57,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -100,7 +101,10 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/address-structured-dk.json
+++ b/test/data/parse/oioubl21/out/address-structured-dk.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "83b62511a8d460fa4600eea51aecfef9f0d59501226da387121fcc1e7f8dfd9f"
+			"val": "e24576365f58e561d8799d66c8076efacc389c76560bbc13588d5e98b6736361"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -57,6 +66,15 @@
 				"country": "DK",
 				"code": "88146328"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK88146328",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/address-structured-id.json
+++ b/test/data/parse/oioubl21/out/address-structured-id.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1aa95cd41384bbbb081a531a20086dab2c7f855a609db01d0619c8a2f55447e5"
+			"val": "98fa2403982169a4959bddd6ca99138956cecc1f0f3ee1ad812048f9586dde62"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -52,7 +52,8 @@
 			],
 			"ext": {
 				"dk-oioubl-address-format": "StructuredID",
-				"dk-oioubl-address-id": "5798009811578"
+				"dk-oioubl-address-id": "5798009811578",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -95,7 +96,10 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/address-structured-id.json
+++ b/test/data/parse/oioubl21/out/address-structured-id.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "d0d1edd0e1ea0b67b0d098673cdf113244d369d62309da9a8e439fcee4688cb7"
+			"val": "1aa95cd41384bbbb081a531a20086dab2c7f855a609db01d0619c8a2f55447e5"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -52,6 +61,15 @@
 				"country": "DK",
 				"code": "88146328"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK88146328",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/address-structured-region.json
+++ b/test/data/parse/oioubl21/out/address-structured-region.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "d6ac2c7a2b34e07688937298982aa9a85040b8a78f2b36abefdd5daa8236ac57"
+			"val": "bf6d1d2a9cad73d5e06c9852af9b5ced024a69bfb0c44cde844ffc6ffbf4c2a1"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -55,6 +64,15 @@
 				"country": "DK",
 				"code": "88146328"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK88146328",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/address-structured-region.json
+++ b/test/data/parse/oioubl21/out/address-structured-region.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bf6d1d2a9cad73d5e06c9852af9b5ced024a69bfb0c44cde844ffc6ffbf4c2a1"
+			"val": "7af299c3542d2a182bde08ee1f12647ad11a7b748106a65535ce0461d3ad100c"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -55,7 +55,8 @@
 			],
 			"ext": {
 				"dk-oioubl-address-district": "Nørrebro",
-				"dk-oioubl-address-format": "StructuredRegion"
+				"dk-oioubl-address-format": "StructuredRegion",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -98,7 +99,10 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/address-unstructured.json
+++ b/test/data/parse/oioubl21/out/address-unstructured.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "08d8138226c6a5592e5131ba9c2207e984c7bae87c623d81f43efe7cd1d38270"
+			"val": "ec08e1bedfb9cb538cd967c4654bdb9a6292571bc13edce1ee95de08bd63ac69"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:12345674"
@@ -54,6 +63,15 @@
 				"country": "DK",
 				"code": "88146328"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK88146328",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/address-unstructured.json
+++ b/test/data/parse/oioubl21/out/address-unstructured.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "ec08e1bedfb9cb538cd967c4654bdb9a6292571bc13edce1ee95de08bd63ac69"
+			"val": "03d6048cdd98ca16eb6f12fdef276b518fef6d06795b3cf07d3a28444bfbb093"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:88146328"
@@ -54,7 +54,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "Unstructured"
+				"dk-oioubl-address-format": "Unstructured",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -97,7 +98,10 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/credit-note-minimal.json
+++ b/test/data/parse/oioubl21/out/credit-note-minimal.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0a91bc01b51f92fb2ad8c666ca34ec8d363784b84fbbc83fc14cefdb535870de"
+			"val": "26546e5136f10953edd90033a9c53c38af319bbb33a2d8b7a7efdbd2da603299"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -75,7 +75,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"customer": {
@@ -125,7 +126,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/credit-note-minimal.json
+++ b/test/data/parse/oioubl21/out/credit-note-minimal.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "99c832a6afb464016ed921767b13fe548801b2419ac0a076775623bb9efecabb"
+			"val": "0a91bc01b51f92fb2ad8c666ca34ec8d363784b84fbbc83fc14cefdb535870de"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -46,6 +46,15 @@
 				"country": "DK",
 				"code": "37990485"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK37990485",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0088:5790000436101"
@@ -75,6 +84,15 @@
 				"country": "DK",
 				"code": "47458714"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK47458714",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/credit-note-no-typecode.json
+++ b/test/data/parse/oioubl21/out/credit-note-no-typecode.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0a91bc01b51f92fb2ad8c666ca34ec8d363784b84fbbc83fc14cefdb535870de"
+			"val": "26546e5136f10953edd90033a9c53c38af319bbb33a2d8b7a7efdbd2da603299"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -75,7 +75,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"customer": {
@@ -125,7 +126,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/credit-note-no-typecode.json
+++ b/test/data/parse/oioubl21/out/credit-note-no-typecode.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "99c832a6afb464016ed921767b13fe548801b2419ac0a076775623bb9efecabb"
+			"val": "0a91bc01b51f92fb2ad8c666ca34ec8d363784b84fbbc83fc14cefdb535870de"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -46,6 +46,15 @@
 				"country": "DK",
 				"code": "37990485"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK37990485",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0088:5790000436101"
@@ -75,6 +84,15 @@
 				"country": "DK",
 				"code": "47458714"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK47458714",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/credit-note.json
+++ b/test/data/parse/oioubl21/out/credit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "31811fac602d777ca39dc4f80e4c33c777221bcaf05554b8c9a88dec043a9967"
+			"val": "00688f0bb28162be411c584b64adedb749ae5e777d1e5cd6cd482d2dd26363ae"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -70,7 +70,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -115,7 +116,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/credit-note.json
+++ b/test/data/parse/oioubl21/out/credit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bc8774dd5ad033b3e281b6e0ee425492b2341fb6c9e5ff1140688dd97c43ac45"
+			"val": "31811fac602d777ca39dc4f80e4c33c777221bcaf05554b8c9a88dec043a9967"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -39,6 +39,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -70,6 +79,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/direct-debit.json
+++ b/test/data/parse/oioubl21/out/direct-debit.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "874d67da1aab47a9cded71a48ad796d2bf91d72a2fffa0b7262dfa4d3fb4e775"
+			"val": "ca6fec447acc9cdf370e3d7cb03209f4c1198bf67392ef1840dbbc83bd1facbf"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/direct-debit.json
+++ b/test/data/parse/oioubl21/out/direct-debit.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "33ce595e4ee48a8fba51c82d2fddcd2ab52e05e931bd3f7952fe62d417c1f5ca"
+			"val": "874d67da1aab47a9cded71a48ad796d2bf91d72a2fffa0b7262dfa4d3fb4e775"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/doc-allowance.json
+++ b/test/data/parse/oioubl21/out/doc-allowance.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "b0a34f5d214785dd8096c71c491b343a242a9d8e97aca27e65d77381b29403b6"
+			"val": "e50079b3dc1562e55d99ede3eaa7409cb0ae859cf22193af3b02c3d4e0864157"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/doc-allowance.json
+++ b/test/data/parse/oioubl21/out/doc-allowance.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e50079b3dc1562e55d99ede3eaa7409cb0ae859cf22193af3b02c3d4e0864157"
+			"val": "714610a13a1a8583b2f6d6667ad58145777792307998f83e53d0342ffc274c6e"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/exempt.json
+++ b/test/data/parse/oioubl21/out/exempt.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "20fed20a3f0aeccf2f420fb4e1d853258b5c7f27b66dfbac933cbb46d13b8091"
+			"val": "a8ac23798fecb062323a16726e88abf0a89acbce418625ae1dc1dc4cdf37d405"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/exempt.json
+++ b/test/data/parse/oioubl21/out/exempt.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a8ac23798fecb062323a16726e88abf0a89acbce418625ae1dc1dc4cdf37d405"
+			"val": "9f8a367713a36485af26792e758ef668b4b8aaa059fa132cdf8b548e14f87a44"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/fik-71.json
+++ b/test/data/parse/oioubl21/out/fik-71.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "42a6bad8577b3ed7c8b952d8f5c9bb6b1aeb00fd8a0dab80c844d313006d9890"
+			"val": "0d54b72d6bc434e9bcb1014d7fc08e1fcc68867fd7107e7452607434f7ddadc4"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/fik-71.json
+++ b/test/data/parse/oioubl21/out/fik-71.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "66f3d7020960b459b818c93f07e95612e95c94102345912ba5eaee140fcf34b1"
+			"val": "42a6bad8577b3ed7c8b952d8f5c9bb6b1aeb00fd8a0dab80c844d313006d9890"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/fik.json
+++ b/test/data/parse/oioubl21/out/fik.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a138b6db9897823f16e3c115848e1c9ecd1c2f3b7aa81f9da8aef3768061d160"
+			"val": "94c5184031788215d6f51ba8817b8fd8b09cdf3ef6d1a3cbcbeb84b701999f30"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/fik.json
+++ b/test/data/parse/oioubl21/out/fik.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "8c55f110477ca39546f72256b827c37cb6a04fc09772d5af334525494ac933ef"
+			"val": "a138b6db9897823f16e3c115848e1c9ecd1c2f3b7aa81f9da8aef3768061d160"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/foreign-party.json
+++ b/test/data/parse/oioubl21/out/foreign-party.json
@@ -4,10 +4,9 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9de4c4bd8372b53511e1286d9aad8ee8e7dc34d97092a8a3d7f23ef65162ad98"
+			"val": "2460de8b6191db8d26e79432229be53d00ee3d69f73776bd2fa1c596c896192c"
 		},
-		"from": "iso6523-actorid-upis::0184:12345674",
-		"to": "iso6523-actorid-upis::9930:DE282741168"
+		"from": "iso6523-actorid-upis::0184:12345674"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -62,7 +61,10 @@
 					"code": "2100",
 					"country": "DK"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"customer": {
 			"name": "Beispiel GmbH",
@@ -91,9 +93,10 @@
 					]
 				}
 			],
-			"endpoints": [
+			"inboxes": [
 				{
-					"uri": "iso6523-actorid-upis::9930:DE282741168"
+					"scheme": "DE:VAT",
+					"code": "DE282741168"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/foreign-party.json
+++ b/test/data/parse/oioubl21/out/foreign-party.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "f561412ae92942d70835b9d88bac0b3bb6dc49f5ebd5e00906490284483e0d9f"
+			"val": "9de4c4bd8372b53511e1286d9aad8ee8e7dc34d97092a8a3d7f23ef65162ad98"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::9930:DE282741168"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/fractional-quantity.json
+++ b/test/data/parse/oioubl21/out/fractional-quantity.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "8fd43a1cb3b52e6a2631da8e56f083b92ef9c5a0559dfde83fde7a3f05f594df"
+			"val": "515372bb2a6947b7b972228df1636147624fa76bc061c24fa498372ff6476aa5"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/fractional-quantity.json
+++ b/test/data/parse/oioubl21/out/fractional-quantity.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "5516bb08140d3ab7193b002f4696cf1aaf9b70f418a40c902b8ebf4b62fc37d9"
+			"val": "8fd43a1cb3b52e6a2631da8e56f083b92ef9c5a0559dfde83fde7a3f05f594df"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/giro-01-ref.json
+++ b/test/data/parse/oioubl21/out/giro-01-ref.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7bc915a078ff41a978d858e6d137d3c7349a053b1ecb147fd99cfa676e4b4d8a"
+			"val": "85dc9b13713de92a918d3a0d50edb88ad92f8462d86d3a0e7019c07e7aed25b0"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/giro-01-ref.json
+++ b/test/data/parse/oioubl21/out/giro-01-ref.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "85dc9b13713de92a918d3a0d50edb88ad92f8462d86d3a0e7019c07e7aed25b0"
+			"val": "f7ed4c8c5f5faa6da3be13f32c6ff2bccab863e7cb3a09fb4fe5cf27c6c377f7"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/giro-04.json
+++ b/test/data/parse/oioubl21/out/giro-04.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "d003d4640d13d1659540b67ce0fa8866cdcb0bc58229591d5aee9f6dcf0e4ff9"
+			"val": "e7f1b81278faecbb1bbf38be4c1a875cf7d8a1fe365d3dae0c31131b3f3ba0ec"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/giro-04.json
+++ b/test/data/parse/oioubl21/out/giro-04.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "093e0ff8d2617c9857bf45b5c5e77f556ec014eefa9daa9c1e810a842c8c7ff5"
+			"val": "d003d4640d13d1659540b67ce0fa8866cdcb0bc58229591d5aee9f6dcf0e4ff9"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/happy-path.json
+++ b/test/data/parse/oioubl21/out/happy-path.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "dea3542cfeb08242ecfd52b3112d8d2911fab328339961b27a4c3b38a53757c2"
+			"val": "cf525bac4bb891a8721e8611836526324b588a9ecddcf82ec0f119457f465825"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -69,6 +78,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/happy-path.json
+++ b/test/data/parse/oioubl21/out/happy-path.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "cf525bac4bb891a8721e8611836526324b588a9ecddcf82ec0f119457f465825"
+			"val": "a596b6f0750febc3cc34bdd6694bc167a74245608e8989a5a1f637ef49eb434f"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -69,7 +69,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -119,7 +120,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/invoice-bare.json
+++ b/test/data/parse/oioubl21/out/invoice-bare.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "70b0595ac8aa4381a7eb74a1bfaf8911df87c92025b2c2e908f237bc069284b8"
+			"val": "ebb0ac00a382d7e9dc7fb7b04c1c1241b13a2435bb5ab18eaca8996cbbe3a860"
 		},
 		"from": "iso6523-actorid-upis::0184:37990485",
 		"to": "iso6523-actorid-upis::0184:47458714"
@@ -57,7 +57,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -102,7 +103,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/invoice-bare.json
+++ b/test/data/parse/oioubl21/out/invoice-bare.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6c0f1588bb104af7ed630bf90905eb11a80e5c1a7b15c083155d70f2a2036b8c"
+			"val": "70b0595ac8aa4381a7eb74a1bfaf8911df87c92025b2c2e908f237bc069284b8"
 		},
 		"from": "iso6523-actorid-upis::0184:37990485",
 		"to": "iso6523-actorid-upis::0184:47458714"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "37990485"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK37990485",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0184:37990485"
@@ -57,6 +66,15 @@
 				"country": "DK",
 				"code": "47458714"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK47458714",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/invoice-minimal.json
+++ b/test/data/parse/oioubl21/out/invoice-minimal.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "32ec0ace710c80517a93deb818e839053182cc09d996f9746bad3da30d817050"
+			"val": "6d466dcb6a66bc7d739e35f56a3f99a89dcc39c18344cc8a99d60c16ffcf2961"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -40,6 +40,15 @@
 				"country": "DK",
 				"code": "37990485"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK37990485",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": null,
@@ -79,6 +88,15 @@
 				"country": "DK",
 				"code": "47458714"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK47458714",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": null,

--- a/test/data/parse/oioubl21/out/invoice-minimal.json
+++ b/test/data/parse/oioubl21/out/invoice-minimal.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6d466dcb6a66bc7d739e35f56a3f99a89dcc39c18344cc8a99d60c16ffcf2961"
+			"val": "03e1eca7b4a595cea9307a2036844672f64d4ebea6fea97d755f84b151eaa3d0"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -79,7 +79,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"customer": {
@@ -127,7 +128,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/line-discount.json
+++ b/test/data/parse/oioubl21/out/line-discount.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "40e65f38e6ae53ea28a0f17fe7d06e4a3a7050f18e73c85b555bd1a8fbcfd64d"
+			"val": "4af5994c5b63de6101b99c17a8b27b8c96b9db7218e73a49ecd0870a36289685"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/line-discount.json
+++ b/test/data/parse/oioubl21/out/line-discount.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "990a2f650721ec176612cf95d2d94d1b358630597b8f08931f65268e7fcad950"
+			"val": "40e65f38e6ae53ea28a0f17fe7d06e4a3a7050f18e73c85b555bd1a8fbcfd64d"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/mixed-allowance-category.json
+++ b/test/data/parse/oioubl21/out/mixed-allowance-category.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "12870fa275603a1849fcc0b4e20d601b555b27c28d78103cc700198a0a44c6c0"
+			"val": "9c937f0123460e7bea152f4c844e77ccd97fa3d1fd06875782686669fed0310c"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -69,7 +69,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -119,7 +120,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/mixed-allowance-category.json
+++ b/test/data/parse/oioubl21/out/mixed-allowance-category.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2e6031f86ebb70b7369bff24e4eb9017f917db899807d09fecfcaab540afa860"
+			"val": "12870fa275603a1849fcc0b4e20d601b555b27c28d78103cc700198a0a44c6c0"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -69,6 +78,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/mixed-categories.json
+++ b/test/data/parse/oioubl21/out/mixed-categories.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "651f57c26f5eb22640131a8e42c30da7eba5c4e7d4d4cfa6fe6d7745f41bf8a6"
+			"val": "7212712346258fcf49a1b1163597fcc3781879555884095e6754358e79e722a6"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -69,6 +78,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/mixed-categories.json
+++ b/test/data/parse/oioubl21/out/mixed-categories.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7212712346258fcf49a1b1163597fcc3781879555884095e6754358e79e722a6"
+			"val": "40ea20dead06359572a04513dadbfa59450f60d560d8f5644a734145e0a163b3"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -69,7 +69,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -119,7 +120,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/pobox-contact.json
+++ b/test/data/parse/oioubl21/out/pobox-contact.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "941a571b71be3b95615492aaa4313e8edd1d758c37dc0889ac632983a6099a2f"
+			"val": "6e165bbc8fdb9fc21e78c3d089e3162fee139c0f4981922a776e09bf27b33940"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -74,6 +83,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/pobox-contact.json
+++ b/test/data/parse/oioubl21/out/pobox-contact.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6e165bbc8fdb9fc21e78c3d089e3162fee139c0f4981922a776e09bf27b33940"
+			"val": "a553d2e3b02db8618d7f7d6c3810344fbebfc870d68d7524653234329fef6ea3"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -74,7 +74,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -124,7 +125,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/prepayment.json
+++ b/test/data/parse/oioubl21/out/prepayment.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "25f2c73b56be1730326b8453fe2221a36ec5554ca098ad1134bb848635f1e4e9"
+			"val": "375ea3ef63a8f5ca4f00b9b3767fa6d7b2f9bf4db3046e4ce39dec6032d0f002"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -69,7 +69,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -114,7 +115,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/prepayment.json
+++ b/test/data/parse/oioubl21/out/prepayment.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "ab26f709c40eda19c8eb6b00a53112b37edb506858dc6ec7f8c44cd4dd25d600"
+			"val": "25f2c73b56be1730326b8453fe2221a36ec5554ca098ad1134bb848635f1e4e9"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -69,6 +78,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/reverse-charge.json
+++ b/test/data/parse/oioubl21/out/reverse-charge.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a3f0f83c210ade832c4671a7760a7a99b4eaa3ef7756e2135900f44258b760bc"
+			"val": "fe0a3613bcd1672fcbc8406323df4cc85b1306ebe6db79ed81a0f8f900b6431a"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/reverse-charge.json
+++ b/test/data/parse/oioubl21/out/reverse-charge.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fe0a3613bcd1672fcbc8406323df4cc85b1306ebe6db79ed81a0f8f900b6431a"
+			"val": "5d00967754b131b058aa293c2219fcd9c860714875798bf4916f2a69c5966c6e"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/sepa-credit-transfer.json
+++ b/test/data/parse/oioubl21/out/sepa-credit-transfer.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "4630e6008e565523b86edaa632bfb4c5c20ea390faa6f94e70b5cb70454c0594"
+			"val": "457cf10efac93cc3fe3d374b397bd4259ef7dfb8ad96b8b273cf4887a664a4c4"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -66,6 +75,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/sepa-credit-transfer.json
+++ b/test/data/parse/oioubl21/out/sepa-credit-transfer.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "457cf10efac93cc3fe3d374b397bd4259ef7dfb8ad96b8b273cf4887a664a4c4"
+			"val": "89c77ee2f3c6a926ab5ee7ea2782c205df24a69b673eefd59a7a3b9fd0c2b034"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -67,7 +67,10 @@
 				{
 					"addr": "billing@eksempel-software.dk"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"customer": {
 			"name": "Modtager Handel A/S",
@@ -114,7 +117,10 @@
 				{
 					"addr": "ap@modtager-handel.dk"
 				}
-			]
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/unstructured-address.json
+++ b/test/data/parse/oioubl21/out/unstructured-address.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "646ad8827d9ebe715643bbfb15425d264e0280ef13e34fd5a46954fbcad4314d"
+			"val": "74129066caea716ddda03387dd6f74e120c0ed60845043dcc22c30e204f2ffaa"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -79,7 +79,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "Unstructured"
+				"dk-oioubl-address-format": "Unstructured",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"customer": {
@@ -127,7 +128,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "GLN"
 			}
 		},
 		"lines": [

--- a/test/data/parse/oioubl21/out/unstructured-address.json
+++ b/test/data/parse/oioubl21/out/unstructured-address.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "8dffc284bb82172d248f9e85870dcf39fd567a989822a69cdde641c62e89917e"
+			"val": "646ad8827d9ebe715643bbfb15425d264e0280ef13e34fd5a46954fbcad4314d"
 		},
 		"from": "iso6523-actorid-upis::0088:5790000436101",
 		"to": "iso6523-actorid-upis::0088:5790000436057"
@@ -40,6 +40,15 @@
 				"country": "DK",
 				"code": "37990485"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK37990485",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": null,
@@ -79,6 +88,15 @@
 				"country": "DK",
 				"code": "47458714"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK47458714",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": null,

--- a/test/data/parse/oioubl21/out/zero-rated.json
+++ b/test/data/parse/oioubl21/out/zero-rated.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "566f20d687e5c726d880ddae4dbdc4dbcefb9d40d44516d556357acc76628959"
+			"val": "0f331a8d97530c928d0e116c70c33758952bc431a6173f57e1a9936a97476fc3"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -33,6 +33,15 @@
 				"country": "DK",
 				"code": "12345674"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK12345674",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {
@@ -64,6 +73,15 @@
 				"country": "DK",
 				"code": "76543216"
 			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "DK76543216",
+					"ext": {
+						"iso-scheme-id": "DK:CVR"
+					}
+				}
+			],
 			"people": [
 				{
 					"name": {

--- a/test/data/parse/oioubl21/out/zero-rated.json
+++ b/test/data/parse/oioubl21/out/zero-rated.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0f331a8d97530c928d0e116c70c33758952bc431a6173f57e1a9936a97476fc3"
+			"val": "aafcd915da57d50def0626c7ebd48ffeae473d05861e833f19fe40e19eeb95e1"
 		},
 		"from": "iso6523-actorid-upis::0184:12345674",
 		"to": "iso6523-actorid-upis::0184:76543216"
@@ -64,7 +64,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"customer": {
@@ -109,7 +110,8 @@
 				}
 			],
 			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
+				"dk-oioubl-address-format": "StructuredDK",
+				"dk-oioubl-address-scheme": "DK:CVR"
 			}
 		},
 		"lines": [


### PR DESCRIPTION
Mapper-not-enforcer move from the #73 review. The dk-oioubl addon now derives the legal identity from the Danish CVR (ISO 6523 0184); the converter maps PartyLegalEntity/CompanyID from it, and the fabrication in newParty + the parse-side un-fabricate hack are removed.

- Requires gobl.dk.oioubl PR `derive-party-legal-identity` (repinned here to e48b20a).
- Convert output unchanged (CompanyID is still DK:CVR — verified, no convert-golden diff).
- Parse now restores the legal identity explicitly (OIOUBL parse goldens carry it).
- Behaviour note: a name-less Danish party with a CVR now passes F-LIB022, since the CVR is its legal identifier (addon tests updated).