### PR TITLE
Simplify the OIOUBL line helpers

### DIFF
--- a/lines.go
+++ b/lines.go
@@ -51,7 +51,7 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 		// netted at the document level); other profiles use the net line total.
 		lineExt := l.Total.String()
 		if context.Is(ContextOIOUBL21) && l.Sum != nil {
-			lineExt = rescaleToCurrency(*l.Sum, ccy)
+			lineExt = roundToCurrency(*l.Sum, ccy).String()
 		}
 		invLine := InvoiceLine{
 			ID: strconv.Itoa(l.Index),
@@ -259,7 +259,7 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 		}
 
 		if context.Is(ContextOIOUBL21) {
-			invLine.TaxTotal = makeLineTaxTotals(l, ccy, context)
+			invLine.TaxTotal = makeOIOUBL21LineTaxTotals(l, ccy)
 		}
 
 		lines = append(lines, invLine)
@@ -298,7 +298,7 @@ func applyOIOUBL21LineTaxCategories(lines []InvoiceLine) {
 	}
 }
 
-// rescaleToCurrency rounds the amount to the natural precision of the given
+// roundToCurrency rounds the amount to the natural precision of the given
 // currency code (e.g. 2 for EUR, 0 for JPY). Falls back to the amount's
 // existing precision if the currency code is unknown.
 func roundToCurrency(a num.Amount, ccy string) num.Amount {
@@ -308,18 +308,17 @@ func roundToCurrency(a num.Amount, ccy string) num.Amount {
 	return a
 }
 
-func rescaleToCurrency(a num.Amount, ccy string) string {
-	return roundToCurrency(a, ccy).String()
-}
-
-func makeLineTaxTotals(line *bill.Line, ccy string, ctx Context) []TaxTotal {
+// makeOIOUBL21LineTaxTotals builds the OIOUBL line-level cac:TaxTotal. It is only
+// called for OIOUBL 2.1, which (unlike other profiles) requires a line TaxTotal
+// on every line, even at 0% (F-INV138 / F-LIB404).
+func makeOIOUBL21LineTaxTotals(line *bill.Line, ccy string) []TaxTotal {
 	if line == nil || len(line.Taxes) == 0 {
 		return nil
 	}
 
 	var taxable num.Amount
 	switch {
-	case ctx.Is(ContextOIOUBL21) && line.Sum != nil:
+	case line.Sum != nil:
 		// OIOUBL line TaxableAmount is gross (Price×Qty), rounded to currency
 		// precision (l.Sum is the raw product); the discount is subtracted once
 		// at the document level (F-LIB402 sums gross line taxable amounts then
@@ -327,8 +326,6 @@ func makeLineTaxTotals(line *bill.Line, ccy string, ctx Context) []TaxTotal {
 		taxable = roundToCurrency(*line.Sum, ccy)
 	case line.Total != nil:
 		taxable = *line.Total
-	case line.Sum != nil:
-		taxable = *line.Sum
 	default:
 		return nil
 	}
@@ -367,11 +364,6 @@ func makeLineTaxTotals(line *bill.Line, ccy string, ctx Context) []TaxTotal {
 		taxTotal.TaxSubtotal = append(taxTotal.TaxSubtotal, subtotal)
 	}
 
-	// OIOUBL requires a line TaxTotal even for 0% lines (F-INV138 / F-LIB404);
-	// other profiles omit it when the line tax amount is zero.
-	if totalAmount.IsZero() && !ctx.Is(ContextOIOUBL21) {
-		return nil
-	}
 	taxTotal.TaxAmount = Amount{Value: totalAmount.String(), CurrencyID: &ccy}
 
 	return []TaxTotal{taxTotal}
@@ -386,7 +378,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 	var base *Amount
 	if baseSum != nil {
 		base = &Amount{
-			Value:      rescaleToCurrency(*baseSum, ccy),
+			Value:      roundToCurrency(*baseSum, ccy).String(),
 			CurrencyID: &ccy,
 		}
 	}
@@ -394,7 +386,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 		ac := &AllowanceCharge{
 			ChargeIndicator: true,
 			Amount: Amount{
-				Value:      rescaleToCurrency(ch.Amount, ccy),
+				Value:      roundToCurrency(ch.Amount, ccy).String(),
 				CurrencyID: &ccy,
 			},
 		}
@@ -420,7 +412,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 		ac := &AllowanceCharge{
 			ChargeIndicator: false,
 			Amount: Amount{
-				Value:      rescaleToCurrency(d.Amount, ccy),
+				Value:      roundToCurrency(d.Amount, ccy).String(),
 				CurrencyID: &ccy,
 			},
 		}

--- a/payment.go
+++ b/payment.go
@@ -196,11 +196,8 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 	if ref := instr.Ref.String(); ref != "" {
 		ui.PaymentMeans[0].PaymentID = &ref
 	}
-	// OIOUBL PaymentChannelCode (IBAN / DK:GIRO / DK:FIK, F-LIB155/F-LIB277) is
-	// precomputed by the dk-oioubl addon in the dk-oioubl-payment-channel
-	// extension. cbc:PaymentID is the dk-oioubl-payment-id "kortart" (overriding
-	// instr.Ref, the Peppol mapping); the FIK creditor account flows through the
-	// credit-transfer Number below (F-LIB305).
+	// The OIOUBL payment channel and PaymentID are precomputed by the dk-oioubl
+	// addon extensions; the converter emits them directly (see applyOIOUBL21PaymentID).
 	if ctx.Is(ContextOIOUBL21) {
 		if ch := instr.Ext.Get(oioubl.ExtKeyPaymentChannel).String(); ch != "" && ui.PaymentMeans[0].PaymentChannelCode == nil {
 			ui.PaymentMeans[0].PaymentChannelCode = &IDType{Value: ch}

--- a/test/data/convert/oioubl21/fractional-quantity-multiline.json
+++ b/test/data/convert/oioubl21/fractional-quantity-multiline.json
@@ -1,0 +1,209 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "6ab3d96a74e6679919e216b65c7e0cf977ff5f91e553dea4e2b27310a0eae75f"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017",
+			"dk-oioubl-v2-1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "FINAL",
+		"code": "FQM01",
+		"issue_date": "2026-05-29",
+		"currency": "DKK",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Eksempel Software ApS",
+			"tax_id": {
+				"country": "DK",
+				"code": "12345674"
+			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "12345674",
+					"ext": {
+						"iso-scheme-id": "0184"
+					}
+				}
+			],
+			"people": [
+				{
+					"name": {
+						"given": "Jens",
+						"surname": "Hansen"
+					}
+				}
+			],
+			"inboxes": [
+				{
+					"scheme": "0184",
+					"code": "12345674"
+				}
+			],
+			"addresses": [
+				{
+					"num": "12",
+					"street": "Kongevejen",
+					"locality": "København",
+					"code": "2100",
+					"country": "DK"
+				}
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
+		},
+		"customer": {
+			"name": "Modtager Handel A/S",
+			"tax_id": {
+				"country": "DK",
+				"code": "76543216"
+			},
+			"identities": [
+				{
+					"scope": "legal",
+					"code": "76543216",
+					"ext": {
+						"iso-scheme-id": "0184"
+					}
+				}
+			],
+			"people": [
+				{
+					"name": {
+						"given": "Mette",
+						"surname": "Sørensen"
+					},
+					"identities": [
+						{
+							"label": "Contact",
+							"code": "C-001"
+						}
+					]
+				}
+			],
+			"inboxes": [
+				{
+					"scheme": "0184",
+					"code": "76543216"
+				}
+			],
+			"addresses": [
+				{
+					"num": "45",
+					"street": "Vestergade",
+					"locality": "Aarhus",
+					"code": "8000",
+					"country": "DK"
+				}
+			],
+			"ext": {
+				"dk-oioubl-address-scheme": "DK:CVR"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1.5",
+				"item": {
+					"name": "Materiale A (kg)",
+					"price": "12.344",
+					"unit": "kg"
+				},
+				"sum": "18.516",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"dk-oioubl-tax-category": "StandardRated",
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "18.516"
+			},
+			{
+				"i": 2,
+				"quantity": "1.5",
+				"item": {
+					"name": "Materiale B (kg)",
+					"price": "12.344",
+					"unit": "kg"
+				},
+				"sum": "18.516",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "25%",
+						"ext": {
+							"dk-oioubl-tax-category": "StandardRated",
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "18.516"
+			}
+		],
+		"payment": {
+			"instructions": {
+				"key": "credit-transfer",
+				"ref": "TEST-007",
+				"credit_transfer": [
+					{
+						"iban": "DK5000400440116243",
+						"bic": "DABADKKK"
+					}
+				],
+				"ext": {
+					"dk-oioubl-payment-channel": "IBAN",
+					"untdid-payment-means": "31"
+				}
+			}
+		},
+		"totals": {
+			"sum": "37.03",
+			"total": "37.03",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"dk-oioubl-tax-category": "StandardRated",
+									"untdid-tax-category": "S"
+								},
+								"base": "37.03",
+								"percent": "25%",
+								"amount": "9.26"
+							}
+						],
+						"amount": "9.26"
+					}
+				],
+				"sum": "9.26"
+			},
+			"tax": "9.26",
+			"total_with_tax": "46.29",
+			"payable": "46.29"
+		}
+	}
+}

