### PR TITLE
Address re-review comments (round 2)

### DIFF
--- a/applicationresponse_parse.go
+++ b/applicationresponse_parse.go
@@ -21,11 +21,9 @@ func (ar *ApplicationResponse) Convert() (*gobl.Envelope, error) {
 	if ar.ProfileID != nil {
 		profileID = ar.ProfileID.Value
 	}
-	// Resolve by CustomizationID + ProfileID first, then fall back to the
-	// CustomizationID alone. OIOUBL keeps a single CustomizationID across all
-	// response types but swaps in a technical-response ProfileID for
-	// acknowledgements (F-APR057/F-APR058), which would otherwise fail the
-	// ProfileID-qualified lookup.
+	// Resolve by CustomizationID+ProfileID, else CustomizationID alone: OIOUBL
+	// swaps in a technical-response ProfileID for acknowledgements (F-APR057/058)
+	// that would fail the ProfileID-qualified lookup.
 	ctx := FindContext(ar.CustomizationID, profileID)
 	if ctx == nil {
 		ctx = FindContext(ar.CustomizationID, "")

--- a/charges.go
+++ b/charges.go
@@ -68,7 +68,7 @@ func makeCharge(ch *bill.Charge, ccy string, baseAmount num.Amount, ctx Context)
 		}
 	}
 	if ch.Taxes != nil {
-		c.TaxCategory = makeTaxCategory(ch.Taxes)
+		c.TaxCategory = makeTaxCategory(ch.Taxes, ctx)
 	}
 
 	return c
@@ -99,19 +99,24 @@ func makeDiscount(d *bill.Discount, ccy string, baseAmount num.Amount, ctx Conte
 		}
 	}
 	if d.Taxes != nil {
-		c.TaxCategory = makeTaxCategory(d.Taxes)
+		c.TaxCategory = makeTaxCategory(d.Taxes, ctx)
 	}
 
 	return c
 }
 
-func makeTaxCategory(taxes tax.Set) []*TaxCategory {
+func makeTaxCategory(taxes tax.Set, ctx Context) []*TaxCategory {
 	set := []*TaxCategory{}
 	for _, t := range taxes {
 		category := TaxCategory{}
 		category.TaxScheme = &TaxScheme{ID: IDType{Value: t.Category.String()}}
 
-		e := oioubl21TaxCategoryID(t.Ext)
+		// OIOUBL emits its own taxcategoryid-1.1 value (StandardRated/…); other
+		// profiles use the EN 16931 UNTDID category directly.
+		e := t.Ext.Get(untdid.ExtKeyTaxCategory).String()
+		if ctx.Is(ContextOIOUBL21) {
+			e = oioubl21TaxCategoryID(t.Ext)
+		}
 		if e != "" {
 			category.ID = &IDType{Value: e}
 		}

--- a/lines.go
+++ b/lines.go
@@ -411,7 +411,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 			}
 		}
 		if ctx.Is(ContextOIOUBL21) {
-			ac.TaxCategory = makeTaxCategory(taxes) // F-LIB226: line allowance needs a TaxCategory
+			ac.TaxCategory = makeTaxCategory(taxes, ctx) // F-LIB226: line allowance needs a TaxCategory
 		}
 		allowanceCharges = append(allowanceCharges, ac)
 	}
@@ -437,7 +437,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 			}
 		}
 		if ctx.Is(ContextOIOUBL21) {
-			ac.TaxCategory = makeTaxCategory(taxes) // F-LIB226: line allowance needs a TaxCategory
+			ac.TaxCategory = makeTaxCategory(taxes, ctx) // F-LIB226: line allowance needs a TaxCategory
 		}
 		allowanceCharges = append(allowanceCharges, ac)
 	}

--- a/party.go
+++ b/party.go
@@ -488,28 +488,24 @@ func oioubl21AddressFormatCode(value string) *IDType {
 	}
 }
 
