### PR TITLE
Deriving OIOUBL address/endpoint/kortart in the converter (extension cleanup)

### DIFF
--- a/excise.go
+++ b/excise.go
@@ -65,7 +65,7 @@ func collectOIOUBL21Excise(inv *bill.Invoice, currency string) []oioubl21Excise 
 	var out []oioubl21Excise
 	for _, ch := range inv.Charges {
 		if s := chargeExciseScheme(ch.Key); s != "" {
-			out = append(out, oioubl21Excise{scheme: s, name: ch.Reason, amount: roundToCurrency(ch.Amount, currency)})
+			out = append(out, oioubl21Excise{scheme: s, name: ch.Reason, amount: rescaleToCurrency(ch.Amount, currency)})
 		}
 	}
 	for _, l := range inv.Lines {
@@ -81,7 +81,7 @@ func collectLineExcise(line *bill.Line, currency string) []oioubl21Excise {
 	var out []oioubl21Excise
 	for _, ch := range line.Charges {
 		if s := chargeExciseScheme(ch.Key); s != "" {
-			out = append(out, oioubl21Excise{scheme: s, name: ch.Reason, amount: roundToCurrency(ch.Amount, currency)})
+			out = append(out, oioubl21Excise{scheme: s, name: ch.Reason, amount: rescaleToCurrency(ch.Amount, currency)})
 		}
 	}
 	return out

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
-	github.com/invopop/gobl.dk.oioubl v0.0.0-20260702172313-ed48dc2cc4e3
+	github.com/invopop/gobl.dk.oioubl v0.0.0-20260702183758-684460de0055
 	github.com/invopop/gobl.fr.ctc v0.0.4
 	github.com/invopop/gobl.sa.zatca v0.0.2
 	github.com/invopop/phive v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	cloud.google.com/go v0.118.0
-	github.com/invopop/gobl.dk.oioubl v0.0.0-20260701152827-d8a4efdeb7db
+	github.com/invopop/gobl.dk.oioubl v0.0.0-20260702172313-ed48dc2cc4e3
 	github.com/invopop/gobl.fr.ctc v0.0.4
 	github.com/invopop/gobl.sa.zatca v0.0.2
 	github.com/invopop/phive v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/invopop/gobl.dk.oioubl v0.0.0-20260701152827-d8a4efdeb7db h1:4py8+6X/
 github.com/invopop/gobl.dk.oioubl v0.0.0-20260701152827-d8a4efdeb7db/go.mod h1:FAUQaukiNS7xTtmmF1gBoI70rKvK4pQ6JyLPnEjsbng=
 github.com/invopop/gobl.dk.oioubl v0.0.0-20260702172313-ed48dc2cc4e3 h1:4HjfWydJ1VMfDxB+OcZhZyG//PHiEUUOkcy1a8yJdlw=
 github.com/invopop/gobl.dk.oioubl v0.0.0-20260702172313-ed48dc2cc4e3/go.mod h1:FAUQaukiNS7xTtmmF1gBoI70rKvK4pQ6JyLPnEjsbng=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260702183758-684460de0055 h1:OrwTkNg9aBjm+0iPHMWyGeV+6q1AwnK7CJgcuAI3V1s=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260702183758-684460de0055/go.mod h1:FAUQaukiNS7xTtmmF1gBoI70rKvK4pQ6JyLPnEjsbng=
 github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
 github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/gobl.sa.zatca v0.0.2 h1:qU2Y0LP+4mjvZkuG1TOUp/Zs0XxRAzkzQFHy3WOVFEU=

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/invopop/gobl.dk.oioubl v0.0.0-20260701143213-cba81e4bb5c9 h1:QVxMdfz3
 github.com/invopop/gobl.dk.oioubl v0.0.0-20260701143213-cba81e4bb5c9/go.mod h1:FAUQaukiNS7xTtmmF1gBoI70rKvK4pQ6JyLPnEjsbng=
 github.com/invopop/gobl.dk.oioubl v0.0.0-20260701152827-d8a4efdeb7db h1:4py8+6X/7WPAZ3MVMUhHCX5Xk2RufIZMAT0FvZ5Dew8=
 github.com/invopop/gobl.dk.oioubl v0.0.0-20260701152827-d8a4efdeb7db/go.mod h1:FAUQaukiNS7xTtmmF1gBoI70rKvK4pQ6JyLPnEjsbng=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260702172313-ed48dc2cc4e3 h1:4HjfWydJ1VMfDxB+OcZhZyG//PHiEUUOkcy1a8yJdlw=
+github.com/invopop/gobl.dk.oioubl v0.0.0-20260702172313-ed48dc2cc4e3/go.mod h1:FAUQaukiNS7xTtmmF1gBoI70rKvK4pQ6JyLPnEjsbng=
 github.com/invopop/gobl.fr.ctc v0.0.4 h1:x4eJ3hp9Y9lTCzWFhNqZYm9kCXyuC34EytOuaU03faE=
 github.com/invopop/gobl.fr.ctc v0.0.4/go.mod h1:YXJ0G7lCWxUehI4C2xBPL1y6rTNC29t/kOul7wY+3Xs=
 github.com/invopop/gobl.sa.zatca v0.0.2 h1:qU2Y0LP+4mjvZkuG1TOUp/Zs0XxRAzkzQFHy3WOVFEU=

--- a/invoice.go
+++ b/invoice.go
@@ -243,14 +243,6 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		applyOIOUBL21Party(out.PayeeParty)
 		applyOIOUBL21TaxRepParty(out.TaxRepresentativeParty)
 		// Reshape the supplier and customer addresses to their declared OIOUBL
-		// address format, after the party pass has derived the DK/ZZZ schemes from
-		// the address country (restricted formats drop it).
-		if p := out.AccountingSupplierParty.Party; p != nil {
-			applyOIOUBL21AddressFormat(p.PostalAddress, inv.Supplier)
-		}
-		if p := out.AccountingCustomerParty.Party; p != nil {
-			applyOIOUBL21AddressFormat(p.PostalAddress, inv.Customer)
-		}
 		out.applyOIOUBL21BillingReference()
 		out.applyOIOUBL21Attachments()
 		out.applyOIOUBL21Totals()

--- a/lines.go
+++ b/lines.go
@@ -51,7 +51,7 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 		// netted at the document level); other profiles use the net line total.
 		lineExt := l.Total.String()
 		if context.Is(ContextOIOUBL21) && l.Sum != nil {
-			lineExt = roundToCurrency(*l.Sum, ccy).String()
+			lineExt = rescaleToCurrency(*l.Sum, ccy).String()
 		}
 		invLine := InvoiceLine{
 			ID: strconv.Itoa(l.Index),
@@ -304,10 +304,10 @@ func applyOIOUBL21LineTaxCategories(lines []InvoiceLine) {
 	}
 }
 
-// roundToCurrency rounds the amount to the natural precision of the given
+// rescaleToCurrency rounds the amount to the natural precision of the given
 // currency code (e.g. 2 for EUR, 0 for JPY). Falls back to the amount's
 // existing precision if the currency code is unknown.
-func roundToCurrency(a num.Amount, ccy string) num.Amount {
+func rescaleToCurrency(a num.Amount, ccy string) num.Amount {
 	if def := currency.Code(ccy).Def(); def != nil {
 		return def.Rescale(a)
 	}
@@ -329,7 +329,7 @@ func makeOIOUBL21LineTaxTotals(line *bill.Line, ccy string) []TaxTotal {
 		// precision (l.Sum is the raw product); the discount is subtracted once
 		// at the document level (F-LIB402 sums gross line taxable amounts then
 		// adjusts for the document AllowanceCharge).
-		taxable = roundToCurrency(*line.Sum, ccy)
+		taxable = rescaleToCurrency(*line.Sum, ccy)
 	case line.Total != nil:
 		taxable = *line.Total
 	default:
@@ -341,7 +341,7 @@ func makeOIOUBL21LineTaxTotals(line *bill.Line, ccy string) []TaxTotal {
 	// the duty-inclusive amount and F-LIB402 reconciles without a charge bridge.
 	for _, ch := range line.Charges {
 		if chargeExciseScheme(ch.Key) != "" {
-			taxable = taxable.Add(roundToCurrency(ch.Amount, ccy))
+			taxable = taxable.Add(rescaleToCurrency(ch.Amount, ccy))
 		}
 	}
 
@@ -399,7 +399,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 	var base *Amount
 	if baseSum != nil {
 		base = &Amount{
-			Value:      roundToCurrency(*baseSum, ccy).String(),
+			Value:      rescaleToCurrency(*baseSum, ccy).String(),
 			CurrencyID: &ccy,
 		}
 	}
@@ -407,7 +407,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 		ac := &AllowanceCharge{
 			ChargeIndicator: true,
 			Amount: Amount{
-				Value:      roundToCurrency(ch.Amount, ccy).String(),
+				Value:      rescaleToCurrency(ch.Amount, ccy).String(),
 				CurrencyID: &ccy,
 			},
 		}
@@ -433,7 +433,7 @@ func makeLineCharges(charges []*bill.LineCharge, discounts []*bill.LineDiscount,
 		ac := &AllowanceCharge{
 			ChargeIndicator: false,
 			Amount: Amount{
-				Value:      roundToCurrency(d.Amount, ccy).String(),
+				Value:      rescaleToCurrency(d.Amount, ccy).String(),
 				CurrencyID: &ccy,
 			},
 		}

--- a/party.go
+++ b/party.go
@@ -419,114 +419,13 @@ func oioubl21AddressFormatCode(value string) *IDType {
 	}
 }
 
-// OIOUBL address extension keys and values, sourced from the dk-oioubl addon (the
-// single source of truth) so the converter and addon never drift. The converter
-// reads them as plain party extensions (GOBL has no address-level extension).
+// OIOUBL addressformatcode-1.1 values. Outbound the converter always emits
+// StructuredLax (it imposes no mandatory sub-fields); StructuredID is recognized
+// when parsing an inbound identifier-only address.
 const (
-	oioubl21AddressFormatKey = oioubl.ExtKeyAddressFormat
-
-	oioubl21AddressStructuredDK     = string(oioubl.ExtValueAddressFormatStructuredDK)
-	oioubl21AddressStructuredLax    = string(oioubl.ExtValueAddressFormatStructuredLax)
-	oioubl21AddressUnstructured     = string(oioubl.ExtValueAddressFormatUnstructured)
-	oioubl21AddressStructuredID     = string(oioubl.ExtValueAddressFormatStructuredID)
-	oioubl21AddressStructuredRegion = string(oioubl.ExtValueAddressFormatStructuredRegion)
-
-	// oioubl21AddressIDScheme (GLN) is the scheme OIOUBL mandates on a StructuredID
-	// address ID (F-LIB028/029); its GS1 agency is oioublGLNAgencyID.
-	oioubl21AddressIDScheme = string(oioubl.SchemeGLN)
+	oioubl21AddressStructuredLax = "StructuredLax"
+	oioubl21AddressStructuredID  = "StructuredID"
 )
-
-// applyOIOUBL21AddressFormat reshapes a party's postal address to its declared
-// dk-oioubl-address-format, dropping the elements each restricted format forbids
-// (F-LIB031/038/040). Must run after applyOIOUBL21Party, which needs the address
-// country before the restricted formats drop it.
-func applyOIOUBL21AddressFormat(addr *PostalAddress, party *org.Party) {
-	if addr == nil || party == nil {
-		return
-	}
-	format := party.Ext.Get(oioubl21AddressFormatKey)
-	if format == "" {
-		return
-	}
-	addr.AddressFormatCode = oioubl21AddressFormatCode(format.String())
-	switch format.String() {
-	case oioubl21AddressUnstructured:
-		// F-LIB031: an Unstructured address carries only AddressLine.
-		lines := oioubl21AddressLines(party)
-		clearStructuredAddress(addr)
-		addr.AddressLine = lines
-	case oioubl21AddressStructuredID:
-		// F-LIB038: a StructuredID address carries only the identifier. GOBL has no
-		// address-identifier field, so the register GLN rides org.Address.Number
-		// (mapped to BuildingNumber by newAddress and idle in this format, which
-		// clears every postal element). Re-emit it as cbc:ID with the mandatory GLN
-		// schemeID (F-LIB028/029), the scheme OIOUBL uses for every GLN identifier.
-		id := ""
-		if addr.BuildingNumber != nil {
-			id = *addr.BuildingNumber
-		}
-		clearStructuredAddress(addr)
-		if id != "" {
-			addr.ID = &IDType{Value: id, SchemeID: ptr(oioubl21AddressIDScheme), SchemeAgencyID: ptr(oioublGLNAgencyID)}
-		}
-	case oioubl21AddressStructuredRegion:
-		// F-LIB040: a StructuredRegion address carries only Region, District and
-		// Country. newAddress mapped the GOBL region to CountrySubentity and the
-		// locality to CityName; move the region to cbc:Region and reinterpret the
-		// locality (org.Address defines it as "village, town, district, or city")
-		// as the district OIOUBL requires here.
-		region := addr.CountrySubentity
-		country := addr.Country
-		district := addr.CityName
-		clearStructuredAddress(addr)
-		addr.Region = region
-		addr.Country = country
-		addr.District = district
-	}
-	// StructuredDK and StructuredLax keep the structured fields as built.
-}
-
-// clearStructuredAddress blanks every postal element except the
-// AddressFormatCode, leaving a canvas for a format-specific rebuild.
-func clearStructuredAddress(addr *PostalAddress) {
-	addr.ID = nil
-	addr.Postbox = nil
-	addr.StreetName = nil
-	addr.AdditionalStreetName = nil
-	addr.BuildingNumber = nil
-	addr.PlotIdentification = nil
-	addr.CitySubdivisionName = nil
-	addr.CityName = nil
-	addr.PostalZone = nil
-	addr.CountrySubentity = nil
-	addr.Region = nil
-	addr.District = nil
-	addr.AddressLine = nil
-	addr.Country = nil
-	addr.LocationCoordinate = nil
-}
-
-// oioubl21AddressLines renders a GOBL address as OIOUBL free-text AddressLine
-// elements for an Unstructured address.
-func oioubl21AddressLines(party *org.Party) []AddressLine {
-	if len(party.Addresses) == 0 {
-		return nil
-	}
-	a := party.Addresses[0]
-	var lines []AddressLine
-	if one := a.LineOne(); one != "" {
-		lines = append(lines, AddressLine{Line: one})
-	} else if a.PostOfficeBox != "" {
-		lines = append(lines, AddressLine{Line: a.PostOfficeBox})
-	}
-	if two := a.LineTwo(); two != "" {
-		lines = append(lines, AddressLine{Line: two})
-	}
-	if loc := strings.TrimSpace(a.Code.String() + " " + a.Locality); loc != "" {
-		lines = append(lines, AddressLine{Line: loc})
-	}
-	return lines
-}
 
 func newAddress(addresses []*org.Address, ctx Context) *PostalAddress {
 	if len(addresses) == 0 {

--- a/party.go
+++ b/party.go
@@ -224,7 +224,7 @@ func addPartyEndpoint(p *Party, party *org.Party, ctx Context) {
 			// The participant scheme (DK:CVR/DK:SE/GLN/…) and code are carried in the
 			// OIOUBL endpoint URI and emitted 1:1 as the EndpointID schemeID + value.
 			if scheme, value, ok := oioubl.ParseOIOUBLEndpoint(ep.URI.String()); ok {
-				p.EndpointID = &EndpointID{SchemeID: scheme, Value: value}
+				p.EndpointID = &EndpointID{SchemeID: scheme.String(), Value: value.String()}
 				break
 			}
 		}

--- a/party_parse.go
+++ b/party_parse.go
@@ -78,9 +78,6 @@ func goblParty(party *Party, o *options) *org.Party {
 		p.Addresses = []*org.Address{
 			parseAddress(party.PostalAddress),
 		}
-		if o.context.Is(ContextOIOUBL21) {
-			applyOIOUBL21AddressFormatParse(party.PostalAddress, p)
-		}
 	}
 
 	if party.Contact != nil {
@@ -205,39 +202,6 @@ func parseAddress(address *PostalAddress) *org.Address {
 		}
 	}
 	return addr
-}
-
-// applyOIOUBL21AddressFormatParse restores the wire cbc:AddressFormatCode to the
-// dk-oioubl-address-format extension so the format round-trips. StructuredLax is
-// the default and carries no extension; the StructuredID id and StructuredRegion
-// region/district round-trip through org.Address fields (Number, Region,
-// Locality), so those formats need only the format extension.
-//
-// An unrecognized value carries no extension: an alternative codelist such as
-// UN/ECE 3477 (the interop AddressFormatCode used by non-OIOUBL senders,
-// OIOUBL_GUIDE_PARTIES §3.1.6) has no GOBL representation, so the address still
-// imports through its structured fields but is left as the lax default.
-func applyOIOUBL21AddressFormatParse(address *PostalAddress, p *org.Party) {
-	if address == nil || address.AddressFormatCode == nil {
-		return
-	}
-	format := address.AddressFormatCode.Value
-	if format == oioubl21AddressStructuredLax || !isOIOUBLAddressFormat(format) {
-		return
-	}
-	p.Ext = tax.ExtensionsOf(cbc.CodeMap{oioubl21AddressFormatKey: cbc.Code(format)})
-}
-
-// isOIOUBLAddressFormat reports whether the value is one of OIOUBL's own
-// addressformatcode-1.1 codes, as opposed to an alternative codelist (§3.1.6).
-func isOIOUBLAddressFormat(format string) bool {
-	switch format {
-	case oioubl21AddressStructuredDK, oioubl21AddressStructuredLax,
-		oioubl21AddressStructuredID, oioubl21AddressStructuredRegion,
-		oioubl21AddressUnstructured:
-		return true
-	}
-	return false
 }
 
 func handleLegalEntityIdentity(party *Party, p *org.Party) {

--- a/payment.go
+++ b/payment.go
@@ -3,7 +3,6 @@ package ubl
 import (
 	"errors"
 
-	oioubl "github.com/invopop/gobl.dk.oioubl/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
@@ -210,8 +209,8 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 	if ref := instr.Ref.String(); ref != "" {
 		ui.PaymentMeans[0].PaymentID = &ref
 	}
-	// The OIOUBL payment channel is derived from the means; the PaymentID kortart is
-	// precomputed by the dk-oioubl addon (see applyOIOUBL21PaymentID).
+	// The OIOUBL payment channel and the Giro/FIK PaymentID kortart are both derived
+	// from the payment means and reference (see applyOIOUBL21PaymentID).
 	if ctx.Is(ContextOIOUBL21) {
 		if ch := oioubl21PaymentChannel(paymentMeansCode); ch != "" && ui.PaymentMeans[0].PaymentChannelCode == nil {
 			ui.PaymentMeans[0].PaymentChannelCode = &IDType{Value: ch}
@@ -257,23 +256,44 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 	return nil
 }
 
-// applyOIOUBL21PaymentID sets the OIOUBL Giro (50) / FIK (93) cbc:PaymentID from
-// the dk-oioubl-payment-id "kortart" (overriding instr.Ref, which is the Peppol
-// mapping). The FIK creditor account flows through the credit-transfer Number
-// (F-LIB305).
+// oioubl21PaymentID deduces the Giro/FIK "kortart" (cbc:PaymentID) from the
+// payment reference. FIK (means 93): no reference is the free-text kortart 73, a
+// 16-character reference is 75, and any other reference is 71 (whose 15-character
+// length F-LIB156 then confirms). Giro (means 50): the free-text kortart 01
+// without a reference, 04 (creditor number) with one — the two-reference form 15
+// isn't distinguishable from GOBL data. A malformed reference is left for the
+// schematron to reject (F-LIB149/156/157/312/336).
+func oioubl21PaymentID(paymentMeansCode, ref string) string {
+	switch paymentMeansCode {
+	case "93":
+		switch {
+		case ref == "":
+			return "73"
+		case len(ref) == 16:
+			return "75"
+		default:
+			return "71"
+		}
+	case "50":
+		if ref == "" {
+			return "01"
+		}
+		return "04"
+	}
+	return ""
+}
+
+// applyOIOUBL21PaymentID sets the Giro (50) / FIK (93) cbc:PaymentID to the kortart
+// deduced for the payment reference; the reference itself rides cbc:InstructionID
+// for the structured kortarts (the free-text 01/73 carry no payment number).
 func applyOIOUBL21PaymentID(pm *PaymentMeans, instr *pay.Instructions, paymentMeansCode string) {
 	if paymentMeansCode != "50" && paymentMeansCode != "93" {
 		return
 	}
-	kortart := instr.Ext.Get(oioubl.ExtKeyPaymentID).String()
-	if kortart == "" {
-		return
-	}
+	ref := instr.Ref.String()
+	kortart := oioubl21PaymentID(paymentMeansCode, ref)
 	pm.PaymentID = &kortart
-	// The payment number rides cbc:InstructionID; the kortart has just overridden
-	// instr.Ref as the PaymentID. The addon governs which kortarts may carry it
-	// (FIK 73 forbids it, the structured types require it).
-	if ref := instr.Ref.String(); ref != "" {
+	if ref != "" && kortart != "01" && kortart != "73" {
 		pm.InstructionID = &ref
 	}
 }

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strings"
 
-	oioubl "github.com/invopop/gobl.dk.oioubl/addon"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
@@ -174,9 +173,6 @@ func goblOIOUBLPaymentChannel(instr *pay.Instructions, paymentMeans *PaymentMean
 	}
 
 	instr.Key = pay.MeansKeyOther
-	if paymentMeans.PaymentID != nil {
-		instr.Ext = instr.Ext.Set(oioubl.ExtKeyPaymentID, cbc.Code(*paymentMeans.PaymentID))
-	}
 	// The generic path put the kortart in Ref; the real payment number, if any,
 	// is the InstructionID of the structured card types.
 	instr.Ref = ""

--- a/reminder.go
+++ b/reminder.go
@@ -192,20 +192,17 @@ func reminderMeansCode(m *pay.Record, ctx Context) string {
 	return ""
 }
 
-// applyOIOUBL21RecordPaymentID sets the Giro (50) / FIK (93) cbc:PaymentID from
-// the dk-oioubl-payment-id kortart and the payment number (cbc:InstructionID)
-// from the record reference, mirroring the invoice path. The addon governs which
-// kortarts may carry the payment number (FIK 73 forbids it).
+// applyOIOUBL21RecordPaymentID sets the Giro (50) / FIK (93) cbc:PaymentID to the
+// kortart deduced for the record reference, mirroring the invoice path (see
+// oioubl21PaymentID); the reference rides cbc:InstructionID for the structured
+// kortarts, while the free-text 01/73 carry no payment number.
 func applyOIOUBL21RecordPaymentID(pm *PaymentMeans, m *pay.Record, code string) {
 	if code != "50" && code != "93" {
 		return
 	}
-	kortart := m.Ext.Get(oioubl.ExtKeyPaymentID).String()
-	if kortart == "" {
-		return
-	}
+	kortart := oioubl21PaymentID(code, m.Ref)
 	pm.PaymentID = &kortart
-	if m.Ref != "" {
+	if m.Ref != "" && kortart != "01" && kortart != "73" {
 		ref := m.Ref
 		pm.InstructionID = &ref
 	}

--- a/reminder_parse.go
+++ b/reminder_parse.go
@@ -150,9 +150,6 @@ func goblReminderGiroFIKMethod(pm *PaymentMeans) *pay.Record {
 			untdid.ExtKeyPaymentMeans: cbc.Code(pm.PaymentMeansCode.Value),
 		}),
 	}
-	if pm.PaymentID != nil {
-		rec.Ext = rec.Ext.Set(oioubl.ExtKeyPaymentID, cbc.Code(*pm.PaymentID))
-	}
 	if pm.InstructionID != nil {
 		rec.Ref = cleanString(*pm.InstructionID)
 	}

--- a/test/data/convert/oioubl21-reminder/reminder-basic.json
+++ b/test/data/convert/oioubl21-reminder/reminder-basic.json
@@ -6,8 +6,8 @@
 			"alg": "sha256",
 			"val": "3bc5d409ad55dd0ae72c51782b4383d5a91d0237e84c36c47d351ca42011fd47"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:88146328"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:88146328"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/payment",
@@ -39,7 +39,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -74,7 +74,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:88146328"
+					"uri": "DK:CVR:88146328"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21-response/invoice-accepted.json
+++ b/test/data/convert/oioubl21-response/invoice-accepted.json
@@ -6,8 +6,8 @@
 			"alg": "sha256",
 			"val": "97465daeb1ca9aac42706859057ba9c0d1a88d7df40e04d44306bce6338040f2"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+		"from": "DK:CVR:76543216",
+		"to": "DK:CVR:12345674"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/status",
@@ -37,7 +37,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -67,7 +67,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/credit-note.json
+++ b/test/data/convert/oioubl21/credit-note.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "275ed218d47e4780817037e43b6ecb7c45d0842c05bec5d6dd9089deeb3f3864"
+			"val": "2b793c6f8f96fcc471b8a722bbb07a7c2ca242995cdb72183459ac5c9dd2287e"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -57,7 +57,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -98,7 +98,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/dual-currency-mixed.json
+++ b/test/data/convert/oioubl21/dual-currency-mixed.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e3d27cb07ca40808402d938df328745f4c66b961dc189eeb105d25328772cd3e"
+			"val": "8de242eccf93daae2fa3f55543250d6f48be85f4694733d8c0dd587e147a4428"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -61,7 +61,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -106,7 +106,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/excise-charge.json
+++ b/test/data/convert/oioubl21/excise-charge.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1acf01095e5e80b83b71572ee8f976437ead03a15881a126b8a9c579d6a8ccd1"
+			"val": "a90378801c3b4a5882d9ec393500547303d1aabb4c62fa9715baad2177eafec4"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -49,7 +49,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -90,7 +90,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/fik.json
+++ b/test/data/convert/oioubl21/fik.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "604b722930772a5be37056c8c391d9847f5c3c3b5185683fc4d2544f8967c86e"
+			"val": "24a9e7723cd632a45eae61a800ff9481cda7beaee700260b31b5c124d68a78e3"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -49,7 +49,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -90,7 +90,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/fik.json
+++ b/test/data/convert/oioubl21/fik.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "24a9e7723cd632a45eae61a800ff9481cda7beaee700260b31b5c124d68a78e3"
+			"val": "49d46b3bd708d58f449e63fdc57ab963e38b19f04a96cb4e8879e76a3f16fd6a"
 		},
 		"from": "DK:CVR:12345674",
 		"to": "DK:CVR:76543216"
@@ -136,7 +136,6 @@
 					}
 				],
 				"ext": {
-					"dk-oioubl-payment-id": "73",
 					"untdid-payment-means": "93"
 				}
 			}

--- a/test/data/convert/oioubl21/happy-path.json
+++ b/test/data/convert/oioubl21/happy-path.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "4135c7307698e2f1692eb4d62db7197b3b363e067028de8a2e776798c8d98565"
+			"val": "f194e6d2474bc9b8799ed221f6b3408545c0eb36eac65281bd34482621983e0b"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -49,7 +49,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -95,7 +95,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/invoice-bare.json
+++ b/test/data/convert/oioubl21/invoice-bare.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "ca4b94b8549d0cfff8d157a46352b289c223a77b83836d6c14f32508abc4feed"
+			"val": "397660fec8ca568a44162b936e086fc27b58a7c210c7b4b2d4e364cc05960de2"
 		}
 	},
 	"doc": {

--- a/test/data/convert/oioubl21/mixed-categories.json
+++ b/test/data/convert/oioubl21/mixed-categories.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "c78e91a0e89333e00ff25796d764d6992c62f6081d58c82c276065d1a1345541"
+			"val": "09007b9ea4d0a72fc564bb109fd2c2cf57a14eb0c93cd65f8b6da688a44a6f88"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -49,7 +49,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -95,7 +95,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/reverse-charge.json
+++ b/test/data/convert/oioubl21/reverse-charge.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "51dcc3e76f9d8a4ad6029c72f426dcb7c2b4706a8b80d74b5bd9abc5c74f3b5e"
+			"val": "cdcc0c8269435f8ecffaca1c1d85a14cd78e9c66a00243539637fc8318eabcd3"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -49,7 +49,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -90,7 +90,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/convert/oioubl21/zero-rated-foreign-currency.json
+++ b/test/data/convert/oioubl21/zero-rated-foreign-currency.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a9f214843db1029fad9bf08a94cf9356488698bb8ab965260706243640e45c33"
+			"val": "382a3980fdbfc6cb2645bc2408839bb36ef911f8127ffc438e8790e396d47bfa"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -61,7 +61,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -106,7 +106,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21-reminder/out/reminder-basic.json
+++ b/test/data/parse/oioubl21-reminder/out/reminder-basic.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "b618e4b26b900e2ed41f3f973d0e6b282fecae14aac21d9ead76b58a4be8a905"
+			"val": "cbd0513185421ab4a461081979720d38b78597fe57f7ce708eae88da6069b708"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:88146328"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:88146328"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/payment",
@@ -41,7 +41,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -78,7 +78,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:88146328"
+					"uri": "DK:CVR:88146328"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21-response/out/invoice-accepted.json
+++ b/test/data/parse/oioubl21-response/out/invoice-accepted.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "57a8dc2b0df1ff430edb3d075574dd9344a4ed1d2bcc0b1b67ac2f7e96438058"
+			"val": "055107565079bc2272bb5360299bee2bb0f303ee52a6c63879562222760018c3"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+		"from": "DK:CVR:76543216",
+		"to": "DK:CVR:12345674"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/status",
@@ -37,7 +37,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -70,7 +70,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21-response/out/invoice-accepted.json
+++ b/test/data/parse/oioubl21-response/out/invoice-accepted.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "055107565079bc2272bb5360299bee2bb0f303ee52a6c63879562222760018c3"
+			"val": "9f9efa88b716423918ea8e986da9b0abcefabbe1a9b7b0bf241e1c41ab139d18"
 		},
 		"from": "DK:CVR:76543216",
 		"to": "DK:CVR:12345674"
@@ -48,10 +48,7 @@
 					"code": "2100",
 					"country": "DK"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"customer": {
 			"name": "Modtager Handel A/S",
@@ -81,10 +78,7 @@
 					"code": "8000",
 					"country": "DK"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/address-alternative-format.json
+++ b/test/data/parse/oioubl21/out/address-alternative-format.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0745c8a934e2684f5eb1eea5640af273229b57609833de703d280066a182ff22"
+			"val": "dcd2faf93466d93b47e87f3c06fb2f04931f3ddc5fcef7896cff23fbb9272788"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:88146328"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:88146328"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -44,7 +44,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -86,7 +86,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:88146328"
+					"uri": "DK:CVR:88146328"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/credit-note-no-typecode.json
+++ b/test/data/parse/oioubl21/out/credit-note-no-typecode.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "efe048545c331e5257f88d31afe4e1b7ba8bb525ecab9a8063414366cfbaa476"
+			"val": "3256d3712aef3ea51bb5fa50c79ab8fdda41776158ae1f9954fe862f41fc79d4"
 		},
 		"from": "GLN:5790000436101",
 		"to": "GLN:5790000436057"
@@ -73,10 +73,7 @@
 				{
 					"addr": "billing@example.com"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"customer": {
 			"name": "Sample Consumer",
@@ -123,10 +120,7 @@
 				{
 					"addr": "email@sample.com"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/credit-note-no-typecode.json
+++ b/test/data/parse/oioubl21/out/credit-note-no-typecode.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "d631b137a011d5cf90b556c57e7e52d8c5ec49f7c804e17de6ad9d3646a81562"
+			"val": "efe048545c331e5257f88d31afe4e1b7ba8bb525ecab9a8063414366cfbaa476"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436101",
-		"to": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436057"
+		"from": "GLN:5790000436101",
+		"to": "GLN:5790000436057"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -57,7 +57,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436101"
+					"uri": "GLN:5790000436101"
 				}
 			],
 			"addresses": [
@@ -107,7 +107,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436057"
+					"uri": "GLN:5790000436057"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/foreign-party.json
+++ b/test/data/parse/oioubl21/out/foreign-party.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a43de7112e81f0ee21cfbd6d6e2d1dc1144c2c689f22b74c8a9c969d7ac5c646"
+			"val": "6cc6b70a31cd371af2c71bbbd239fe5a27f00157dfbbc4d3c90e726aa5e69446"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DE:VAT:DE282741168"
+		"from": "DK:CVR:12345674",
+		"to": "DE:VAT:DE282741168"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -51,7 +51,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -93,7 +93,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DE:VAT:DE282741168"
+					"uri": "DE:VAT:DE282741168"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/happy-path.json
+++ b/test/data/parse/oioubl21/out/happy-path.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "8076477fff4a25a4db7105b87c9117eefff3390c3820dec35778388225b31031"
+			"val": "85b0e340e074d014b70436b04f2ede2c87a9ed6f830bbd051ceb84625dc7f151"
 		},
 		"from": "DK:CVR:12345674",
 		"to": "DK:CVR:76543216"
@@ -67,10 +67,7 @@
 				{
 					"addr": "billing@eksempel-software.dk"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"customer": {
 			"name": "Modtager Handel A/S",
@@ -117,10 +114,7 @@
 				{
 					"addr": "ap@modtager-handel.dk"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/happy-path.json
+++ b/test/data/parse/oioubl21/out/happy-path.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "af0b1e054a864e39c5ab3375361ca8a8dfcba9fca676b2cff4c9fe3780905a14"
+			"val": "8076477fff4a25a4db7105b87c9117eefff3390c3820dec35778388225b31031"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+		"from": "DK:CVR:12345674",
+		"to": "DK:CVR:76543216"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -51,7 +51,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:12345674"
+					"uri": "DK:CVR:12345674"
 				}
 			],
 			"addresses": [
@@ -101,7 +101,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:76543216"
+					"uri": "DK:CVR:76543216"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/invoice-bare.json
+++ b/test/data/parse/oioubl21/out/invoice-bare.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "29417ed8a73a634ddd6770ae0abb35e394eafa61c1ddb3a75c49795fd5e3efc6"
+			"val": "f38cecea8256e868468949436bac40493da20920ea00ad9ca30822c9232043b2"
 		},
 		"from": "DK:CVR:37990485",
 		"to": "DK:CVR:47458714"
@@ -55,10 +55,7 @@
 					"code": "2100",
 					"country": "DK"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"customer": {
 			"name": "Lego System A/S",
@@ -100,10 +97,7 @@
 					"code": "7190",
 					"country": "DK"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"lines": [
 			{

--- a/test/data/parse/oioubl21/out/invoice-bare.json
+++ b/test/data/parse/oioubl21/out/invoice-bare.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fbaebc1e0982f250f897165a3c5301507ea0d114150a30edfc4fb4835b48ab3d"
+			"val": "29417ed8a73a634ddd6770ae0abb35e394eafa61c1ddb3a75c49795fd5e3efc6"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:37990485",
-		"to": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:47458714"
+		"from": "DK:CVR:37990485",
+		"to": "DK:CVR:47458714"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -44,7 +44,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:37990485"
+					"uri": "DK:CVR:37990485"
 				}
 			],
 			"addresses": [
@@ -89,7 +89,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::DK:CVR:47458714"
+					"uri": "DK:CVR:47458714"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/invoice-minimal.json
+++ b/test/data/parse/oioubl21/out/invoice-minimal.json
@@ -4,10 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "5a6745020d07e041d71d4e0bc713f1acf29b2f1dffaadecc569e229bc3f6a38b"
+			"val": "1d8c3e661f4b232da63e8bb371490906dfcda444465aa7abe77d5fcc3cae03f5"
 		},
-		"from": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436101",
-		"to": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436057"
+		"from": "GLN:5790000436101",
+		"to": "GLN:5790000436057"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -61,7 +61,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436101"
+					"uri": "GLN:5790000436101"
 				}
 			],
 			"addresses": [
@@ -109,7 +109,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "urn:oioubl:scheme:endpointid-1.1::GLN:5790000436057"
+					"uri": "GLN:5790000436057"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/oioubl21/out/invoice-minimal.json
+++ b/test/data/parse/oioubl21/out/invoice-minimal.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1d8c3e661f4b232da63e8bb371490906dfcda444465aa7abe77d5fcc3cae03f5"
+			"val": "04a93d9b0ea52e82aed5053cadf753bb72da3f7b1835dfd76669e47c88446e65"
 		},
 		"from": "GLN:5790000436101",
 		"to": "GLN:5790000436057"
@@ -77,10 +77,7 @@
 				{
 					"addr": "billing@example.com"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"customer": {
 			"name": "Sample Consumer",
@@ -125,10 +122,7 @@
 				{
 					"addr": "email@sample.com"
 				}
-			],
-			"ext": {
-				"dk-oioubl-address-format": "StructuredDK"
-			}
+			]
 		},
 		"lines": [
 			{

--- a/totals.go
+++ b/totals.go
@@ -65,7 +65,7 @@ func (ui *Invoice) addOIOUBL21MonetaryTotal(inv *bill.Invoice, ctx Context, curr
 	excise := num.MakeAmount(0, exp)
 	for _, l := range inv.Lines {
 		if l.Sum != nil {
-			grossSum = grossSum.Add(roundToCurrency(*l.Sum, currency))
+			grossSum = grossSum.Add(rescaleToCurrency(*l.Sum, currency))
 		}
 		for _, d := range l.Discounts {
 			lineDiscounts = lineDiscounts.Add(d.Amount)
@@ -73,7 +73,7 @@ func (ui *Invoice) addOIOUBL21MonetaryTotal(inv *bill.Invoice, ctx Context, curr
 		ordinary := make([]*bill.LineCharge, 0, len(l.Charges))
 		for _, c := range l.Charges {
 			if chargeExciseScheme(c.Key) != "" {
-				excise = excise.Add(roundToCurrency(c.Amount, currency))
+				excise = excise.Add(rescaleToCurrency(c.Amount, currency))
 				continue
 			}
 			lineCharges = lineCharges.Add(c.Amount)
@@ -99,7 +99,7 @@ func (ui *Invoice) addOIOUBL21MonetaryTotal(inv *bill.Invoice, ctx Context, curr
 	}
 	for _, ch := range inv.Charges {
 		if chargeExciseScheme(ch.Key) != "" {
-			a := roundToCurrency(ch.Amount, currency)
+			a := rescaleToCurrency(ch.Amount, currency)
 			excise = excise.Add(a)
 			chg = chg.Subtract(a) // counted in t.Charge above; OIOUBL emits it as tax
 		}


### PR DESCRIPTION
Converter counterpart to gobl.dk.oioubl#9 — the OIOUBL extension surface is reduced by deriving values in the converter. Based on `map-oioubl-tax-category-from-key` (the OIOUBL features branch feeding #73).

### Changes
- **Address format**: always emit `cbc:AddressFormatCode` = `StructuredLax` (accepts any native address fields); removed the ext-driven reshaping (`applyOIOUBL21AddressFormat`, `clearStructuredAddress`, `oioubl21AddressLines`) and the parse-side ext restore. Inbound parse keeps native field mapping (incl. StructuredID → `org.Address.Number`).
- **Endpoint**: parse a bare `DK:CVR:CODE` / `GLN:CODE` / `DK:SE:CODE` (via last-colon split); the emitted `cbc:EndpointID` is unchanged.
- **Giro/FIK kortart**: `oioubl21PaymentID` deduces the kortart from the reference (FIK 73/71/75 by length, Giro 01/04 by presence); invoice + reminder paths share it. Parse no longer stores a kortart ext (the value round-trips because it's a function of the reference).

### Notes
- Depends on gobl.dk.oioubl#9 (removes the matching extensions); locally linked, both build + test + lint(0) green, OIOUBL fixtures phive-green.
- Giro `04` vs `15` isn't distinguishable from GOBL data → `15` is never emitted; malformed references fall to the schematron.
