### PR TITLE
OIOUBL: UBLVersionID 2.1, codelist into addon, + re-review fixes

### DIFF
--- a/applicationresponse.go
+++ b/applicationresponse.go
@@ -71,18 +71,12 @@ func ublApplicationResponse(st *bill.Status, o *options) *ApplicationResponse {
 		sender, receiver = st.Supplier, st.Customer
 	}
 
-	// OIOUBL declares UBLVersionID 2.0 on the wire; other UBL contexts keep 2.1.
-	ublVersion := Version
-	if o.context.Is(ContextOIOUBL21) {
-		ublVersion = oioublUBLVersion
-	}
-
 	out := &ApplicationResponse{
 		XMLName:         xml.Name{Local: "ApplicationResponse"},
 		CACNamespace:    NamespaceCAC,
 		CBCNamespace:    NamespaceCBC,
 		UBLNamespace:    NamespaceUBLApplicationResponse,
-		UBLVersionID:    ublVersion,
+		UBLVersionID:    Version,
 		CustomizationID: o.context.CustomizationID,
 		ID:              invoiceNumber(st.Series, st.Code),
 		IssueDate:       formatDate(st.IssueDate),
@@ -170,13 +164,6 @@ const (
 	oioublProfileSchemeID    = "urn:oioubl:id:profileid-1.4"
 	oioublProfileTechnicalID = "Procurement-TecRes-1.0"
 	oioublCodeListAgencyID   = "320"
-	// oioublUBLVersion is the UBLVersionID OIOUBL declares on the wire. "OIOUBL 2.1"
-	// is the profile (cbc:CustomizationID); the UBL syntax version is separate, and
-	// we emit "2.0" to match the documents Unimaze produces. The element model is
-	// UBL 2.1 regardless.
-	// FLAGGED: F-LIB001 permits "2.1" too, so this OIOUBL-only override could be
-	// dropped for a uniform 2.1 once a Unimaze re-send confirms 2.1 is accepted.
-	oioublUBLVersion = "2.0"
 )
 
 // OIOUBL responsedocumenttypecode-1.1 values for the referenced document.

--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -21,11 +21,9 @@ func (ar *ApplicationResponse) Convert() (*gobl.Envelope, error) {
 	if ar.ProfileID != nil {
 		profileID = ar.ProfileID.Value
 	}
-	// Resolve by CustomizationID + ProfileID first, then fall back to the
-	// CustomizationID alone. OIOUBL keeps a single CustomizationID across all
-	// response types but swaps in a technical-response ProfileID for
-	// acknowledgements (F-APR057/F-APR058), which would otherwise fail the
-	// ProfileID-qualified lookup.
+	// Resolve by CustomizationID+ProfileID, else CustomizationID alone: OIOUBL
+	// swaps in a technical-response ProfileID for acknowledgements (F-APR057/058)
+	// that would fail the ProfileID-qualified lookup.
 	ctx := FindContext(ar.CustomizationID, profileID)
 	if ctx == nil {
 		ctx = FindContext(ar.CustomizationID, "")

--- a/charges.go
+++ b/charges.go
@@ -68,7 +68,7 @@ func makeCharge(ch *bill.Charge, ccy string, baseAmount num.Amount, ctx Context)
 		}
 	}
 	if ch.Taxes != nil {
-		c.TaxCategory = makeTaxCategory(ch.Taxes)
+		c.TaxCategory = makeTaxCategory(ch.Taxes, ctx)
 	}
 
 	return c
@@ -99,19 +99,24 @@ func makeDiscount(d *bill.Discount, ccy string, baseAmount num.Amount, ctx Conte
 		}
 	}
 	if d.Taxes != nil {
-		c.TaxCategory = makeTaxCategory(d.Taxes)
+		c.TaxCategory = makeTaxCategory(d.Taxes, ctx)
 	}
 
 	return c
 }
 
