### PR TITLE
Completing the generic UBL wire model for a country overlay

### DIFF
--- a/charges.go
+++ b/charges.go
@@ -99,18 +99,18 @@ func makeTaxCategory(taxes tax.Set) []*TaxCategory {
 	set := []*TaxCategory{}
 	for _, t := range taxes {
 		category := TaxCategory{}
-		category.TaxScheme = &TaxScheme{ID: t.Category.String()}
+		category.TaxScheme = &TaxScheme{ID: IDType{Value: t.Category.String()}}
 
 		e := t.Ext.Get(untdid.ExtKeyTaxCategory).String()
 		if e != "" {
-			category.ID = &e
+			category.ID = &IDType{Value: e}
 		}
 
 		// Set percent: required unless category is "O" (outside scope)
 		if t.Percent != nil {
 			p := t.Percent.StringWithoutSymbol()
 			category.Percent = &p
-		} else if category.ID == nil || *category.ID != "O" {
+		} else if category.ID == nil || category.ID.Value != "O" {
 			// Default to 0% when not outside scope
 			zero := "0"
 			category.Percent = &zero

--- a/charges_parse.go
+++ b/charges_parse.go
@@ -96,16 +96,16 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 	if len(ac.TaxCategory) > 0 && ac.TaxCategory[0].TaxScheme != nil {
 		ch.Taxes = tax.Set{
 			{
-				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID),
+				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID.Value),
 			},
 		}
 
 		// Add tax category ID to extensions
 		if ac.TaxCategory[0].ID != nil {
-			ch.Taxes[0].Ext = ch.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, cbc.Code(*ac.TaxCategory[0].ID))
+			ch.Taxes[0].Ext = ch.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, cbc.Code(ac.TaxCategory[0].ID.Value))
 
 			// Look up exemption code from TaxTotal
-			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID, *ac.TaxCategory[0].ID, ac.TaxCategory[0].Percent)
+			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				ch.Taxes[0].Ext = ch.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))
 			}
@@ -123,7 +123,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 
 			// Skip setting percent if it's 0% and tax category is not "Z" (zero-rated)
 			// This prevents GOBL from normalizing to "zero" tax rate for exempt/reverse-charge cases
-			if !p.IsZero() || (ac.TaxCategory[0].ID != nil && *ac.TaxCategory[0].ID == "Z") {
+			if !p.IsZero() || (ac.TaxCategory[0].ID != nil && ac.TaxCategory[0].ID.Value == "Z") {
 				ch.Taxes[0].Percent = &p
 			}
 		}
@@ -178,16 +178,16 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 	if len(ac.TaxCategory) > 0 && ac.TaxCategory[0].TaxScheme != nil {
 		d.Taxes = tax.Set{
 			{
-				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID),
+				Category: cbc.Code(ac.TaxCategory[0].TaxScheme.ID.Value),
 			},
 		}
 
 		// Add tax category ID to extensions
 		if ac.TaxCategory[0].ID != nil {
-			d.Taxes[0].Ext = d.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, cbc.Code(*ac.TaxCategory[0].ID))
+			d.Taxes[0].Ext = d.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, cbc.Code(ac.TaxCategory[0].ID.Value))
 
 			// Look up exemption code from TaxTotal
-			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID, *ac.TaxCategory[0].ID, ac.TaxCategory[0].Percent)
+			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				d.Taxes[0].Ext = d.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))
 			}
@@ -205,7 +205,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 
 			// Skip setting percent if it's 0% and tax category is not "Z" (zero-rated)
 			// This prevents GOBL from normalizing to "zero" tax rate for exempt/reverse-charge cases
-			if !percent.IsZero() || (ac.TaxCategory[0].ID != nil && *ac.TaxCategory[0].ID == "Z") {
+			if !percent.IsZero() || (ac.TaxCategory[0].ID != nil && ac.TaxCategory[0].ID.Value == "Z") {
 				d.Taxes[0].Percent = &percent
 			}
 		}