-// OIOUBL address-format extension keys and values, mirrored from the dk-oioubl
-// addon. The converter reads them as plain extension keys on the GOBL party
-// (GOBL has no address-level extension); only the formats that reshape the
-// output need an explicit case.
+// OIOUBL address extension keys and values, sourced from the dk-oioubl addon (the
+// single source of truth) so the converter and addon never drift. The converter
+// reads them as plain party extensions (GOBL has no address-level extension).
 const (
-	oioubl21AddressFormatKey   cbc.Key = "dk-oioubl-address-format"
-	oioubl21AddressIDKey       cbc.Key = "dk-oioubl-address-id"
-	oioubl21AddressDistrictKey cbc.Key = "dk-oioubl-address-district"
-	// oioubl21AddressSchemeKey overrides the derived EndpointID/PartyIdentification
-	// symbolic scheme (F-LIB179/F-LIB183) for a foreign participant; see newParty.
-	oioubl21AddressSchemeKey cbc.Key = "dk-oioubl-address-scheme"
+	oioubl21AddressFormatKey   = oioubl.ExtKeyAddressFormat
+	oioubl21AddressIDKey       = oioubl.ExtKeyAddressID
+	oioubl21AddressDistrictKey = oioubl.ExtKeyAddressDistrict
+	oioubl21AddressSchemeKey   = oioubl.ExtKeyAddressScheme
 
-	oioubl21AddressStructuredLax    = "StructuredLax"
-	oioubl21AddressUnstructured     = "Unstructured"
-	oioubl21AddressStructuredID     = "StructuredID"
-	oioubl21AddressStructuredRegion = "StructuredRegion"
+	oioubl21AddressStructuredLax    = string(oioubl.ExtValueAddressFormatStructuredLax)
+	oioubl21AddressUnstructured     = string(oioubl.ExtValueAddressFormatUnstructured)
+	oioubl21AddressStructuredID     = string(oioubl.ExtValueAddressFormatStructuredID)
+	oioubl21AddressStructuredRegion = string(oioubl.ExtValueAddressFormatStructuredRegion)
 
-	// oioubl21AddressIDScheme is the address-register schemeID OIOUBL mandates on
-	// a StructuredID address ID (F-LIB028/029); the ID is a GLN.
-	oioubl21AddressIDScheme = "GLN"
-	// oioubl21GLNAgencyID is the GS1 scheme agency (9) OIOUBL stamps on GLN IDs.
-	oioubl21GLNAgencyID = "9"
+	// oioubl21AddressIDScheme (GLN) and its GS1 agency are wire-serialization
+	// attributes OIOUBL mandates on a StructuredID address ID (F-LIB028/029).
+	oioubl21AddressIDScheme = string(oioubl.SchemeGLN)
+	oioubl21GLNAgencyID     = "9"
 )
 
 // applyOIOUBL21AddressFormat reshapes a party's postal address to the OIOUBL
@@ -716,15 +712,13 @@ const (
 // already passes through here. An unmapped value passes through unchanged.
 var oioubl21EndpointSchemes = oioubl.EndpointSchemes
 
-// oioubl21EndpointICDs restores wire EndpointIDs to ISO 6523 endpoints on
-// parse. Inverse of oioubl21EndpointSchemes (the Danish schemes); a foreign
-// symbolic scheme has no ICD here and is restored as an inbox instead.
+// oioubl21EndpointICDs is the inverse of the Danish endpoint-scheme map, used on
+// parse to restore a wire EndpointID to its ISO 6523 endpoint. The map is 1:1, so
+// a foreign symbolic scheme has no entry and is restored as an inbox instead.
 var oioubl21EndpointICDs = func() map[string]string {
 	m := make(map[string]string, len(oioubl21EndpointSchemes))
 	for icd, scheme := range oioubl21EndpointSchemes {
-		if cur, ok := m[scheme]; !ok || icd < cur {
-			m[scheme] = icd
-		}
+		m[scheme] = icd
 	}
 	return m
 }()


### PR DESCRIPTION
Addresses the 2026-06-26 re-review on #73 — the clear code fixes:

- **charges.go (gating):** `makeTaxCategory` now takes `Context`; the OIOUBL `taxcategoryid-1.1` lookup is gated, so generic profiles use the EN 16931 UNTDID category directly (behaviour-neutral — the OIOUBL helper already fell back to UNTDID).
- **party.go (DRY/source-of-truth):** the `dk-oioubl-address-*` extension keys and format values are now sourced from the `gobl.dk.oioubl` addon instead of re-declared as literals, so converter and addon can't drift.
- **party.go (maintainability):** `oioubl21EndpointICDs` simplified — the endpoint-scheme map is 1:1 now, so the collision dedup was dead code.
- **applicationresponse_parse.go:** trimmed the verbose context-resolution comment.

Build/test/lint green. The UBLVersionID comment (#73) is resolved separately by #92. Remaining re-review items (delivery rule-vs-mapper, and several rationale questions) handled in the thread.