--- a/test/data/convert/oioubl21/out/fractional-quantity-multiline.xml
+++ b/test/data/convert/oioubl21/out/fractional-quantity-multiline.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
+  <cbc:ProfileID schemeAgencyID="320" schemeID="urn:oioubl:id:profileid-1.2">urn:www.nesubl.eu:profiles:profile5:ver2.0</cbc:ProfileID>
+  <cbc:ID>FINAL-FQM01</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2026-05-29</cbc:IssueDate>
+  <cbc:InvoiceTypeCode listAgencyID="320" listID="urn:oioubl:codelist:invoicetypecode-1.1">380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>DKK</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Eksempel Software ApS</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredLax</cbc:AddressFormatCode>
+        <cbc:StreetName>Kongevejen</cbc:StreetName>
+        <cbc:BuildingNumber>12</cbc:BuildingNumber>
+        <cbc:CityName>København</cbc:CityName>
+        <cbc:PostalZone>2100</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK12345674</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Eksempel Software ApS</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK12345674</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Jens Hansen</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="DK:CVR">DK76543216</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Modtager Handel A/S</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredLax</cbc:AddressFormatCode>
+        <cbc:StreetName>Vestergade</cbc:StreetName>
+        <cbc:BuildingNumber>45</cbc:BuildingNumber>
+        <cbc:CityName>Aarhus</cbc:CityName>
+        <cbc:PostalZone>8000</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID schemeID="DK:SE">DK76543216</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Modtager Handel A/S</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="DK:CVR">DK76543216</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>C-001</cbc:ID>
+        <cbc:Name>Mette Sørensen</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode>31</cbc:PaymentMeansCode>
+    <cbc:PaymentChannelCode listID="urn:oioubl:codelist:paymentchannelcode-1.1">IBAN</cbc:PaymentChannelCode>
+    <cbc:PaymentID>TEST-007</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>DK5000400440116243</cbc:ID>
+      <cac:FinancialInstitutionBranch>
+        <cac:FinancialInstitution>
+          <cbc:ID>DABADKKK</cbc:ID>
+        </cac:FinancialInstitution>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="DKK">9.26</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="DKK">37.03</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="DKK">9.26</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="DKK">37.04</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="DKK">9.26</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="DKK">46.30</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="DKK">46.30</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="KGM">1.5</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="DKK">18.52</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="DKK">4.63</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="DKK">18.52</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="DKK">4.63</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+            <cbc:Name>Moms</cbc:Name>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Materiale A (kg)</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="DKK">12.344</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="KGM">1.5</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="DKK">18.52</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="DKK">4.63</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="DKK">18.52</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="DKK">4.63</cbc:TaxAmount>
+        <cac:TaxCategory>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+          <cbc:Percent>25</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+            <cbc:Name>Moms</cbc:Name>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Materiale B (kg)</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
+        <cbc:Percent>25</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeAgencyID="320" schemeID="urn:oioubl:id:taxschemeid-1.1">63</cbc:ID>
+          <cbc:Name>Moms</cbc:Name>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="DKK">12.344</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>


### PR DESCRIPTION
Two behaviour-preserving cleanups in lines.go (goldens unchanged):

- Drop `rescaleToCurrency` — it was just `roundToCurrency(a, ccy).String()`; the four callers now call `roundToCurrency` directly.
- Rename `makeLineTaxTotals` → `makeOIOUBL21LineTaxTotals` and remove its dead non-OIOUBL branches + `ctx` param (its only caller is OIOUBL-gated).