--- a/common.go
+++ b/common.go
@@ -30,12 +30,14 @@ const (
 
 // IDType represents an ID with optional scheme attributes
 type IDType struct {
-	ListID        *string `xml:"listID,attr"`
-	ListVersionID *string `xml:"listVersionID,attr"`
-	SchemeID      *string `xml:"schemeID,attr"`
-	SchemeName    *string `xml:"schemeName,attr"`
-	Name          *string `xml:"name,attr"`
-	Value         string  `xml:",chardata"`
+	SchemeAgencyID *string `xml:"schemeAgencyID,attr"`
+	ListAgencyID   *string `xml:"listAgencyID,attr"`
+	ListID         *string `xml:"listID,attr"`
+	ListVersionID  *string `xml:"listVersionID,attr"`
+	SchemeID       *string `xml:"schemeID,attr"`
+	SchemeName     *string `xml:"schemeName,attr"`
+	Name           *string `xml:"name,attr"`
+	Value          string  `xml:",chardata"`
 }
 
 // ExchangeRate represents an exchange rate
@@ -102,9 +104,10 @@ type CommodityClassification struct {
 
 // ClassifiedTaxCategory represents a classified tax category
 type ClassifiedTaxCategory struct {
-	ID        *string    `xml:"cbc:ID,omitempty"`
-	Percent   *string    `xml:"cbc:Percent,omitempty"`
-	TaxScheme *TaxScheme `xml:"cac:TaxScheme,omitempty"`
+	ID                     *IDType    `xml:"cbc:ID,omitempty"`
+	Percent                *string    `xml:"cbc:Percent,omitempty"`
+	TaxExemptionReasonCode *string    `xml:"cbc:TaxExemptionReasonCode,omitempty"`
+	TaxScheme              *TaxScheme `xml:"cac:TaxScheme,omitempty"`
 }
 
 // AdditionalItemProperty represents an additional property of an item

--- a/common.go
+++ b/common.go
@@ -104,10 +104,9 @@ type CommodityClassification struct {
 
 // ClassifiedTaxCategory represents a classified tax category
 type ClassifiedTaxCategory struct {
-	ID                     *IDType    `xml:"cbc:ID,omitempty"`
-	Percent                *string    `xml:"cbc:Percent,omitempty"`
-	TaxExemptionReasonCode *string    `xml:"cbc:TaxExemptionReasonCode,omitempty"`
-	TaxScheme              *TaxScheme `xml:"cac:TaxScheme,omitempty"`
+	ID        *IDType    `xml:"cbc:ID,omitempty"`
+	Percent   *string    `xml:"cbc:Percent,omitempty"`
+	TaxScheme *TaxScheme `xml:"cac:TaxScheme,omitempty"`
 }
 
 // AdditionalItemProperty represents an additional property of an item

--- a/context_test.go
+++ b/context_test.go
@@ -57,7 +57,7 @@ func TestContextPeppol(t *testing.T) {
 
 		// Verify CustomizationID and ProfileID
 		assert.Equal(t, "urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0", ublInv.CustomizationID)
-		assert.Equal(t, "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", ublInv.ProfileID)
+		assert.Equal(t, "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", ublInv.ProfileID.Value)
 	})
 
 }
@@ -81,7 +81,7 @@ func TestContextXRechnung(t *testing.T) {
 
 		// Verify CustomizationID and ProfileID
 		assert.Equal(t, "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0", ublInv.CustomizationID)
-		assert.Equal(t, "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", ublInv.ProfileID)
+		assert.Equal(t, "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0", ublInv.ProfileID.Value)
 	})
 }
 
