### PR TITLE
Ordering TaxPointDate before CreditNoteTypeCode in credit-note output

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -20,6 +20,9 @@ const (
 	NamespaceUBLCreditNote = "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2"
 )
 
+// rootNameCreditNote is the XML root element local name of a UBL Credit Note.
+const rootNameCreditNote = "CreditNote"
+
 // Schema locationa and customization constants
 const (
 	SchemaLocationInvoice     = "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd"
@@ -169,7 +172,7 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 	}
 
 	if docType.In(bill.InvoiceTypeCreditNote) {
-		out.XMLName = xml.Name{Local: "CreditNote"}
+		out.XMLName = xml.Name{Local: rootNameCreditNote}
 		out.UBLNamespace = NamespaceUBLCreditNote
 		out.SchemaLocation = SchemaLocationCrediteNote
 		out.InvoiceTypeCode = nil
@@ -272,7 +275,7 @@ func ConvertInvoice(env *gobl.Envelope, opts ...Option) (*Invoice, error) {
 // based on XML name instead of gobl's invoice type key
 func (ui *Invoice) getInvoiceTypeBasedOnXMLName() cbc.Key {
 	switch ui.XMLName.Local {
-	case "CreditNote":
+	case rootNameCreditNote:
 		return bill.InvoiceTypeCreditNote
 	default:
 		return bill.InvoiceTypeStandard

--- a/test/data/convert/peppol/credit-note-taxpoint.json
+++ b/test/data/convert/peppol/credit-note-taxpoint.json
@@ -1,0 +1,185 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"dig": {
+			"alg": "sha256",
+			"val": "c4157b2872c2f1c5c2ad953118d5244eecb99c75205d938a0dbd9aae315dc250"
+		},
+		"from": "iso6523-actorid-upis::9930:111111125",
+		"to": "iso6523-actorid-upis::9920:282741168"
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "BE",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "credit-note",
+		"series": "CN",
+		"code": "002",
+		"issue_date": "2024-02-14",
+		"value_date": "2024-02-10",
+		"currency": "EUR",
+		"preceding": [
+			{
+				"issue_date": "2024-02-05",
+				"series": "F",
+				"code": "001",
+				"ext": {
+					"untdid-document-type": "380"
+				}
+			}
+		],
+		"tax": {
+			"ext": {
+				"untdid-document-type": "381"
+			}
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"tax_id": {
+				"country": "DE",
+				"code": "111111125"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "John",
+						"surname": "Doe"
+					}
+				}
+			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::9930:111111125"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "9930",
+					"code": "111111125"
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "+49100200300"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "LU",
+				"code": "282741168"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::9920:282741168"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "9920",
+					"code": "282741168"
+				}
+			],
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1800.00"
+			}
+		],
+		"ordering": {
+			"code": "XR-2024-4"
+		},
+		"payment": {
+			"terms": {
+				"due_dates": [
+					{
+						"date": "2024-03-15",
+						"amount": "2142.00"
+					}
+				],
+				"notes": "lorem ipsum"
+			}
+		},
+		"totals": {
+			"sum": "1800.00",
+			"total": "1800.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1800.00",
+								"percent": "21.0%",
+								"amount": "378.00"
+							}
+						],
+						"amount": "378.00"
+					}
+				],
+				"sum": "378.00"
+			},
+			"tax": "378.00",
+			"total_with_tax": "2178.00",
+			"payable": "2178.00"
+		}
+	}
+}

