### PR TITLE
Emit ZATCA BR-KSA-17 reason without payment instructions

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -11,7 +11,7 @@ import (
 
 // PaymentMeans represents the means of payment
 type PaymentMeans struct {
-	PaymentMeansCode      IDType            `xml:"cbc:PaymentMeansCode"`
+	PaymentMeansCode      *IDType           `xml:"cbc:PaymentMeansCode,omitempty"`
 	PaymentDueDate        *string           `xml:"cbc:PaymentDueDate"`
 	InstructionID         *string           `xml:"cbc:InstructionID"`
 	InstructionNote       []string          `xml:"cbc:InstructionNote,omitempty"`
@@ -71,8 +71,20 @@ func (ui *Invoice) addPayment(inv *bill.Invoice, ctx Context) error {
 	pymt := inv.Payment
 
 	if pymt.Instructions != nil {
-		if err := ui.addPaymentInstructions(inv, ctx); err != nil {
+		if err := ui.addPaymentInstructions(inv); err != nil {
 			return err
+		}
+	}
+
+	// BR-KSA-17: Debit and credit note must contain the reason for this
+	// invoice type issuing. Applies independently of payment instructions, so
+	// it runs after them and ensures a PaymentMeans exists to carry the notes.
+	if inv.Preceding != nil && ctx.Is(ContextZATCA) {
+		if len(ui.PaymentMeans) == 0 {
+			ui.PaymentMeans = []PaymentMeans{{}}
+		}
+		for _, ref := range inv.Preceding {
+			ui.PaymentMeans[0].InstructionNote = append(ui.PaymentMeans[0].InstructionNote, ref.Reason)
 		}
 	}
 
@@ -104,7 +116,7 @@ func (ui *Invoice) addPayment(inv *bill.Invoice, ctx Context) error {
 	return nil
 }
 
-func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error {
+func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice) error {
 	instr := inv.Payment.Instructions
 	if instr.Ext.IsZero() || instr.Ext.Get(untdid.ExtKeyPaymentMeans).String() == "" {
 		return validation.Errors{
@@ -117,7 +129,7 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 	}
 	ui.PaymentMeans = []PaymentMeans{
 		{
-			PaymentMeansCode: IDType{Value: instr.Ext.Get(untdid.ExtKeyPaymentMeans).String()},
+			PaymentMeansCode: &IDType{Value: instr.Ext.Get(untdid.ExtKeyPaymentMeans).String()},
 		},
 	}
 	if ref := instr.Ref.String(); ref != "" {
@@ -153,13 +165,6 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 	if ui.CreditNoteTypeCode != nil && inv.Payment.Terms != nil && len(inv.Payment.Terms.DueDates) > 0 {
 		formattedDate := formatDate(*inv.Payment.Terms.DueDates[0].Date)
 		ui.PaymentMeans[0].PaymentDueDate = &formattedDate
-	}
-	// BR-KSA-17: Debit and credit note must contain the
-	// reason for this invoice type issuing.
-	if inv.Preceding != nil && ctx.Is(ContextZATCA) {
-		for _, ref := range inv.Preceding {
-			ui.PaymentMeans[0].InstructionNote = append(ui.PaymentMeans[0].InstructionNote, ref.Reason)
-		}
 	}
 	return nil
 }

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -72,7 +72,7 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice, o *options) error {
 		payment.Terms.DueDates[0].Percent = &percent
 	}
 
-	if len(ui.PaymentMeans) > 0 {
+	if len(ui.PaymentMeans) > 0 && ui.PaymentMeans[0].PaymentMeansCode != nil {
 		payment.Instructions = goblInvoiceInstructions(out, &ui.PaymentMeans[0])
 	}
 

--- a/test/data/convert/zatca/credit-note-no-payment-instructions.json
+++ b/test/data/convert/zatca/credit-note-no-payment-instructions.json
@@ -1,0 +1,153 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "1145188f18fc716a88a6ce279e40ddf53757a3041eeb636f241d111cd284c3c9"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "SA",
+		"$addons": [
+			"eu-en16931-v2017",
+			"sa-zatca-v1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "credit-note",
+		"series": "SAMPLE-CN",
+		"code": "0001",
+		"issue_date": "2026-06-30",
+		"issue_time": "18:06:03",
+		"currency": "ARS",
+		"preceding": [
+			{
+				"type": "standard",
+				"issue_date": "2026-06-30",
+				"series": "SAMPLE",
+				"code": "1",
+				"reason": "Order change"
+			}
+		],
+		"tax": {
+			"rounding": "currency",
+			"ext": {
+				"sa-zatca-invoice-type": "0100000",
+				"untdid-document-type": "381"
+			}
+		},
+		"supplier": {
+			"uuid": "0c9aebea-a0e2-411e-b2dc-c5a689623fa7",
+			"name": "Acme Industries Est.",
+			"tax_id": {
+				"country": "SA",
+				"code": "399999999900003"
+			},
+			"identities": [
+				{
+					"type": "CRN",
+					"code": "399999999900003"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1234",
+					"street": "King Fahd Road",
+					"street_extra": "Al Olaya",
+					"locality": "Riyadh",
+					"code": "12345",
+					"country": "SA"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"uuid": "300fcb2c-65c4-41c3-9a7d-3b566f0359eb",
+			"name": "Global Buyer Co.",
+			"tax_id": {
+				"country": "SA",
+				"code": "399999999900043"
+			},
+			"addresses": [
+				{
+					"num": "1234",
+					"street": "Prince Sultan Road",
+					"street_extra": "Al Malaz",
+					"locality": "Riyadh",
+					"code": "12345",
+					"country": "SA"
+				}
+			],
+			"emails": [
+				{
+					"addr": "info@example.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"uuid": "cc624cd2-b159-4a12-a1f2-b398acb1a846",
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Consulting service",
+					"currency": "ARS",
+					"price": "10.00",
+					"unit": "one"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "15%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"notes": "Credit note"
+			}
+		},
+		"delivery": {
+			"date": "2026-06-30"
+		},
+		"totals": {
+			"sum": "10.00",
+			"total": "10.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "10.00",
+								"percent": "15%",
+								"amount": "1.50"
+							}
+						],
+						"amount": "1.50"
+					}
+				],
+				"sum": "1.50"
+			},
+			"tax": "1.50",
+			"total_with_tax": "11.50",
+			"payable": "11.50"
+		}
+	}
+}

--- a/test/data/convert/zatca/out/credit-note-no-payment-instructions.xml
+++ b/test/data/convert/zatca/out/credit-note-no-payment-instructions.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:zatca.gov.sa:e-invoicing:1.0</cbc:CustomizationID>
+  <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+  <cbc:ID>SAMPLE-CN-0001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2026-06-30</cbc:IssueDate>
+  <cbc:IssueTime>18:06:03</cbc:IssueTime>
+  <cbc:InvoiceTypeCode name="0100000">381</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>ARS</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>SAMPLE-1</cbc:ID>
+      <cbc:IssueDate>2026-06-30</cbc:IssueDate>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">399999999900003</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Acme Industries Est.</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>King Fahd Road 1234</cbc:StreetName>
+        <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+        <cbc:CitySubdivisionName>Al Olaya</cbc:CitySubdivisionName>
+        <cbc:CityName>Riyadh</cbc:CityName>
+        <cbc:PostalZone>12345</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>399999999900003</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Acme Industries Est.</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>billing@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>Global Buyer Co.</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Prince Sultan Road 1234</cbc:StreetName>
+        <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+        <cbc:CitySubdivisionName>Al Malaz</cbc:CitySubdivisionName>
+        <cbc:CityName>Riyadh</cbc:CityName>
+        <cbc:PostalZone>12345</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>399999999900043</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Global Buyer Co.</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>info@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cbc:ActualDeliveryDate>2026-06-30</cbc:ActualDeliveryDate>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:InstructionNote>Order change</cbc:InstructionNote>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Credit note</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="ARS">1.50</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="ARS">10.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="ARS">1.50</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="ARS">10.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="ARS">10.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="ARS">11.50</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="ARS">11.50</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="ARS">10.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="ARS">1.50</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="ARS">11.50</cbc:RoundingAmount>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Consulting service</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="ARS">10.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/parse/zatca/credit-note-no-payment-instructions.xml
+++ b/test/data/parse/zatca/credit-note-no-payment-instructions.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:zatca.gov.sa:e-invoicing:1.0</cbc:CustomizationID>
+  <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+  <cbc:ID>SAMPLE-CN-0001</cbc:ID>
+  <cbc:UUID>0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2</cbc:UUID>
+  <cbc:IssueDate>2026-06-30</cbc:IssueDate>
+  <cbc:IssueTime>18:06:03</cbc:IssueTime>
+  <cbc:InvoiceTypeCode name="0100000">381</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>ARS</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>NA</cbc:ID>
+  </cac:OrderReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>SAMPLE-1</cbc:ID>
+      <cbc:IssueDate>2026-06-30</cbc:IssueDate>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="CRN">399999999900003</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>Acme Industries Est.</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>King Fahd Road 1234</cbc:StreetName>
+        <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+        <cbc:CitySubdivisionName>Al Olaya</cbc:CitySubdivisionName>
+        <cbc:CityName>Riyadh</cbc:CityName>
+        <cbc:PostalZone>12345</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>399999999900003</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Acme Industries Est.</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>billing@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>Global Buyer Co.</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Prince Sultan Road 1234</cbc:StreetName>
+        <cbc:BuildingNumber>1234</cbc:BuildingNumber>
+        <cbc:CitySubdivisionName>Al Malaz</cbc:CitySubdivisionName>
+        <cbc:CityName>Riyadh</cbc:CityName>
+        <cbc:PostalZone>12345</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SA</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>399999999900043</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Global Buyer Co.</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>info@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cbc:ActualDeliveryDate>2026-06-30</cbc:ActualDeliveryDate>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:InstructionNote>Order change</cbc:InstructionNote>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Credit note</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="ARS">1.50</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="ARS">10.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="ARS">1.50</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="ARS">10.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="ARS">10.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="ARS">11.50</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="ARS">11.50</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="ARS">10.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="ARS">1.50</cbc:TaxAmount>
+      <cbc:RoundingAmount currencyID="ARS">11.50</cbc:RoundingAmount>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Name>Consulting service</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>15</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="ARS">10.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/test/data/parse/zatca/out/credit-note-no-payment-instructions.json
+++ b/test/data/parse/zatca/out/credit-note-no-payment-instructions.json
@@ -1,0 +1,153 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "4de3fd5572039aab558ac035f12913c9054c7fc7d8a0041d427074d991f08284"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "SA",
+		"$addons": [
+			"eu-en16931-v2017",
+			"sa-zatca-v1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "credit-note",
+		"code": "SAMPLE-CN-0001",
+		"issue_date": "2026-06-30",
+		"issue_time": "18:06:03",
+		"currency": "ARS",
+		"preceding": [
+			{
+				"issue_date": "2026-06-30",
+				"code": "SAMPLE-1",
+				"reason": "Order change"
+			}
+		],
+		"tax": {
+			"rounding": "currency",
+			"ext": {
+				"sa-zatca-invoice-type": "0100000",
+				"untdid-document-type": "381"
+			}
+		},
+		"supplier": {
+			"name": "Acme Industries Est.",
+			"tax_id": {
+				"country": "SA",
+				"code": "399999999900003"
+			},
+			"identities": [
+				{
+					"type": "CRN",
+					"code": "399999999900003"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1234",
+					"street": "King Fahd Road 1234",
+					"street_extra": "Al Olaya",
+					"locality": "Riyadh",
+					"code": "12345",
+					"country": "SA"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Global Buyer Co.",
+			"tax_id": {
+				"country": "SA",
+				"code": "399999999900043"
+			},
+			"addresses": [
+				{
+					"num": "1234",
+					"street": "Prince Sultan Road 1234",
+					"street_extra": "Al Malaz",
+					"locality": "Riyadh",
+					"code": "12345",
+					"country": "SA"
+				}
+			],
+			"emails": [
+				{
+					"addr": "info@example.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Consulting service",
+					"price": "10.00",
+					"unit": "one"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"percent": "15%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"ordering": {
+			"purchases": [
+				{
+					"code": "NA"
+				}
+			]
+		},
+		"payment": {
+			"terms": {
+				"notes": "Credit note"
+			}
+		},
+		"delivery": {
+			"date": "2026-06-30"
+		},
+		"totals": {
+			"sum": "10.00",
+			"total": "10.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "10.00",
+								"percent": "15%",
+								"amount": "1.50"
+							}
+						],
+						"amount": "1.50"
+					}
+				],
+				"sum": "1.50"
+			},
+			"tax": "1.50",
+			"total_with_tax": "11.50",
+			"payable": "11.50"
+		}
+	}
+}


### PR DESCRIPTION
Emit the ZATCA BR-KSA-17 preceding-document reason for debit/credit notes even when the invoice has no payment instructions.

Changes:
- Move the BR-KSA-17 InstructionNote logic into addPayment (independent of instructions)
- Make PaymentMeans.PaymentMeansCode a *IDType with omitempty (no empty element)
- On parse, only build payment instructions when a PaymentMeansCode is present
- Add convert + parse round-trip fixtures for the no-instructions case

🤖 Generated with [Claude Code](https://claude.com/claude-code)