@@ -99,7 +99,7 @@ func TestContextPeppolFranceCIUS(t *testing.T) {
 		// Verify OutputCustomizationID is used in the output
 		assert.Equal(t, "urn:cen.eu:en16931:2017", ublInv.CustomizationID)
 		// Verify ProfileID comes from the fr-ctc-billing-mode extension
-		assert.Equal(t, "S1", ublInv.ProfileID)
+		assert.Equal(t, "S1", ublInv.ProfileID.Value)
 	})
 
 	t.Run("external identification uses full CustomizationID", func(t *testing.T) {
@@ -130,7 +130,7 @@ func TestContextPeppolFranceExtended(t *testing.T) {
 		// Verify OutputCustomizationID is used
 		assert.Equal(t, "urn:cen.eu:en16931:2017#conformant#urn.cpro.gouv.fr:1p0:extended-ctc-fr", ublInv.CustomizationID)
 		// No billing mode extension in minimal invoice, so ProfileID falls back to context's Peppol process ID
-		assert.Equal(t, "urn:peppol:france:billing:regulated", ublInv.ProfileID)
+		assert.Equal(t, "urn:peppol:france:billing:regulated", ublInv.ProfileID.Value)
 	})
 
 	t.Run("external identification uses full CustomizationID", func(t *testing.T) {
@@ -160,7 +160,7 @@ func TestContextPeppolSelfBilled(t *testing.T) {
 
 		// Verify CustomizationID and ProfileID
 		assert.Equal(t, "urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0", ublInv.CustomizationID)
-		assert.Equal(t, "urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0", ublInv.ProfileID)
+		assert.Equal(t, "urn:fdc:peppol.eu:2017:poacc:selfbilling:01:1.0", ublInv.ProfileID.Value)
 	})
 }
 

--- a/delivery.go
+++ b/delivery.go
@@ -7,6 +7,7 @@ type Delivery struct {
 	ActualDeliveryDate      *string   `xml:"cbc:ActualDeliveryDate"`
 	LatestDeliveryDate      *string   `xml:"cbc:LatestDeliveryDate"`
 	DeliveryLocation        *Location `xml:"cac:DeliveryLocation"`
+	RequestedDeliveryPeriod *Period   `xml:"cac:RequestedDeliveryPeriod"`
 	EstimatedDeliveryPeriod *Period   `xml:"cac:EstimatedDeliveryPeriod"`
 	DeliveryParty           *Party    `xml:"cac:DeliveryParty"`
 }

--- a/invoice.go
+++ b/invoice.go
@@ -44,7 +44,7 @@ type Invoice struct {
 	Extensions         *Extensions `xml:"ext:UBLExtensions,omitempty"`
 	UBLVersionID       string      `xml:"cbc:UBLVersionID,omitempty"`
 	CustomizationID    string      `xml:"cbc:CustomizationID,omitempty"`
-	ProfileID          string      `xml:"cbc:ProfileID,omitempty"`
+	ProfileID          *IDType     `xml:"cbc:ProfileID,omitempty"`
 	ProfileExecutionID string      `xml:"cbc:ProfileExecutionID,omitempty"`
 	ID                 string      `xml:"cbc:ID"`
 	CopyIndicator      bool        `xml:"cbc:CopyIndicator,omitempty"`
@@ -134,7 +134,6 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		EXTNamespace:            NamespaceEXT,
 		SchemaLocation:          SchemaLocationInvoice,
 		CustomizationID:         customizationID,
-		ProfileID:               profileID,
 		ID:                      invoiceNumber(inv.Series, inv.Code),
 		IssueDate:               formatDate(inv.IssueDate),
 		AccountingCost:          "", // TODO: ordering cost
@@ -142,6 +141,12 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		DocumentCurrencyCode:    string(inv.Currency),
 		AccountingSupplierParty: SupplierParty{Party: newParty(inv.Supplier, o.context)},
 		AccountingCustomerParty: CustomerParty{Party: newParty(inv.Customer, o.context)},
+	}
+
+	// ProfileID is omitted when empty; when present it only carries a value here
+	// (a country overlay may add the schemeID/schemeAgencyID attributes).
+	if profileID != "" {
+		out.ProfileID = &IDType{Value: profileID}
 	}
 
 	// PEPPOL-EN16931-R005 / BR-53: only map BT-6 when a matching exchange rate

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -40,7 +40,7 @@ func (ui *Invoice) Convert() (*gobl.Envelope, error) {
 	o := new(options)
 
 	// Detect context from the invoice
-	ctx := FindContext(ui.CustomizationID, ui.ProfileID)
+	ctx := FindContext(ui.CustomizationID, ui.profileID())
 	if ctx != nil {
 		o.context = *ctx
 	}
@@ -115,10 +115,18 @@ func (ui *Invoice) goblInvoice(o *options) (*bill.Invoice, error) {
 	return out, nil
 }
 
+// profileID returns the ProfileID value, or "" when absent.
+func (ui *Invoice) profileID() string {
+	if ui.ProfileID == nil {
+		return ""
+	}
+	return ui.ProfileID.Value
+}
+
 // applyContextTaxExtensions sets tax extensions that depend on the active context.
 func (ui *Invoice) applyContextTaxExtensions(out *bill.Invoice, o *options) {
 	if o.context.Is(ContextPeppolFranceCIUS) || o.context.Is(ContextPeppolFranceExtended) {
-		out.Tax.Ext = out.Tax.Ext.Set(dgfip.ExtKeyBillingMode, cbc.Code(ui.ProfileID))
+		out.Tax.Ext = out.Tax.Ext.Set(dgfip.ExtKeyBillingMode, cbc.Code(ui.profileID()))
 	}
 
 	if o.context.Is(ContextZATCA) && ui.InvoiceTypeCode != nil && ui.InvoiceTypeCode.Name != nil {

--- a/lines.go
+++ b/lines.go
@@ -154,26 +154,26 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 			if len(l.Taxes) > 0 && l.Taxes[0].Category != "" {
 				it.ClassifiedTaxCategory = &ClassifiedTaxCategory{
 					TaxScheme: &TaxScheme{
-						ID: l.Taxes[0].Category.String(),
+						ID: IDType{Value: l.Taxes[0].Category.String()},
 					},
 				}
 
 				if rate := l.Taxes[0].Ext.Get(untdid.ExtKeyTaxCategory).String(); rate != "" {
-					it.ClassifiedTaxCategory.ID = &rate
+					it.ClassifiedTaxCategory.ID = &IDType{Value: rate}
 				}
 
 				// Set percent: required unless category is "O" (outside scope)
 				if l.Taxes[0].Percent != nil {
 					p := l.Taxes[0].Percent.StringWithoutSymbol()
 					it.ClassifiedTaxCategory.Percent = &p
-				} else if it.ClassifiedTaxCategory.ID == nil || *it.ClassifiedTaxCategory.ID != "O" {
+				} else if it.ClassifiedTaxCategory.ID == nil || it.ClassifiedTaxCategory.ID.Value != "O" {
 					// Default to 0% when not outside scope
 					p := "0"
 					it.ClassifiedTaxCategory.Percent = &p
 				}
 
 				if rate := l.Taxes[0].Ext.Get(untdid.ExtKeyTaxCategory).String(); rate != "" {
-					it.ClassifiedTaxCategory.ID = &rate
+					it.ClassifiedTaxCategory.ID = &IDType{Value: rate}
 				}
 			}
 

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -199,16 +199,16 @@ func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[stri
 
 	line.Taxes = tax.Set{
 		{
-			Category: cbc.Code(ctc.TaxScheme.ID),
+			Category: cbc.Code(ctc.TaxScheme.ID.Value),
 		},
 	}
 	if ctc.ID != nil {
 		line.Taxes[0].Ext = tax.ExtensionsOf(cbc.CodeMap{
-			untdid.ExtKeyTaxCategory: cbc.Code(*ctc.ID),
+			untdid.ExtKeyTaxCategory: cbc.Code(ctc.ID.Value),
 		})
 
 		// Try to get exemption code from TaxTotal
-		key := buildTaxCategoryKey(ctc.TaxScheme.ID, *ctc.ID, ctc.Percent)
+		key := buildTaxCategoryKey(ctc.TaxScheme.ID.Value, ctc.ID.Value, ctc.Percent)
 		if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 			line.Taxes[0].Ext = line.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))
 		}
@@ -223,7 +223,7 @@ func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[stri
 
 		// Skip setting percent if it's 0% and tax category is not "Z" (zero-rated)
 		// This prevents GOBL from normalizing to "zero" tax rate for exempt/reverse-charge cases
-		if percent.IsZero() && ctc.ID != nil && *ctc.ID != "Z" {
+		if percent.IsZero() && ctc.ID != nil && ctc.ID.Value != "Z" {
 			return
 		}
 

--- a/lines_test.go
+++ b/lines_test.go
@@ -17,7 +17,7 @@ func TestNewLines(t *testing.T) {
 		assert.Equal(t, "1800.00", doc.InvoiceLines[0].LineExtensionAmount.Value)
 		assert.Equal(t, "Development services", doc.InvoiceLines[0].Item.Name)
 		assert.Equal(t, "HUR", doc.InvoiceLines[0].InvoicedQuantity.UnitCode)
-		assert.Equal(t, "VAT", doc.InvoiceLines[0].Item.ClassifiedTaxCategory.TaxScheme.ID)
+		assert.Equal(t, "VAT", doc.InvoiceLines[0].Item.ClassifiedTaxCategory.TaxScheme.ID.Value)
 		assert.Equal(t, "19", *doc.InvoiceLines[0].Item.ClassifiedTaxCategory.Percent)
 		assert.True(t, doc.InvoiceLines[0].AllowanceCharge[0].ChargeIndicator)
 		assert.Equal(t, "Testing", *doc.InvoiceLines[0].AllowanceCharge[0].AllowanceChargeReason)

--- a/party.go
+++ b/party.go
@@ -56,6 +56,9 @@ type PartyName struct {
 
 // PostalAddress represents a postal address
 type PostalAddress struct {
+	ID                   *IDType             `xml:"cbc:ID,omitempty"`
+	AddressFormatCode    *IDType             `xml:"cbc:AddressFormatCode"`
+	Postbox              *string             `xml:"cbc:Postbox,omitempty"`
 	StreetName           *string             `xml:"cbc:StreetName"`
 	AdditionalStreetName *string             `xml:"cbc:AdditionalStreetName"`
 	BuildingNumber       *string             `xml:"cbc:BuildingNumber,omitempty"`
@@ -64,6 +67,8 @@ type PostalAddress struct {
 	CityName             *string             `xml:"cbc:CityName"`
 	PostalZone           *string             `xml:"cbc:PostalZone"`
 	CountrySubentity     *string             `xml:"cbc:CountrySubentity"`
+	Region               *string             `xml:"cbc:Region,omitempty"`
+	District             *string             `xml:"cbc:District,omitempty"`
 	AddressLine          []AddressLine       `xml:"cac:AddressLine"`
 	Country              *Country            `xml:"cac:Country"`
 	LocationCoordinate   *LocationCoordinate `xml:"cac:LocationCoordinate"`
@@ -89,14 +94,15 @@ type Country struct {
 
 // PartyTaxScheme represents a party's tax scheme
 type PartyTaxScheme struct {
-	CompanyID *string    `xml:"cbc:CompanyID"`
+	CompanyID *IDType    `xml:"cbc:CompanyID"`
 	TaxScheme *TaxScheme `xml:"cac:TaxScheme"`
 }
 
 // TaxScheme represents a tax scheme
 type TaxScheme struct {
-	ID          string `xml:"cbc:ID"`
-	TaxTypeCode string `xml:"cbc:TaxTypeCode,omitempty"`
+	ID          IDType  `xml:"cbc:ID"`
+	Name        *string `xml:"cbc:Name"`
+	TaxTypeCode *IDType `xml:"cbc:TaxTypeCode,omitempty"`
 }
 
 // PartyLegalEntity represents the legal entity of a party
@@ -108,6 +114,7 @@ type PartyLegalEntity struct {
 
 // Contact represents contact information
 type Contact struct {
+	ID             *string `xml:"cbc:ID"`
 	Name           *string `xml:"cbc:Name"`
 	Telephone      *string `xml:"cbc:Telephone"`
 	ElectronicMail *string `xml:"cbc:ElectronicMail"`
@@ -162,9 +169,9 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 		}
 
 		taxScheme := PartyTaxScheme{
-			CompanyID: &code,
+			CompanyID: &IDType{Value: code},
 			TaxScheme: &TaxScheme{
-				ID: id.String(),
+				ID: IDType{Value: id.String()},
 			},
 		}
 
@@ -245,9 +252,9 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 			if id.Scope == org.IdentityScopeTax {
 				code := id.Code.String()
 				taxScheme := PartyTaxScheme{
-					CompanyID: &code,
+					CompanyID: &IDType{Value: code},
 					TaxScheme: &TaxScheme{
-						ID: id.Type.String(),
+						ID: IDType{Value: id.Type.String()},
 					},
 				}
 				p.PartyTaxScheme = append(p.PartyTaxScheme, taxScheme)

--- a/party_parse.go
+++ b/party_parse.go
@@ -175,7 +175,7 @@ func handlePartyTaxSchemes(party *Party, p *org.Party) {
 func extractValidTaxSchemes(schemes []PartyTaxScheme) []PartyTaxScheme {
 	validSchemes := make([]PartyTaxScheme, 0)
 	for _, pts := range schemes {
-		if pts.CompanyID != nil && *pts.CompanyID != "" && pts.TaxScheme != nil {
+		if pts.CompanyID != nil && pts.CompanyID.Value != "" && pts.TaxScheme != nil {
 			validSchemes = append(validSchemes, pts)
 		}
 	}
@@ -185,15 +185,15 @@ func extractValidTaxSchemes(schemes []PartyTaxScheme) []PartyTaxScheme {
 func setTaxIDFromScheme(pts PartyTaxScheme, p *org.Party, countryCode string) {
 	p.TaxID = &tax.Identity{
 		Country: l10n.TaxCountryCode(countryCode),
-		Code:    cbc.Code(*pts.CompanyID),
+		Code:    cbc.Code(pts.CompanyID.Value),
 	}
-	sc := cbc.Code(pts.TaxScheme.ID)
+	sc := cbc.Code(pts.TaxScheme.ID.Value)
 	if p.TaxID.GetScheme() != sc {
 		var scheme cbc.Code
-		if pts.TaxScheme.TaxTypeCode != "" {
-			scheme = cbc.Code(pts.TaxScheme.TaxTypeCode)
+		if pts.TaxScheme.TaxTypeCode != nil && pts.TaxScheme.TaxTypeCode.Value != "" {
+			scheme = cbc.Code(pts.TaxScheme.TaxTypeCode.Value)
 		} else {
-			scheme = cbc.Code(pts.TaxScheme.ID)
+			scheme = cbc.Code(pts.TaxScheme.ID.Value)
 		}
 		p.TaxID.Scheme = scheme
 	}
@@ -218,7 +218,7 @@ func handleMultipleTaxSchemes(validSchemes []PartyTaxScheme, p *org.Party, count
 
 func findVATSchemeIndex(schemes []PartyTaxScheme) int {
 	for i, pts := range schemes {
-		if pts.TaxScheme.ID == TaxSchemeVAT {
+		if pts.TaxScheme.ID.Value == TaxSchemeVAT {
 			return i
 		}
 	}
@@ -233,9 +233,9 @@ func addRemainingTaxSchemesAsIdentities(validSchemes []PartyTaxScheme, taxIDIdx 
 
 		identity := &org.Identity{
 			Country: l10n.ISOCountryCode(countryCode),
-			Code:    cbc.Code(*pts.CompanyID),
+			Code:    cbc.Code(pts.CompanyID.Value),
 			Scope:   org.IdentityScopeTax,
-			Type:    cbc.Code(pts.TaxScheme.ID),
+			Type:    cbc.Code(pts.TaxScheme.ID.Value),
 		}
 
 		if p.Identities == nil {

--- a/party_test.go
+++ b/party_test.go
@@ -81,12 +81,12 @@ func TestNewParty(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotEmpty(t, doc.AccountingSupplierParty.Party.PartyTaxScheme)
-		assert.Equal(t, "NO923456783MVA", *doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID)
+		assert.Equal(t, "NO923456783MVA", doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID.Value)
 
 		// An already-suffixed code must not be doubled.
 		inv.Supplier.TaxID.Code = "923456783MVA"
 		doc, err = ubl.ConvertInvoice(env)
 		require.NoError(t, err)
-		assert.Equal(t, "NO923456783MVA", *doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID)
+		assert.Equal(t, "NO923456783MVA", doc.AccountingSupplierParty.Party.PartyTaxScheme[0].CompanyID.Value)
 	})
 }

--- a/payment.go
+++ b/payment.go
@@ -53,7 +53,7 @@ type Branch struct {
 	FinancialInstitution *FinancialInstitution `xml:"cac:FinancialInstitution"`
 }
 
-// FinancialInstitution represents a financial institution
+// FinancialInstitution identifies a financial institution by its BIC in cbc:ID.
 type FinancialInstitution struct {
 	ID *string `xml:"cbc:ID"`
 }

--- a/payment.go
+++ b/payment.go
@@ -13,12 +13,14 @@ import (
 type PaymentMeans struct {
 	PaymentMeansCode      IDType            `xml:"cbc:PaymentMeansCode"`
 	PaymentDueDate        *string           `xml:"cbc:PaymentDueDate"`
+	PaymentChannelCode    *IDType           `xml:"cbc:PaymentChannelCode,omitempty"`
 	InstructionID         *string           `xml:"cbc:InstructionID"`
 	InstructionNote       []string          `xml:"cbc:InstructionNote,omitempty"`
 	PaymentID             *string           `xml:"cbc:PaymentID"`
 	CardAccount           *CardAccount      `xml:"cac:CardAccount"`
 	PayerFinancialAccount *FinancialAccount `xml:"cac:PayerFinancialAccount"`
 	PayeeFinancialAccount *FinancialAccount `xml:"cac:PayeeFinancialAccount"`
+	CreditAccount         *CreditAccount    `xml:"cac:CreditAccount"`
 	PaymentMandate        *PaymentMandate   `xml:"cac:PaymentMandate"`
 }
 
@@ -46,13 +48,25 @@ type FinancialAccount struct {
 
 // Branch represents a branch of a financial institution
 type Branch struct {
-	ID   *string `xml:"cbc:ID"`
-	Name *string `xml:"cbc:Name"`
+	ID                   *string               `xml:"cbc:ID"`
+	Name                 *string               `xml:"cbc:Name"`
+	FinancialInstitution *FinancialInstitution `xml:"cac:FinancialInstitution"`
+}
+
+// FinancialInstitution represents a financial institution
+type FinancialInstitution struct {
+	ID *string `xml:"cbc:ID"`
+}
+
+// CreditAccount represents a credit account (e.g. the Danish Giro/FIK account)
+type CreditAccount struct {
+	AccountID string `xml:"cbc:AccountID"`
 }
 
 // PaymentTerms represents the terms of payment
 type PaymentTerms struct {
-	Note string `xml:"cbc:Note"`
+	Note   string  `xml:"cbc:Note,omitempty"`
+	Amount *Amount `xml:"cbc:Amount,omitempty"`
 }
 
 // PrepaidPayment represents a prepaid payment

--- a/totals.go
+++ b/totals.go
@@ -19,14 +19,15 @@ type TaxTotal struct {
 
 // TaxSubtotal represents a tax subtotal
 type TaxSubtotal struct {
-	TaxableAmount Amount      `xml:"cbc:TaxableAmount,omitempty"`
-	TaxAmount     Amount      `xml:"cbc:TaxAmount"`
-	TaxCategory   TaxCategory `xml:"cac:TaxCategory"`
+	TaxableAmount                Amount      `xml:"cbc:TaxableAmount,omitempty"`
+	TaxAmount                    Amount      `xml:"cbc:TaxAmount"`
+	TransactionCurrencyTaxAmount *Amount     `xml:"cbc:TransactionCurrencyTaxAmount,omitempty"`
+	TaxCategory                  TaxCategory `xml:"cac:TaxCategory"`
 }
 
 // TaxCategory represents a tax category
 type TaxCategory struct {
-	ID                     *string    `xml:"cbc:ID,omitempty"`
+	ID                     *IDType    `xml:"cbc:ID,omitempty"`
 	Percent                *string    `xml:"cbc:Percent,omitempty"`
 	TaxExemptionReasonCode *string    `xml:"cbc:TaxExemptionReasonCode,omitempty"`
 	TaxExemptionReason     *string    `xml:"cbc:TaxExemptionReason,omitempty"`
@@ -114,7 +115,7 @@ func (ui *Invoice) addTotals(inv *bill.Invoice, ctx Context) {
 				taxCat := TaxCategory{}
 
 				if k := r.Ext.Get(untdid.ExtKeyTaxCategory).String(); k != "" {
-					taxCat.ID = &k
+					taxCat.ID = &IDType{Value: k}
 				}
 				if v := r.Ext.Get(cef.ExtKeyVATEX).String(); v != "" {
 					taxCat.TaxExemptionReasonCode = &v
@@ -130,14 +131,14 @@ func (ui *Invoice) addTotals(inv *bill.Invoice, ctx Context) {
 				if r.Percent != nil {
 					p := r.Percent.StringWithoutSymbol()
 					taxCat.Percent = &p
-				} else if taxCat.ID == nil || *taxCat.ID != "O" {
+				} else if taxCat.ID == nil || taxCat.ID.Value != "O" {
 					// Default to 0% when not outside scope
 					p := "0"
 					taxCat.Percent = &p
 				}
 
 				if cat.Code != cbc.CodeEmpty {
-					taxCat.TaxScheme = &TaxScheme{ID: cat.Code.String()}
+					taxCat.TaxScheme = &TaxScheme{ID: IDType{Value: cat.Code.String()}}
 				}
 				subtotal.TaxCategory = taxCat
 				ui.TaxTotal[0].TaxSubtotal = append(ui.TaxTotal[0].TaxSubtotal, subtotal)
@@ -158,8 +159,8 @@ func (ui *Invoice) buildTaxCategoryMap() map[string]*taxCategoryInfo {
 	for _, taxTotal := range ui.TaxTotal {
 		for _, subtotal := range taxTotal.TaxSubtotal {
 			if subtotal.TaxCategory.ID != nil && subtotal.TaxCategory.TaxScheme != nil {
-				schemeID := subtotal.TaxCategory.TaxScheme.ID
-				categoryID := *subtotal.TaxCategory.ID
+				schemeID := subtotal.TaxCategory.TaxScheme.ID.Value
+				categoryID := subtotal.TaxCategory.ID.Value
 				key := buildTaxCategoryKey(schemeID, categoryID, subtotal.TaxCategory.Percent)
 				info := &taxCategoryInfo{}
 				if subtotal.TaxCategory.TaxExemptionReasonCode != nil {
@@ -183,9 +184,9 @@ func (ui *Invoice) goblAddTaxNotes(inv *bill.Invoice) {
 				continue
 			}
 			note := &tax.Note{
-				Category: cbc.Code(tc.TaxScheme.ID),
+				Category: cbc.Code(tc.TaxScheme.ID.Value),
 				Text:     cleanString(*tc.TaxExemptionReason),
-				Ext:      tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyTaxCategory: cbc.Code(*tc.ID)}),
+				Ext:      tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyTaxCategory: cbc.Code(tc.ID.Value)}),
 			}
 			inv.Tax = inv.Tax.MergeNotes(note)
 		}

--- a/totals_test.go
+++ b/totals_test.go
@@ -23,7 +23,7 @@ func TestNewTotals(t *testing.T) {
 		assert.Equal(t, "1764.18", doc.LegalMonetaryTotal.PayableAmount.Value)
 
 		assert.Equal(t, "340.20", doc.TaxTotal[0].TaxAmount.Value)
-		assert.Equal(t, "VAT", doc.TaxTotal[0].TaxSubtotal[0].TaxCategory.TaxScheme.ID)
+		assert.Equal(t, "VAT", doc.TaxTotal[0].TaxSubtotal[0].TaxCategory.TaxScheme.ID.Value)
 		assert.Equal(t, "21.0", *doc.TaxTotal[0].TaxSubtotal[0].TaxCategory.Percent)
 	})
 
@@ -44,7 +44,7 @@ func TestNewTotals(t *testing.T) {
 		require.Len(t, doc.TaxTotal[0].TaxSubtotal, 1)
 		tc := doc.TaxTotal[0].TaxSubtotal[0].TaxCategory
 
-		assert.Equal(t, "AE", *tc.ID)
+		assert.Equal(t, "AE", tc.ID.Value)
 		assert.Equal(t, "0", *tc.Percent)
 		require.NotNil(t, tc.TaxExemptionReasonCode)
 		assert.Equal(t, "VATEX-EU-AE", *tc.TaxExemptionReasonCode)


### PR DESCRIPTION
## What

Completes gobl.ubl's generic UBL wire model with the standard UBL attributes and elements that the EN16931/Peppol invoice model leaves empty, so a **country addon can overlay the shared model instead of forking it** (the DK OIOUBL converter is the first consumer). Scoped to invoice + credit-note.

No output changes: every addition is either an omitempty pointer field or a value-only retype, so the EN16931 and Peppol goldens are **byte-identical** (tests pass with no `-update`).

## Why the `ID` fields become `IDType`

OIOUBL (and UBL generally) require several code fields to be emitted **with scheme attributes**, e.g.:

```xml
<cbc:ProfileID schemeID="urn:oioubl:id:profileid-1.2" schemeAgencyID="320">Procurement-BilSim-1.0</cbc:ProfileID>
<cbc:ID schemeID="urn:oioubl:id:taxcategoryid-1.1">StandardRated</cbc:ID>
```

A plain `string` field cannot carry those attributes — it can only hold the element's text. `IDType` is the **existing** gobl.ubl type for exactly this: a chardata `Value` plus optional `schemeID`, `schemeAgencyID`, `listID`, … attributes. It's already how the model represents `InvoiceTypeCode`, `CreditNoteTypeCode` and `PaymentMeansCode`.

So this promotes the following code fields from `string`/`*string` to `IDType`/`*IDType`:

- `Invoice.ProfileID`
- `TaxScheme.ID` and `TaxScheme.TaxTypeCode`
- `TaxCategory.ID`
- `ClassifiedTaxCategory.ID`
- `PartyTaxScheme.CompanyID`


## Other additive fields

Standard UBL fields an overlay needs, all `omitempty` so existing output is unchanged:

- `IDType`: `schemeAgencyID`, `listAgencyID`
- `PaymentMeans`: `PaymentChannelCode`, `CreditAccount`
- `TaxScheme.Name`
- `PostalAddress`: `ID`, `AddressFormatCode`, `Postbox`, `Region`, `District`
- `Contact.ID`, `PaymentTerms.Amount`, `Branch.FinancialInstitution`
- `Delivery.RequestedDeliveryPeriod`, `TaxSubtotal.TransactionCurrencyTaxAmount`

## Compatibility

The `string → IDType` retypes are a **Go source-level change** for any other consumer that reads these fields (they now read `.Value` / set `IDType{Value: …}`). The **XML output is unchanged**. This is the same kind of change already made for `InvoiceTypeCode`/`PaymentMeansCode`.


## Verification

- `GOWORK=off go build ./... && go test ./...` — green, goldens byte-identical (no `-update`)
- `golangci-lint run` — 0 issues; `gofmt` clean