--- a/test/data/convert/peppol/out/credit-note-taxpoint.xml
+++ b/test/data/convert/peppol/out/credit-note-taxpoint.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CreditNote xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDataTypes-2" xmlns:udt="urn:oasis:names:specification:ubl:schema:xsd:UnqualifiedDataTypes-2" xmlns:ccts="urn:un:unece:uncefact:documentation:2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2 https://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-CreditNote-2.1.xsd">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>CN-002</cbc:ID>
+  <cbc:IssueDate>2024-02-14</cbc:IssueDate>
+  <cbc:TaxPointDate>2024-02-10</cbc:TaxPointDate>
+  <cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>XR-2024-4</cbc:BuyerReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>F-001</cbc:ID>
+      <cbc:IssueDate>2024-02-05</cbc:IssueDate>
+      <cbc:DocumentTypeCode>380</cbc:DocumentTypeCode>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9930">111111125</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Provide One GmbH</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Dietmar-Hopp-Allee 16</cbc:StreetName>
+        <cbc:CityName>Walldorf</cbc:CityName>
+        <cbc:PostalZone>69190</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>DE111111125</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Provide One GmbH</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>John Doe</cbc:Name>
+        <cbc:Telephone>+49100200300</cbc:Telephone>
+        <cbc:ElectronicMail>billing@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9920">282741168</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Sample Consumer</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Werner-Heisenberg-Allee 25</cbc:StreetName>
+        <cbc:CityName>München</cbc:CityName>
+        <cbc:PostalZone>80939</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>LU282741168</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Sample Consumer</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ElectronicMail>email@sample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentTerms>
+    <cbc:Note>lorem ipsum</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">378.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">1800.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">378.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">1800.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2178.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">2178.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:CreditNoteLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:CreditedQuantity unitCode="HUR">20</cbc:CreditedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">1800.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Name>Development services</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">90.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:CreditNoteLine>
+</CreditNote>

--- a/ubl.go
+++ b/ubl.go
@@ -179,6 +179,10 @@ func Bytes(in any) ([]byte, error) {
 	// Go's xml.Marshal encodes single quotes as &#39,
 	// this is a quick fix
 	b = bytes.ReplaceAll(b, []byte("&#39;"), []byte("'"))
+
+	if creditNoteNeedsTaxPointDateReorder(in) {
+		b = reorderCreditNoteTaxPointDate(b)
+	}
 	return append([]byte(xml.Header), b...), nil
 }
 
@@ -190,5 +194,79 @@ func BytesCompact(in any) ([]byte, error) {
 		return nil, err
 	}
 	b = bytes.ReplaceAll(b, []byte("&#39;"), []byte("'"))
+
+	if creditNoteNeedsTaxPointDateReorder(in) {
+		b = reorderCreditNoteTaxPointDate(b)
+	}
 	return append([]byte(xml.Header), b...), nil
+}
+
+// creditNoteNeedsTaxPointDateReorder reports whether in is a credit note
+// carrying a cbc:TaxPointDate, which the CreditNote XSD sequences differently
+// from the shared Invoice struct — see reorderCreditNoteTaxPointDate.
+func creditNoteNeedsTaxPointDateReorder(in any) bool {
+	var inv *Invoice
+	switch v := in.(type) {
+	case *Invoice:
+		inv = v
+	case Invoice:
+		inv = &v
+	default:
+		return false
+	}
+	return inv != nil && inv.XMLName.Local == "CreditNote" && inv.TaxPointDate != ""
+}
+
+// reorderCreditNoteTaxPointDate moves cbc:TaxPointDate ahead of
+// cbc:CreditNoteTypeCode to match the CreditNote XSD sequence. Invoice and
+// CreditNote share one Go struct, and encoding/xml can neither vary field order
+// per struct nor survive a decode/re-encode (it mangles the cac:/cbc: prefixes),
+// so the fix edits the marshaled bytes directly.
+func reorderCreditNoteTaxPointDate(b []byte) []byte {
+	const (
+		open     = "<cbc:TaxPointDate>"
+		closeTag = "</cbc:TaxPointDate>"
+		typeCode = "<cbc:CreditNoteTypeCode"
+	)
+
+	tpd := bytes.Index(b, []byte(open))
+	tc := bytes.Index(b, []byte(typeCode))
+	if tpd < 0 || tc < 0 || tpd < tc {
+		return b // type code absent, or already correctly ordered
+	}
+	rel := bytes.Index(b[tpd:], []byte(closeTag))
+	if rel < 0 {
+		return b
+	}
+	elemEnd := tpd + rel + len(closeTag)
+	elem := append([]byte(nil), b[tpd:elemEnd]...)
+
+	// Drop the element together with the newline + indent that preceded it.
+	cut := tpd
+	for cut > 0 && (b[cut-1] == ' ' || b[cut-1] == '\t') {
+		cut--
+	}
+	if cut > 0 && b[cut-1] == '\n' {
+		cut--
+	}
+	rest := append(append([]byte(nil), b[:cut]...), b[elemEnd:]...)
+
+	// Re-insert it before the type code, reusing that line's leading whitespace
+	// (empty for the compact, non-indented output).
+	tc = bytes.Index(rest, []byte(typeCode))
+	indentStart := tc
+	for indentStart > 0 && (rest[indentStart-1] == ' ' || rest[indentStart-1] == '\t') {
+		indentStart--
+	}
+	if indentStart > 0 && rest[indentStart-1] == '\n' {
+		indentStart--
+	}
+	sep := rest[indentStart:tc]
+
+	out := make([]byte, 0, len(rest)+len(elem)+len(sep))
+	out = append(out, rest[:tc]...)
+	out = append(out, elem...)
+	out = append(out, sep...)
+	out = append(out, rest[tc:]...)
+	return out
 }

