### PR TITLE
fix(cli): convert UBL XML to a GOBL envelope, not the raw struct

### DIFF
--- a/cmd/gobl.ubl/convert.go
+++ b/cmd/gobl.ubl/convert.go
@@ -72,7 +72,21 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 	} else {
 		// Assume XML if not JSON
 
-		env, err := ubl.Parse(inData)
+		doc, err := ubl.Parse(inData)
+		if err != nil {
+			return fmt.Errorf("building GOBL envelope: %w", err)
+		}
+
+		// Every supported UBL document (Invoice, ApplicationResponse, Reminder)
+		// converts back to a GOBL envelope through this method.
+		conv, ok := doc.(interface {
+			Convert() (*gobl.Envelope, error)
+		})
+		if !ok {
+			return fmt.Errorf("building GOBL envelope: %w", ubl.ErrUnsupportedDocumentType)
+		}
+
+		env, err := conv.Convert()
 		if err != nil {
 			return fmt.Errorf("building GOBL envelope: %w", err)
 		}

--- a/cmd/gobl.ubl/convert.go
+++ b/cmd/gobl.ubl/convert.go
@@ -77,7 +77,7 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("building GOBL envelope: %w", err)
 		}
 
-		// Every supported UBL document (Invoice, ApplicationResponse, Reminder)
+		// Every supported UBL document type
 		// converts back to a GOBL envelope through this method.
 		conv, ok := doc.(interface {
 			Convert() (*gobl.Envelope, error)

--- a/cmd/gobl.ubl/convert.go
+++ b/cmd/gobl.ubl/convert.go
@@ -14,6 +14,12 @@ type convertOpts struct {
 	*rootOpts
 }
 
+// converter is implemented by every supported UBL document type that
+// ubl.Parse can return; each converts back to a GOBL envelope.
+type converter interface {
+	Convert() (*gobl.Envelope, error)
+}
+
 func convert(o *rootOpts) *convertOpts {
 	return &convertOpts{rootOpts: o}
 }
@@ -77,11 +83,7 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("building GOBL envelope: %w", err)
 		}
 
-		// Every supported UBL document type
-		// converts back to a GOBL envelope through this method.
-		conv, ok := doc.(interface {
-			Convert() (*gobl.Envelope, error)
-		})
+		conv, ok := doc.(converter)
 		if !ok {
 			return fmt.Errorf("building GOBL envelope: %w", ubl.ErrUnsupportedDocumentType)
 		}

--- a/cmd/gobl.ubl/convert.go
+++ b/cmd/gobl.ubl/convert.go
@@ -14,12 +14,6 @@ type convertOpts struct {
 	*rootOpts
 }
 
-// converter is implemented by every supported UBL document type that
-// ubl.Parse can return; each converts back to a GOBL envelope.
-type converter interface {
-	Convert() (*gobl.Envelope, error)
-}
-
 func convert(o *rootOpts) *convertOpts {
 	return &convertOpts{rootOpts: o}
 }
@@ -83,12 +77,12 @@ func (c *convertOpts) runE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("building GOBL envelope: %w", err)
 		}
 
-		conv, ok := doc.(converter)
+		inv, ok := doc.(*ubl.Invoice)
 		if !ok {
 			return fmt.Errorf("building GOBL envelope: %w", ubl.ErrUnsupportedDocumentType)
 		}
 
-		env, err := conv.Convert()
+		env, err := inv.Convert()
 		if err != nil {
 			return fmt.Errorf("building GOBL envelope: %w", err)
 		}

--- a/cmd/gobl.ubl/convert_test.go
+++ b/cmd/gobl.ubl/convert_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/bill"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertCommand(t *testing.T) {
+	t.Run("UBL XML input converts to a GOBL envelope", func(t *testing.T) {
+		out := runConvert(t, "../../test/data/parse/en16931/ubl-example1.xml")
+
+		// Regression for #99: the XML branch must return a GOBL envelope, not
+		// the raw parsed *ubl.Invoice struct (whose JSON has CACNamespace etc.).
+		require.Contains(t, out, "https://gobl.org/draft-0/envelope")
+		require.NotContains(t, out, "CACNamespace")
+
+		env := new(gobl.Envelope)
+		require.NoError(t, json.Unmarshal([]byte(out), env))
+		assert.Equal(t, "https://gobl.org/draft-0/envelope", string(env.Schema))
+		_, ok := env.Extract().(*bill.Invoice)
+		assert.True(t, ok, "envelope should wrap a bill.Invoice")
+	})
+
+	t.Run("GOBL JSON input converts to a UBL document", func(t *testing.T) {
+		out := runConvert(t, "../../test/data/parse/en16931/out/ubl-example1.json")
+		assert.Contains(t, out, "<Invoice")
+	})
+}
+
+// runConvert runs `gobl.ubl convert <infile>`, capturing stdout.
+func runConvert(t *testing.T, infile string) string {
+	t.Helper()
+	cmd := root().cmd()
+	cmd.SetArgs([]string{"convert", infile})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Execute())
+	return out.String()
+}


### PR DESCRIPTION
## What

`gobl.ubl convert invoice.xml out.json` (UBL XML → GOBL) exits 0 and writes valid JSON, but that JSON is the internal parsed struct (`XMLName`, `CACNamespace`, `CBCNamespace`, …) rather than a GOBL envelope. There is no error to signal the output is wrong.

The cause: the XML branch marshals the result of `ubl.Parse` directly. Per `ubl.Parse`'s own doc comment it only returns the raw parsed UBL document — a `Convert()` call is required to build the `*gobl.Envelope`.

## Fix

Route the parsed document through its `Convert()` method before marshalling, so the CLI emits a proper GOBL envelope (matching what `gobl.cii` already does).

This is the standalone port of the `cmd/gobl.ubl/convert.go` hunk from #81 onto `main`, as requested in #99. The fix currently only lives behind the still-open #73/#83, so no tagged release contains it.

## Verification

Before (main): output starts with `"XMLName"`, `"CACNamespace"`, …
After: output starts with `"$schema": "https://gobl.org/draft-0/envelope"`.

Fixes #99