-func makeTaxCategory(taxes tax.Set) []*TaxCategory {
+func makeTaxCategory(taxes tax.Set, ctx Context) []*TaxCategory {
 	set := []*TaxCategory{}
 	for _, t := range taxes {
 		category := TaxCategory{}
 		category.TaxScheme = &TaxScheme{ID: IDType{Value: t.Category.String()}}
 
-		e := oioubl21TaxCategoryID(t.Ext)
+		// OIOUBL emits its own taxcategoryid-1.1 value (StandardRated/…); other
+		// profiles use the EN 16931 UNTDID category directly.
+		e := t.Ext.Get(untdid.ExtKeyTaxCategory).String()
+		if ctx.Is(ContextOIOUBL21) {
+			e = oioubl21TaxCategoryID(t.Ext)
+		}
 		if e != "" {
 			category.ID = &IDType{Value: e}
 		}

--- a/cmd/gobl.ubl/convert_test.go
+++ b/cmd/gobl.ubl/convert_test.go
@@ -29,7 +29,7 @@ func TestConvertBuildOptionsNemhandel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "OIOUBL-2.1", doc.CustomizationID)
 	assert.Equal(t, "urn:www.nesubl.eu:profiles:profile5:ver2.0", doc.ProfileID.Value)
-	assert.Equal(t, "2.0", doc.UBLVersionID)
+	assert.Equal(t, "2.1", doc.UBLVersionID)
 	assert.NotEmpty(t, doc.UUID)
 }
 

--- a/delivery.go
+++ b/delivery.go
@@ -7,6 +7,7 @@ type Delivery struct {
 	ActualDeliveryDate      *string   `xml:"cbc:ActualDeliveryDate"`
 	LatestDeliveryDate      *string   `xml:"cbc:LatestDeliveryDate"`
 	DeliveryLocation        *Location `xml:"cac:DeliveryLocation"`
+	RequestedDeliveryPeriod *Period   `xml:"cac:RequestedDeliveryPeriod"`
 	EstimatedDeliveryPeriod *Period   `xml:"cac:EstimatedDeliveryPeriod"`
 	DeliveryParty           *Party    `xml:"cac:DeliveryParty"`
 }
@@ -35,11 +36,17 @@ func newDelivery(del *bill.DeliveryDetails, ctx Context) *Delivery {
 	}
 
 	if del.Period != nil {
-		start := formatDate(del.Period.Start)
-		out.ActualDeliveryDate = &start
-		// OIOUBL forbids cac:Delivery/cbc:LatestDeliveryDate (F-INV087); only the
-		// actual delivery date (period start) is carried under OIOUBL.
-		if !ctx.Is(ContextOIOUBL21) {
+		if ctx.Is(ContextOIOUBL21) {
+			// A delivery window maps to RequestedDeliveryPeriod — the only delivery
+			// period OIOUBL permits, since it forbids LatestDeliveryDate (F-INV087)
+			// and the Promised/Estimated periods (F-INV089/F-INV090).
+			out.RequestedDeliveryPeriod = &Period{
+				StartDate: formatDate(del.Period.Start),
+				EndDate:   formatDate(del.Period.End),
+			}
+		} else {
+			start := formatDate(del.Period.Start)
+			out.ActualDeliveryDate = &start
 			end := formatDate(del.Period.End)
 			out.LatestDeliveryDate = &end
 		}

--- a/delivery_parse.go
+++ b/delivery_parse.go
@@ -33,6 +33,13 @@ func (ui *Invoice) goblAddDelivery(out *bill.Invoice) error {
 				}
 				d.Date = &deliveryDate
 			}
+			if del.RequestedDeliveryPeriod != nil {
+				p, err := goblPeriodDates(del.RequestedDeliveryPeriod)
+				if err != nil {
+					return err
+				}
+				d.Period = p
+			}
 			if del.EstimatedDeliveryPeriod != nil {
 				p, err := goblPeriodDates(del.EstimatedDeliveryPeriod)
 				if err != nil {
@@ -71,7 +78,7 @@ func (ui *Invoice) goblAddDelivery(out *bill.Invoice) error {
 		}
 	}
 
-	if d.Receiver != nil || d.Date != nil || d.Identities != nil {
+	if d.Receiver != nil || d.Date != nil || d.Period != nil || d.Identities != nil {
 		out.Delivery = d
 	}
 	return nil

--- a/examples_test.go
+++ b/examples_test.go
@@ -28,7 +28,7 @@ const (
 // updateOut is a flag that can be set to update example files
 var updateOut = flag.Bool("update", false, "Update the example files in test/data")
 
-// validate is a flag that enables Phive validation (used by the France probe test).
+// validate is a flag that enables Phive validation
 var validate = flag.Bool("validate", false, "Run Phive validation on generated XML")
 
 func TestConvertToInvoice(t *testing.T) {

--- a/examples_test.go
+++ b/examples_test.go
@@ -2,6 +2,7 @@ package ubl_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"io"
@@ -14,8 +15,11 @@ import (
 	ubl "github.com/invopop/gobl.ubl"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/phive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -32,6 +36,19 @@ var updateOut = flag.Bool("update", false, "Update the example files in test/dat
 var validate = flag.Bool("validate", false, "Run Phive validation on generated XML")
 
 func TestConvertToInvoice(t *testing.T) {
+	var pc phive.ValidationServiceClient
+
+	// Only connect to Phive if validation is requested
+	if *validate {
+		conn, err := grpc.NewClient(
+			"127.0.0.1:9090",
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close() //nolint:errcheck
+		pc = phive.NewValidationServiceClient(conn)
+	}
+
 	// Define contexts to test
 	contexts := []struct {
 		name    string
@@ -72,6 +89,24 @@ func TestConvertToInvoice(t *testing.T) {
 					if *updateOut {
 						err = os.WriteFile(outPath, data, 0644)
 						require.NoError(t, err)
+					}
+
+					// Run Phive validation if requested
+					if *validate {
+						env, err := loadTestEnvelopeFromPath(example)
+						require.NoError(t, err)
+						inv, ok := env.Extract().(*bill.Invoice)
+						require.True(t, ok, "Document should be an invoice")
+						vesid := ctx.context.GetVESID(inv)
+
+						resp, err := pc.ValidateXml(context.Background(), &phive.ValidateXmlRequest{
+							Vesid:      vesid,
+							XmlContent: data,
+						})
+						require.NoError(t, err)
+						results, err := json.MarshalIndent(resp.Results, "", "  ")
+						require.NoError(t, err)
+						require.True(t, resp.Success, "Generated XML should be valid for %s: %s", vesid, string(results))
 					}
 
 					output, err := os.ReadFile(outPath)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
-	github.com/invopop/gobl.dk.oioubl v0.0.0-20260626085027-b52a11b0b281
+	github.com/invopop/gobl.dk.oioubl v0.0.0-20260626111014-3b4d7acb3c88
 	github.com/invopop/gobl.fr.ctc v0.0.4
 	github.com/invopop/gobl.sa.zatca v0.0.2
 	github.com/invopop/phive v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267 h1:JESDuqkaOexIBJQ9AQOxaSSbQADO1s+HtRnNsCNWvaA=
 github.com/invopop/gobl v0.500.1-0.20260611093239-b095308b8267/go.mod h1:EGDHHuPbF8JxRfct0q/s9t7ei2gjkOwjH3SytjB3aS0=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260626085027-b52a11b0b281 h1:LQHXIPd46MelMc8wuZAHVF/Gd6tjfawpEm4/39X+CRw=
-github.com/invopop/gobl.dk.oioubl v0.0.0-20260626085027-b52a11b0b281/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260626111014-3b4d7acb3c88 h1:0djEtsAdZvKZ0ddcCCstHXgFThtg+dPQhNegNLCgCC0=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260626111014-3b4d7acb3c88/go.mod h1:tODJD+IZkk4Ds8PR8XEpe3umiyiG2NUN0+sBRnXnE0g=
 github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
 github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/gobl.sa.zatca v0.0.2 h1:qU2Y0LP+4mjvZkuG1TOUp/Zs0XxRAzkzQFHy3WOVFEU=

--- a/invoice.go
+++ b/invoice.go
@@ -159,7 +159,7 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 	}
 
 	if o.context.Is(ContextOIOUBL21) {
-		out.UBLVersionID = oioublUBLVersion
+		out.UBLVersionID = Version
 		if !inv.UUID.IsZero() {
 			out.UUID = inv.UUID.String()
 		}

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -39,12 +39,9 @@ var InvoiceTagMap = map[string][]cbc.Key{
 func (ui *Invoice) Convert() (*gobl.Envelope, error) {
 	o := new(options)
 
-	// Detect context from the invoice. Resolve by CustomizationID + ProfileID
-	// first, then fall back to the CustomizationID alone, mirroring the
-	// ApplicationResponse parser. OIOUBL keeps a single CustomizationID
-	// ("OIOUBL-2.1") but carries one of ~40 legal procurement ProfileIDs
-	// (Procurement-BilSim-1.0, …) rather than only profile5, which would
-	// otherwise fail the ProfileID-qualified lookup and parse with no addons.
+	// Resolve by CustomizationID+ProfileID, else CustomizationID alone: OIOUBL
+	// carries ~40 procurement ProfileIDs under one CustomizationID, so the
+	// ProfileID-qualified lookup alone would miss the context (and its addons).
 	ctx := FindContext(ui.CustomizationID, profileIDValue(ui.ProfileID))
 	if ctx == nil {
 		ctx = FindContext(ui.CustomizationID, "")

--- a/invoice_parse_test.go
+++ b/invoice_parse_test.go
@@ -76,11 +76,9 @@ func TestParseInvoiceTypes(t *testing.T) {
 }
 
 func TestParseInvoiceOIOUBLNonProfile5Context(t *testing.T) {
-	// Real NemHandel invoices keep the single CustomizationID "OIOUBL-2.1" but
-	// carry one of the ~40 procurement ProfileIDs (Procurement-BilSim-1.0, …)
-	// rather than profile5. The parser must still resolve the OIOUBL context —
-	// and its dk-oioubl-v2-1 addon — via the CustomizationID-only fallback;
-	// otherwise the document parses with no addons. (FINDINGS-2026-06-11 §2.16.)
+	// A non-profile5 ProfileID (one of OIOUBL's ~40 procurement profiles) must
+	// still resolve the OIOUBL context and its addon via the CustomizationID-only
+	// fallback; otherwise the document parses with no addons.
 	data, err := testLoadXML("oioubl21/invoice-minimal.xml")
 	require.NoError(t, err)
 

--- a/lines.go
+++ b/lines.go
@@ -411,7 +411,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 			}
 		}
 		if ctx.Is(ContextOIOUBL21) {
-			ac.TaxCategory = makeTaxCategory(taxes) // F-LIB226: line allowance needs a TaxCategory
+			ac.TaxCategory = makeTaxCategory(taxes, ctx) // F-LIB226: line allowance needs a TaxCategory
 		}
 		allowanceCharges = append(allowanceCharges, ac)
 	}
@@ -437,7 +437,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 			}
 		}
 		if ctx.Is(ContextOIOUBL21) {
-			ac.TaxCategory = makeTaxCategory(taxes) // F-LIB226: line allowance needs a TaxCategory
+			ac.TaxCategory = makeTaxCategory(taxes, ctx) // F-LIB226: line allowance needs a TaxCategory
 		}
 		allowanceCharges = append(allowanceCharges, ac)
 	}

--- a/lines.go
+++ b/lines.go
@@ -164,8 +164,14 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 					},
 				}
 
-				if s := oioubl21TaxCategoryID(l.Taxes[0].Ext); s != "" {
-					it.ClassifiedTaxCategory.ID = &IDType{Value: s}
+				// OIOUBL emits its own taxcategoryid-1.1 value; other profiles use
+				// the EN 16931 UNTDID category directly.
+				cat := l.Taxes[0].Ext.Get(untdid.ExtKeyTaxCategory).String()
+				if context.Is(ContextOIOUBL21) {
+					cat = oioubl21TaxCategoryID(l.Taxes[0].Ext)
+				}
+				if cat != "" {
+					it.ClassifiedTaxCategory.ID = &IDType{Value: cat}
 				}
 
 				// Set percent: required unless category is "O" (outside scope)

--- a/party.go
+++ b/party.go
@@ -473,11 +473,8 @@ func splitISO6523Endpoint(uri cbc.URI) (string, string, bool) {
 	return icd, code, true
 }
 
-// oioubl21AddressFormatCode returns an OIOUBL AddressFormatCode (codelist
-// addressformatcode-1.1), required on every address (F-LIB025). The value
-// defaults to StructuredLax, which imposes no mandatory sub-fields and matches
-// real NemHandel traffic; a party may override it via the dk-oioubl-address-format
-// extension (see applyOIOUBL21AddressFormat).
+// oioubl21AddressFormatCode builds the cbc:AddressFormatCode (codelist
+// addressformatcode-1.1) required on every OIOUBL address (F-LIB025).
 func oioubl21AddressFormatCode(value string) *IDType {
 	listID := "urn:oioubl:codelist:addressformatcode-1.1"
 	listAgencyID := "320"
@@ -508,14 +505,10 @@ const (
 	oioubl21GLNAgencyID     = "9"
 )
 
-// applyOIOUBL21AddressFormat reshapes a party's postal address to the OIOUBL
-// addressformatcode-1.1 value declared on the GOBL party
-// (dk-oioubl-address-format). Without a declared format the address keeps the
-// StructuredLax form newAddress produced. Each restricted format drops the
-// elements OIOUBL forbids (F-LIB031/038/040); the StructuredID identifier and the
-// StructuredRegion district — which GOBL does not model — are read from the party
-// extension. It must run after applyOIOUBL21Party, which derives the DK vs ZZZ
-// schemes from the address country before the restricted formats drop it.
+// applyOIOUBL21AddressFormat reshapes a party's postal address to its declared
+// dk-oioubl-address-format, dropping the elements each restricted format forbids
+// (F-LIB031/038/040). Must run after applyOIOUBL21Party, which needs the address
+// country before the restricted formats drop it.
 func applyOIOUBL21AddressFormat(addr *PostalAddress, party *org.Party) {
 	if addr == nil || party == nil {
 		return

--- a/party.go
+++ b/party.go
@@ -695,33 +695,15 @@ func contactName(n *org.Name) string {
 	return fmt.Sprintf("%s %s", given, surname)
 }
 
-// OIOUBL symbolic EndpointID schemes (F-LIB179) and the ISO 6523 ICDs they
-// correspond to. The symbolic schemes are defined by the dk-oioubl addon (the
-// single source of truth, shared with the ICD->scheme map below).
+// OIOUBL symbolic schemes (F-LIB179), defined by the dk-oioubl addon (the single
+// source of truth). The ICD<->scheme codelist also lives in the addon, reached via
+// oioubl.SchemeForICD (convert) and oioubl.ICDForScheme (parse).
 const (
 	oioubl21SchemeDKCVR = oioubl.SchemeDKCVR
 	oioubl21SchemeDKSE  = oioubl.SchemeDKSE
 	oioubl21SchemeZZZ   = oioubl.SchemeZZZ
 	icdDKSE             = "0198"
 )
-
-// oioubl21EndpointSchemes maps the Danish ISO 6523 ICDs to their symbolic
-// OIOUBL EndpointID schemeID (F-LIB179) — numeric scheme IDs are rejected on
-// the NemHandel wire. Danish ICDs are derived; a foreign participant supplies
-// its scheme via the dk-oioubl-address-scheme extension (see newParty), which
-// already passes through here. An unmapped value passes through unchanged.
-var oioubl21EndpointSchemes = oioubl.EndpointSchemes
-
-// oioubl21EndpointICDs is the inverse of the Danish endpoint-scheme map, used on
-// parse to restore a wire EndpointID to its ISO 6523 endpoint. The map is 1:1, so
-// a foreign symbolic scheme has no entry and is restored as an inbox instead.
-var oioubl21EndpointICDs = func() map[string]string {
-	m := make(map[string]string, len(oioubl21EndpointSchemes))
-	for icd, scheme := range oioubl21EndpointSchemes {
-		m[scheme] = icd
-	}
-	return m
-}()
 
 // applyOIOUBL21Party rewrites an assembled party into OIOUBL 2.1 form: symbolic
 // endpoint scheme + DK-prefixed CVR (F-LIB179/F-LIB180), a fallback PartyName,
@@ -818,8 +800,8 @@ func applyOIOUBL21PartyIdentifications(p *Party) {
 			continue
 		}
 		scheme := *id.SchemeID
-		if mapped, ok := oioubl21EndpointSchemes[scheme]; ok {
-			scheme = mapped
+		if mapped := oioubl.SchemeForICD(scheme); mapped != "" {
+			scheme = mapped.String()
 		} else if isNumericICDScheme(scheme) {
 			scheme = oioubl21SchemeZZZ
 		}

--- a/party.go
+++ b/party.go
@@ -488,28 +488,24 @@ func oioubl21AddressFormatCode(value string) *IDType {
 	}
 }
 
-// OIOUBL address-format extension keys and values, mirrored from the dk-oioubl
-// addon. The converter reads them as plain extension keys on the GOBL party
-// (GOBL has no address-level extension); only the formats that reshape the
-// output need an explicit case.
+// OIOUBL address extension keys and values, sourced from the dk-oioubl addon (the
+// single source of truth) so the converter and addon never drift. The converter
+// reads them as plain party extensions (GOBL has no address-level extension).
 const (
-	oioubl21AddressFormatKey   cbc.Key = "dk-oioubl-address-format"
-	oioubl21AddressIDKey       cbc.Key = "dk-oioubl-address-id"
-	oioubl21AddressDistrictKey cbc.Key = "dk-oioubl-address-district"
-	// oioubl21AddressSchemeKey overrides the derived EndpointID/PartyIdentification
-	// symbolic scheme (F-LIB179/F-LIB183) for a foreign participant; see newParty.
-	oioubl21AddressSchemeKey cbc.Key = "dk-oioubl-address-scheme"
+	oioubl21AddressFormatKey   = oioubl.ExtKeyAddressFormat
+	oioubl21AddressIDKey       = oioubl.ExtKeyAddressID
+	oioubl21AddressDistrictKey = oioubl.ExtKeyAddressDistrict
+	oioubl21AddressSchemeKey   = oioubl.ExtKeyAddressScheme
 
-	oioubl21AddressStructuredLax    = "StructuredLax"
-	oioubl21AddressUnstructured     = "Unstructured"
-	oioubl21AddressStructuredID     = "StructuredID"
-	oioubl21AddressStructuredRegion = "StructuredRegion"
+	oioubl21AddressStructuredLax    = string(oioubl.ExtValueAddressFormatStructuredLax)
+	oioubl21AddressUnstructured     = string(oioubl.ExtValueAddressFormatUnstructured)
+	oioubl21AddressStructuredID     = string(oioubl.ExtValueAddressFormatStructuredID)
+	oioubl21AddressStructuredRegion = string(oioubl.ExtValueAddressFormatStructuredRegion)
 
-	// oioubl21AddressIDScheme is the address-register schemeID OIOUBL mandates on
-	// a StructuredID address ID (F-LIB028/029); the ID is a GLN.
-	oioubl21AddressIDScheme = "GLN"
-	// oioubl21GLNAgencyID is the GS1 scheme agency (9) OIOUBL stamps on GLN IDs.
-	oioubl21GLNAgencyID = "9"
+	// oioubl21AddressIDScheme (GLN) and its GS1 agency are wire-serialization
+	// attributes OIOUBL mandates on a StructuredID address ID (F-LIB028/029).
+	oioubl21AddressIDScheme = string(oioubl.SchemeGLN)
+	oioubl21GLNAgencyID     = "9"
 )
 
 // applyOIOUBL21AddressFormat reshapes a party's postal address to the OIOUBL
@@ -716,15 +712,13 @@ const (
 // already passes through here. An unmapped value passes through unchanged.
 var oioubl21EndpointSchemes = oioubl.EndpointSchemes
 
-// oioubl21EndpointICDs restores wire EndpointIDs to ISO 6523 endpoints on
-// parse. Inverse of oioubl21EndpointSchemes (the Danish schemes); a foreign
-// symbolic scheme has no ICD here and is restored as an inbox instead.
+// oioubl21EndpointICDs is the inverse of the Danish endpoint-scheme map, used on
+// parse to restore a wire EndpointID to its ISO 6523 endpoint. The map is 1:1, so
+// a foreign symbolic scheme has no entry and is restored as an inbox instead.
 var oioubl21EndpointICDs = func() map[string]string {
 	m := make(map[string]string, len(oioubl21EndpointSchemes))
 	for icd, scheme := range oioubl21EndpointSchemes {
-		if cur, ok := m[scheme]; !ok || icd < cur {
-			m[scheme] = icd
-		}
+		m[scheme] = icd
 	}
 	return m
 }()

--- a/party_parse.go
+++ b/party_parse.go
@@ -3,6 +3,7 @@ package ubl
 import (
 	"strings"
 
+	oioubl "github.com/invopop/gobl.dk.oioubl/addon"
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
@@ -25,10 +26,11 @@ func goblParty(party *Party, o *options) *org.Party {
 		case eID.SchemeID == "EM": // email
 			p.Inboxes = append(p.Inboxes, &org.Inbox{Email: eID.Value})
 		case o.context.Is(ContextOIOUBL21):
-			// OIOUBL participants are restored as ISO 6523 endpoints, the
-			// going-forward GOBL routing model. Symbolic schemes without an
-			// ICD equivalent fall back to an inbox so no identifier is lost.
-			if icd, ok := oioubl21EndpointICDs[eID.SchemeID]; ok {
+			// OIOUBL participants are restored as ISO 6523 org.Endpoints, the
+			// going-forward routing model (org.Inbox is deprecated). The numeric ICD
+			// comes from the addon codelist (ICDForScheme); a foreign symbolic scheme
+			// has no Danish ICD and falls back to an inbox so no identifier is lost.
+			if icd, ok := oioubl.ICDForScheme(eID.SchemeID); ok {
 				code := eID.Value
 				if eID.SchemeID == oioubl21SchemeDKCVR {
 					// Reverse the wire-only DK prefix (F-LIB180).

--- a/party_parse.go
+++ b/party_parse.go
@@ -200,13 +200,10 @@ func parseAddress(address *PostalAddress) *org.Address {
 	return addr
 }
 
-// applyOIOUBL21AddressFormatParse restores the OIOUBL address format declared on
-// the wire (cbc:AddressFormatCode) to the GOBL party extensions the emit side
-// reads (see applyOIOUBL21AddressFormat), so the format round-trips. StructuredLax
-// is the default form newAddress emits for an address without a declared format,
-// so it carries no extension. The StructuredID identifier (cbc:ID) and the
-// StructuredRegion district (cbc:District) are not modelled by org.Address and are
-// read back onto the party extension.
+// applyOIOUBL21AddressFormatParse restores the wire cbc:AddressFormatCode to the
+// dk-oioubl-address-format extension so the format round-trips. StructuredLax is
+// the default and carries no extension; the StructuredID id and StructuredRegion
+// district (not modelled by org.Address) are read back onto the party extension.
 func applyOIOUBL21AddressFormatParse(address *PostalAddress, p *org.Party) {
 	if address == nil || address.AddressFormatCode == nil {
 		return

--- a/reminder.go
+++ b/reminder.go
@@ -57,18 +57,12 @@ type ReminderLine struct {
 func ublReminder(pmt *bill.Payment, o *options) *Reminder {
 	currency := pmt.Currency.String()
 
-	// OIOUBL declares UBLVersionID 2.0 on the wire; other UBL contexts keep 2.1.
-	ublVersion := Version
-	if o.context.Is(ContextOIOUBL21) {
-		ublVersion = oioublUBLVersion
-	}
-
 	out := &Reminder{
 		XMLName:                 xml.Name{Local: "Reminder"},
 		CBCNamespace:            NamespaceCBC,
 		CACNamespace:            NamespaceCAC,
 		UBLNamespace:            NamespaceUBLReminder,
-		UBLVersionID:            ublVersion,
+		UBLVersionID:            Version,
 		CustomizationID:         o.context.CustomizationID,
 		ID:                      invoiceNumber(pmt.Series, pmt.Code),
 		IssueDate:               formatDate(pmt.IssueDate),

--- a/test/data/convert/oioubl21-reminder/out/reminder-basic.xml
+++ b/test/data/convert/oioubl21-reminder/out/reminder-basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Reminder xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">Procurement-BilSim-1.0</cbc:ProfileID>
   <cbc:ID>2026-R-1000</cbc:ID>

--- a/test/data/convert/oioubl21-reminder/out/reminder-fik.xml
+++ b/test/data/convert/oioubl21-reminder/out/reminder-fik.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Reminder xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Reminder-2">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">Procurement-BilSim-1.0</cbc:ProfileID>
   <cbc:ID>2026-R-1000</cbc:ID>

--- a/test/data/convert/oioubl21-response/out/invoice-accepted.xml
+++ b/test/data/convert/oioubl21-response/out/invoice-accepted.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApplicationResponse xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>RESP-002</cbc:ID>

--- a/test/data/convert/oioubl21-response/out/invoice-acknowledged.xml
+++ b/test/data/convert/oioubl21-response/out/invoice-acknowledged.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApplicationResponse xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">Procurement-TecRes-1.0</cbc:ProfileID>
   <cbc:ID>RESP-003</cbc:ID>

--- a/test/data/convert/oioubl21-response/out/invoice-errored.xml
+++ b/test/data/convert/oioubl21-response/out/invoice-errored.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApplicationResponse xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>RESP-004</cbc:ID>

--- a/test/data/convert/oioubl21-response/out/invoice-rejected.xml
+++ b/test/data/convert/oioubl21-response/out/invoice-rejected.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApplicationResponse xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.4">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>RESP-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/address-structured-dk.xml
+++ b/test/data/convert/oioubl21/out/address-structured-dk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>ADDR-1000</cbc:ID>

--- a/test/data/convert/oioubl21/out/address-structured-id.xml
+++ b/test/data/convert/oioubl21/out/address-structured-id.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>ADDR-1000</cbc:ID>

--- a/test/data/convert/oioubl21/out/address-structured-region.xml
+++ b/test/data/convert/oioubl21/out/address-structured-region.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>ADDR-1000</cbc:ID>

--- a/test/data/convert/oioubl21/out/address-unstructured.xml
+++ b/test/data/convert/oioubl21/out/address-unstructured.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>ADDR-1000</cbc:ID>

--- a/test/data/convert/oioubl21/out/attachment.xml
+++ b/test/data/convert/oioubl21/out/attachment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-ATT</cbc:ID>

--- a/test/data/convert/oioubl21/out/credit-note-minimal.xml
+++ b/test/data/convert/oioubl21/out/credit-note-minimal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2 https://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>CN-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/credit-note-value-date.xml
+++ b/test/data/convert/oioubl21/out/credit-note-value-date.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2 https://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-004</cbc:ID>

--- a/test/data/convert/oioubl21/out/credit-note.xml
+++ b/test/data/convert/oioubl21/out/credit-note.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2 https://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-003</cbc:ID>

--- a/test/data/convert/oioubl21/out/delivery.xml
+++ b/test/data/convert/oioubl21/out/delivery.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>SAMPLE-DELIV-1</cbc:ID>

--- a/test/data/convert/oioubl21/out/delivery.xml
+++ b/test/data/convert/oioubl21/out/delivery.xml
@@ -80,7 +80,6 @@
     </cac:Party>
   </cac:AccountingCustomerParty>
   <cac:Delivery>
-    <cbc:ActualDeliveryDate>2026-05-20</cbc:ActualDeliveryDate>
     <cac:DeliveryLocation>
       <cac:Address>
         <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredLax</cbc:AddressFormatCode>
@@ -93,6 +92,10 @@
         </cac:Country>
       </cac:Address>
     </cac:DeliveryLocation>
+    <cac:RequestedDeliveryPeriod>
+      <cbc:StartDate>2026-05-20</cbc:StartDate>
+      <cbc:EndDate>2026-05-25</cbc:EndDate>
+    </cac:RequestedDeliveryPeriod>
     <cac:DeliveryParty>
       <cac:PartyName>
         <cbc:Name>Leveringssted ApS</cbc:Name>

--- a/test/data/convert/oioubl21/out/direct-debit.xml
+++ b/test/data/convert/oioubl21/out/direct-debit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-DD01</cbc:ID>

--- a/test/data/convert/oioubl21/out/doc-allowance.xml
+++ b/test/data/convert/oioubl21/out/doc-allowance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-DA01</cbc:ID>

--- a/test/data/convert/oioubl21/out/dual-currency-mixed.xml
+++ b/test/data/convert/oioubl21/out/dual-currency-mixed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-DUAL-MIX</cbc:ID>

--- a/test/data/convert/oioubl21/out/exempt-no-reason.xml
+++ b/test/data/convert/oioubl21/out/exempt-no-reason.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-EXNR01</cbc:ID>

--- a/test/data/convert/oioubl21/out/exempt.xml
+++ b/test/data/convert/oioubl21/out/exempt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-EX01</cbc:ID>

--- a/test/data/convert/oioubl21/out/fik-71.xml
+++ b/test/data/convert/oioubl21/out/fik-71.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-FIK71</cbc:ID>

--- a/test/data/convert/oioubl21/out/fik.xml
+++ b/test/data/convert/oioubl21/out/fik.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-FIK01</cbc:ID>

--- a/test/data/convert/oioubl21/out/foreign-party.xml
+++ b/test/data/convert/oioubl21/out/foreign-party.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-FOREIGN-1</cbc:ID>

--- a/test/data/convert/oioubl21/out/fractional-quantity.xml
+++ b/test/data/convert/oioubl21/out/fractional-quantity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-FQ01</cbc:ID>

--- a/test/data/convert/oioubl21/out/giro-01-ref.xml
+++ b/test/data/convert/oioubl21/out/giro-01-ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-GIRO01REF</cbc:ID>

--- a/test/data/convert/oioubl21/out/giro-04.xml
+++ b/test/data/convert/oioubl21/out/giro-04.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-GIRO04</cbc:ID>

--- a/test/data/convert/oioubl21/out/giro.xml
+++ b/test/data/convert/oioubl21/out/giro.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-GIRO01</cbc:ID>

--- a/test/data/convert/oioubl21/out/happy-path.xml
+++ b/test/data/convert/oioubl21/out/happy-path.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/invoice-bare.xml
+++ b/test/data/convert/oioubl21/out/invoice-bare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>SAMPLE-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/invoice-minimal.xml
+++ b/test/data/convert/oioubl21/out/invoice-minimal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>SAMPLE-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/invoice-preceding.xml
+++ b/test/data/convert/oioubl21/out/invoice-preceding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-PREC</cbc:ID>

--- a/test/data/convert/oioubl21/out/item-origin.xml
+++ b/test/data/convert/oioubl21/out/item-origin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-ORIGIN-1</cbc:ID>

--- a/test/data/convert/oioubl21/out/line-discount.xml
+++ b/test/data/convert/oioubl21/out/line-discount.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-002</cbc:ID>

--- a/test/data/convert/oioubl21/out/mixed-allowance-category.xml
+++ b/test/data/convert/oioubl21/out/mixed-allowance-category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>ALWCAT-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/mixed-categories.xml
+++ b/test/data/convert/oioubl21/out/mixed-categories.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>MIXED-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/participant-schemes.xml
+++ b/test/data/convert/oioubl21/out/participant-schemes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>SE-EP-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/payee.xml
+++ b/test/data/convert/oioubl21/out/payee.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-PAYEE-1</cbc:ID>

--- a/test/data/convert/oioubl21/out/pobox-contact.xml
+++ b/test/data/convert/oioubl21/out/pobox-contact.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>POBOX-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/prepayment.xml
+++ b/test/data/convert/oioubl21/out/prepayment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-005</cbc:ID>

--- a/test/data/convert/oioubl21/out/reverse-charge.xml
+++ b/test/data/convert/oioubl21/out/reverse-charge.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-RC01</cbc:ID>

--- a/test/data/convert/oioubl21/out/sepa-credit-transfer.xml
+++ b/test/data/convert/oioubl21/out/sepa-credit-transfer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-SEPA-001</cbc:ID>

--- a/test/data/convert/oioubl21/out/tax-representative.xml
+++ b/test/data/convert/oioubl21/out/tax-representative.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>TAXREP-1000</cbc:ID>

--- a/test/data/convert/oioubl21/out/zero-rated.xml
+++ b/test/data/convert/oioubl21/out/zero-rated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
-  <cbc:UBLVersionID>2.0</cbc:UBLVersionID>
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
   <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
   <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
   <cbc:ID>FINAL-006</cbc:ID>


### PR DESCRIPTION
Three related OIOUBL converter changes (from the #73 re-review).

### 1. UBLVersionID 2.1 (was 2.0)
Drops the OIOUBL-only `oioublUBLVersion="2.0"` override; emits the package `Version` (2.1) uniformly. F-LIB001 accepts both, the official ERST OIOUBL 2.1 samples use 2.1, and a sandbox re-send confirmed Unimaze approves 2.1 (Delivered/Approved). Parse still accepts 2.0 input. 43 convert goldens flip 2.0→2.1.

### 2. Endpoint codelist moved into the addon
The converter no longer holds the ICD↔symbolic map or builds the inverse — convert goes through `oioubl.SchemeForICD`, parse through `oioubl.ICDForScheme`. The codelist is OIOUBL knowledge and now lives only in `gobl.dk.oioubl`. Parse still rebuilds a canonical `org.Endpoint` (`org.Inbox` is deprecated). Behaviour-neutral. Requires the addon repin (done).

### 3. Re-review fixes
- charges.go: `makeTaxCategory` takes `Context`; OIOUBL taxcategoryid lookup gated.
- party.go: address ext keys/values sourced from the addon, not re-declared.
- applicationresponse_parse.go: comment trimmed.

Build/test/lint green throughout.