--- a/ubl.go
+++ b/ubl.go
@@ -214,7 +214,7 @@ func creditNoteNeedsTaxPointDateReorder(in any) bool {
 	default:
 		return false
 	}
-	return inv != nil && inv.XMLName.Local == "CreditNote" && inv.TaxPointDate != ""
+	return inv != nil && inv.XMLName.Local == rootNameCreditNote && inv.TaxPointDate != ""
 }
 
 // reorderCreditNoteTaxPointDate moves cbc:TaxPointDate ahead of


### PR DESCRIPTION
## BUG — credit notes with a `TaxPointDate` are XSD-invalid

### Symptom
Any UBL credit note that carries a `cbc:TaxPointDate` (mapped from GOBL `inv.ValueDate`) is generated with the element in the **wrong position** and fails UBL XSD validation. This affects **all contexts that emit credit notes** (Peppol, EN 16931, …) — it is not context-specific.

### Root cause
`Invoice` and `CreditNote` share a single Go struct, whose field order is fixed. In that struct `CreditNoteTypeCode` precedes `TaxPointDate`, which is correct for the **Invoice** XSD but wrong for the **CreditNote** XSD:

| | UBL-Invoice-2.1.xsd | UBL-CreditNote-2.1.xsd |
|---|---|---|
| order | …`InvoiceTypeCode` → `TaxPointDate` | `TaxPointDate` → `CreditNoteTypeCode` |

`encoding/xml` emits fields in the single struct order, so a credit note places `TaxPointDate` after `CreditNoteTypeCode` — violating the CreditNote sequence.

### Proof (on `main`, before this change)
Generating a standard Peppol/EN 16931 credit note with a `value_date` and validating via phive (`eu.peppol.bis3:creditnote:2025.5`):

```
validation_type: "xsd"  →  external/schemas/ubl21/maindoc/UBL-CreditNote-2.1.xsd
cvc-complex-type.2.4.a: Invalid content was found starting with element 'TaxPointDate'.
One of '{Note, DocumentCurrencyCode, TaxCurrencyCode, ...}' is expected.
```

The CEN-EN16931 and PEPPOL-EN16931 **schematron** layers pass — the failure is purely the **XSD sequence**.

### Fix
`Bytes`/`BytesCompact` post-process the marshaled output: when the document is a credit note carrying a `TaxPointDate`, move that element ahead of `CreditNoteTypeCode` to match the CreditNote XSD sequence. The reorder edits bytes directly because `encoding/xml` can neither vary field order per struct nor survive a decode/re-encode (it mangles the `cac:`/`cbc:` prefixes).

After the fix the same document is phive-green (`TaxPointDate` on the line before `CreditNoteTypeCode`).

### Test
Adds `test/data/convert/peppol/credit-note-taxpoint.json` (+ golden), a standard Peppol/EN 16931 credit note with a `value_date`, which is phive-valid with the fix and reproduces the failure without it.

### Notes
- The same fix is also present in the in-flight OIOUBL PR #73 (where it was first noticed); this PR lands it as a standalone generic fix against `main` since the bug pre-dates and is independent of OIOUBL.
- The reproduction GOBL is saved for console verification.
