### PR TITLE
Exporting shared converter helpers for country overlays

### DIFF
--- a/attachments_parse.go
+++ b/attachments_parse.go
@@ -28,10 +28,10 @@ type BinaryAttachment struct {
 	URI string
 }
 
-// goblAddAttachments processes all attachments from the UBL Invoice and returns
+// GoblAddAttachments processes all attachments from the UBL Invoice and returns
 // external reference attachments only.
 // Binary attachments are skipped - use ExtractBinaryAttachments to retrieve them.
-func (ui *Invoice) goblAddAttachments() []*org.Attachment {
+func (ui *Invoice) GoblAddAttachments() []*org.Attachment {
 	var attachments []*org.Attachment
 
 	for _, ref := range ui.AdditionalDocumentReference {
@@ -71,8 +71,8 @@ func (ui *Invoice) processExternalAttachment(ref *Reference) *org.Attachment {
 		}
 	}
 
-	att.Code = cbc.Code(cleanString(ref.ID.Value))
-	att.Description = cleanString(ref.DocumentDescription)
+	att.Code = cbc.Code(CleanString(ref.ID.Value))
+	att.Description = CleanString(ref.DocumentDescription)
 
 	return att
 }

--- a/charges_parse.go
+++ b/charges_parse.go
@@ -55,7 +55,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 		ch.Reason = *ac.AllowanceChargeReason
 	}
 	if ac.Amount.Value != "" {
-		a, err := num.AmountFromString(normalizeNumericString(ac.Amount.Value))
+		a, err := num.AmountFromString(NormalizeNumericString(ac.Amount.Value))
 		if err != nil {
 			return nil, err
 		}
@@ -67,14 +67,14 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 		})
 	}
 	if ac.BaseAmount != nil {
-		b, err := num.AmountFromString(normalizeNumericString(ac.BaseAmount.Value))
+		b, err := num.AmountFromString(NormalizeNumericString(ac.BaseAmount.Value))
 		if err != nil {
 			return nil, err
 		}
 		ch.Base = &b
 	}
 	if ac.MultiplierFactorNumeric != nil {
-		multiplier := normalizeNumericString(*ac.MultiplierFactorNumeric)
+		multiplier := NormalizeNumericString(*ac.MultiplierFactorNumeric)
 		if !strings.HasSuffix(multiplier, "%") {
 			multiplier += "%"
 		}
@@ -86,7 +86,7 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 
 		// Check if there is a base amount
 		if ac.BaseAmount != nil {
-			base, err := num.AmountFromString(normalizeNumericString(ac.BaseAmount.Value))
+			base, err := num.AmountFromString(NormalizeNumericString(ac.BaseAmount.Value))
 			if err != nil {
 				return nil, err
 			}
@@ -105,14 +105,14 @@ func goblCharge(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInfo)
 			ch.Taxes[0].Ext = ch.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, cbc.Code(ac.TaxCategory[0].ID.Value))
 
 			// Look up exemption code from TaxTotal
-			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
+			key := BuildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				ch.Taxes[0].Ext = ch.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))
 			}
 		}
 
 		if ac.TaxCategory[0].Percent != nil {
-			percent := normalizeNumericString(*ac.TaxCategory[0].Percent)
+			percent := NormalizeNumericString(*ac.TaxCategory[0].Percent)
 			if !strings.HasSuffix(percent, "%") {
 				percent += "%"
 			}
@@ -137,7 +137,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 		d.Reason = *ac.AllowanceChargeReason
 	}
 	if ac.Amount.Value != "" {
-		a, err := num.AmountFromString(normalizeNumericString(ac.Amount.Value))
+		a, err := num.AmountFromString(NormalizeNumericString(ac.Amount.Value))
 		if err != nil {
 			return nil, err
 		}
@@ -149,14 +149,14 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 		})
 	}
 	if ac.BaseAmount != nil {
-		b, err := num.AmountFromString(normalizeNumericString(ac.BaseAmount.Value))
+		b, err := num.AmountFromString(NormalizeNumericString(ac.BaseAmount.Value))
 		if err != nil {
 			return nil, err
 		}
 		d.Base = &b
 	}
 	if ac.MultiplierFactorNumeric != nil {
-		multiplier := normalizeNumericString(*ac.MultiplierFactorNumeric)
+		multiplier := NormalizeNumericString(*ac.MultiplierFactorNumeric)
 		if !strings.HasSuffix(multiplier, "%") {
 			multiplier += "%"
 		}
@@ -168,7 +168,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 
 		// Check if there is a base amount
 		if ac.BaseAmount != nil {
-			base, err := num.AmountFromString(normalizeNumericString(ac.BaseAmount.Value))
+			base, err := num.AmountFromString(NormalizeNumericString(ac.BaseAmount.Value))
 			if err != nil {
 				return nil, err
 			}
@@ -187,14 +187,14 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 			d.Taxes[0].Ext = d.Taxes[0].Ext.Set(untdid.ExtKeyTaxCategory, cbc.Code(ac.TaxCategory[0].ID.Value))
 
 			// Look up exemption code from TaxTotal
-			key := buildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
+			key := BuildTaxCategoryKey(ac.TaxCategory[0].TaxScheme.ID.Value, ac.TaxCategory[0].ID.Value, ac.TaxCategory[0].Percent)
 			if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 				d.Taxes[0].Ext = d.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))
 			}
 		}
 
 		if ac.TaxCategory[0].Percent != nil {
-			percentStr := normalizeNumericString(*ac.TaxCategory[0].Percent)
+			percentStr := NormalizeNumericString(*ac.TaxCategory[0].Percent)
 			if !strings.HasSuffix(percentStr, "%") {
 				percentStr += "%"
 			}
@@ -214,7 +214,7 @@ func goblDiscount(ac *AllowanceCharge, taxCategoryMap map[string]*taxCategoryInf
 }
 
 func goblLineCharge(ac *AllowanceCharge) (*bill.LineCharge, error) {
-	amount, err := num.AmountFromString(normalizeNumericString(ac.Amount.Value))
+	amount, err := num.AmountFromString(NormalizeNumericString(ac.Amount.Value))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func goblLineCharge(ac *AllowanceCharge) (*bill.LineCharge, error) {
 		ch.Reason = *ac.AllowanceChargeReason
 	}
 	if ac.MultiplierFactorNumeric != nil {
-		multiplier := normalizeNumericString(*ac.MultiplierFactorNumeric)
+		multiplier := NormalizeNumericString(*ac.MultiplierFactorNumeric)
 		if !strings.HasSuffix(multiplier, "%") {
 			multiplier += "%"
 		}
@@ -242,7 +242,7 @@ func goblLineCharge(ac *AllowanceCharge) (*bill.LineCharge, error) {
 
 		// Check if there is a base amount
 		if ac.BaseAmount != nil {
-			base, err := num.AmountFromString(normalizeNumericString(ac.BaseAmount.Value))
+			base, err := num.AmountFromString(NormalizeNumericString(ac.BaseAmount.Value))
 			if err != nil {
 				return nil, err
 			}
@@ -253,7 +253,7 @@ func goblLineCharge(ac *AllowanceCharge) (*bill.LineCharge, error) {
 }
 
 func goblLineDiscount(ac *AllowanceCharge) (*bill.LineDiscount, error) {
-	a, err := num.AmountFromString(normalizeNumericString(ac.Amount.Value))
+	a, err := num.AmountFromString(NormalizeNumericString(ac.Amount.Value))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func goblLineDiscount(ac *AllowanceCharge) (*bill.LineDiscount, error) {
 		d.Reason = *ac.AllowanceChargeReason
 	}
 	if ac.MultiplierFactorNumeric != nil {
-		multiplier := normalizeNumericString(*ac.MultiplierFactorNumeric)
+		multiplier := NormalizeNumericString(*ac.MultiplierFactorNumeric)
 		if !strings.HasSuffix(multiplier, "%") {
 			multiplier += "%"
 		}
@@ -281,7 +281,7 @@ func goblLineDiscount(ac *AllowanceCharge) (*bill.LineDiscount, error) {
 
 		// Check if there is a base amount
 		if ac.BaseAmount != nil {
-			base, err := num.AmountFromString(normalizeNumericString(ac.BaseAmount.Value))
+			base, err := num.AmountFromString(NormalizeNumericString(ac.BaseAmount.Value))
 			if err != nil {
 				return nil, err
 			}

--- a/common.go
+++ b/common.go
@@ -135,26 +135,26 @@ func getTypeCode(inv *bill.Invoice) (string, error) {
 	return inv.Tax.Ext.Get(untdid.ExtKeyDocumentType).String(), nil
 }
 
-// buildTaxCategoryKey constructs a unique key for a tax category from its scheme ID and category ID.
+// BuildTaxCategoryKey constructs a unique key for a tax category from its scheme ID and category ID.
 // For standard-rate "S" entries the normalized percent is also included, since a single invoice can
 // have multiple S subtotals at different rates (e.g. 10% and 20%). For all other categories (E, K,
 // AE, Z, etc.) there is at most one entry per scheme+category, so the percent is omitted to allow
 // lines and charges that omit the percent element to still match.
 // The percent is normalized so that "20", "20.0", and "20.00" all produce the same key.
-func buildTaxCategoryKey(taxSchemeID, categoryID string, percent *string) string {
+func BuildTaxCategoryKey(taxSchemeID, categoryID string, percent *string) string {
 	if categoryID == "S" {
-		return taxSchemeID + ":" + categoryID + ":" + normalizeTaxPercent(percent)
+		return taxSchemeID + ":" + categoryID + ":" + NormalizeTaxPercent(percent)
 	}
 	return taxSchemeID + ":" + categoryID
 }
 
-// normalizeTaxPercent converts a percent string to a canonical form by stripping trailing zeros,
+// NormalizeTaxPercent converts a percent string to a canonical form by stripping trailing zeros,
 // so that "20", "20.0", and "20.00" all map to "20".
-func normalizeTaxPercent(percent *string) string {
+func NormalizeTaxPercent(percent *string) string {
 	if percent == nil {
 		return ""
 	}
-	s := normalizeNumericString(*percent)
+	s := NormalizeNumericString(*percent)
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return s
@@ -162,11 +162,11 @@ func normalizeTaxPercent(percent *string) string {
 	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
-// normalizeNumericString cleans up numeric strings to ensure they can be parsed correctly.
+// NormalizeNumericString cleans up numeric strings to ensure they can be parsed correctly.
 // It handles:
 // - Leading/trailing whitespace (e.g., " 123.45 " -> "123.45")
 // - Numbers starting with decimal point (e.g., ".07" -> "0.07")
-func normalizeNumericString(s string) string {
+func NormalizeNumericString(s string) string {
 	// Trim whitespace
 	s = strings.TrimSpace(s)
 

--- a/common_test.go
+++ b/common_test.go
@@ -56,7 +56,7 @@ func TestNormalizeNumericString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeNumericString(tt.input)
+			result := NormalizeNumericString(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/date.go
+++ b/date.go
@@ -6,7 +6,8 @@ import (
 	"github.com/invopop/gobl/cal"
 )
 
-func formatDate(date cal.Date) string {
+// FormatDate formats a GOBL date as a UBL date string.
+func FormatDate(date cal.Date) string {
 	if date.IsZero() {
 		return ""
 	}
@@ -14,8 +15,8 @@ func formatDate(date cal.Date) string {
 	return t.Format("2006-01-02")
 }
 
-// parseDate converts a date string to a cal.Date.
-func parseDate(date string) (cal.Date, error) {
+// ParseDate converts a date string to a cal.Date.
+func ParseDate(date string) (cal.Date, error) {
 	t, err := time.Parse("2006-01-02", date)
 	if err != nil {
 		return cal.Date{}, err

--- a/delivery.go
+++ b/delivery.go
@@ -31,13 +31,13 @@ func newDelivery(del *bill.DeliveryDetails, ctx Context) *Delivery {
 	out := new(Delivery)
 
 	if del.Date != nil {
-		date := formatDate(*del.Date)
+		date := FormatDate(*del.Date)
 		out.ActualDeliveryDate = &date
 	}
 
 	if del.Period != nil {
-		end := formatDate(del.Period.End)
-		start := formatDate(del.Period.Start)
+		end := FormatDate(del.Period.End)
+		start := FormatDate(del.Period.Start)
 		out.LatestDeliveryDate = &end
 		out.ActualDeliveryDate = &start
 	}

--- a/delivery_parse.go
+++ b/delivery_parse.go
@@ -16,25 +16,25 @@ func (ui *Invoice) goblAddDelivery(out *bill.Invoice) error {
 			if del.ActualDeliveryDate != nil && del.LatestDeliveryDate != nil {
 				// ZATCA maps delivery period as ActualDeliveryDate (start) +
 				// LatestDeliveryDate (end)
-				start, err := parseDate(*del.ActualDeliveryDate)
+				start, err := ParseDate(*del.ActualDeliveryDate)
 				if err != nil {
 					return err
 				}
-				end, err := parseDate(*del.LatestDeliveryDate)
+				end, err := ParseDate(*del.LatestDeliveryDate)
 				if err != nil {
 					return err
 				}
 				d.Date = &start
 				d.Period = &cal.Period{Start: start, End: end}
 			} else if del.ActualDeliveryDate != nil {
-				deliveryDate, err := parseDate(*del.ActualDeliveryDate)
+				deliveryDate, err := ParseDate(*del.ActualDeliveryDate)
 				if err != nil {
 					return err
 				}
 				d.Date = &deliveryDate
 			}
 			if del.EstimatedDeliveryPeriod != nil {
-				p, err := goblPeriodDates(del.EstimatedDeliveryPeriod)
+				p, err := GoblPeriodDates(del.EstimatedDeliveryPeriod)
 				if err != nil {
 					return err
 				}

--- a/invoice.go
+++ b/invoice.go
@@ -134,8 +134,8 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 		EXTNamespace:            NamespaceEXT,
 		SchemaLocation:          SchemaLocationInvoice,
 		CustomizationID:         customizationID,
-		ID:                      invoiceNumber(inv.Series, inv.Code),
-		IssueDate:               formatDate(inv.IssueDate),
+		ID:                      InvoiceNumber(inv.Series, inv.Code),
+		IssueDate:               FormatDate(inv.IssueDate),
 		AccountingCost:          "", // TODO: ordering cost
 		InvoiceTypeCode:         &IDType{Value: tc},
 		DocumentCurrencyCode:    string(inv.Currency),
@@ -183,13 +183,13 @@ func ublInvoice(inv *bill.Invoice, o *options) (*Invoice, error) {
 
 	// BT-7: VAT point date
 	if inv.ValueDate != nil {
-		out.TaxPointDate = formatDate(*inv.ValueDate)
+		out.TaxPointDate = FormatDate(*inv.ValueDate)
 	}
 
 	if len(inv.Notes) > 0 {
 		var noteTexts []string
 		for _, note := range inv.Notes {
-			if text := formatNote(note); text != "" {
+			if text := FormatNote(note); text != "" {
 				noteTexts = append(noteTexts, text)
 			}
 		}
@@ -251,7 +251,8 @@ func (ui *Invoice) addTaxPoint(t *bill.Tax) {
 	ui.InvoicePeriod[0].DescriptionCode = code
 }
 
-func invoiceNumber(series cbc.Code, code cbc.Code) string {
+// InvoiceNumber joins a GOBL series and code into a UBL document ID.
+func InvoiceNumber(series cbc.Code, code cbc.Code) string {
 	if series == "" {
 		return code.String()
 	}

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -88,7 +88,7 @@ func (ui *Invoice) goblInvoice(o *options) (*bill.Invoice, error) {
 	if err := ui.goblAddPayment(out, o); err != nil {
 		return nil, err
 	}
-	if err := ui.goblAddOrdering(out); err != nil {
+	if err := ui.GoblAddOrdering(out); err != nil {
 		return nil, err
 	}
 	if err := ui.goblAddDelivery(out); err != nil {
@@ -109,7 +109,7 @@ func (ui *Invoice) goblInvoice(o *options) (*bill.Invoice, error) {
 		}
 	}
 
-	out.Attachments = ui.goblAddAttachments()
+	out.Attachments = ui.GoblAddAttachments()
 	ui.goblAddTaxNotes(out)
 
 	return out, nil
@@ -148,7 +148,7 @@ func (ui *Invoice) resolveInvoiceType(out *bill.Invoice, o *options) {
 
 // parseInvoiceDates parses IssueDate, IssueTime, and TaxPointDate (BT-7).
 func (ui *Invoice) parseInvoiceDates(out *bill.Invoice) error {
-	issueDate, err := parseDate(ui.IssueDate)
+	issueDate, err := ParseDate(ui.IssueDate)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func (ui *Invoice) parseInvoiceDates(out *bill.Invoice) error {
 
 	// BT-7: VAT point date
 	if ui.TaxPointDate != "" {
-		vd, err := parseDate(ui.TaxPointDate)
+		vd, err := ParseDate(ui.TaxPointDate)
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ func (ui *Invoice) parseInvoiceNotes(out *bill.Invoice) {
 	}
 	out.Notes = make([]*org.Note, 0, len(ui.Note))
 	for _, note := range ui.Note {
-		out.Notes = append(out.Notes, parseNote(note))
+		out.Notes = append(out.Notes, ParseNote(note))
 	}
 }
 
@@ -209,13 +209,13 @@ func (ui *Invoice) parseBillingReferences(out *bill.Invoice) error {
 		)
 		switch {
 		case ref.InvoiceDocumentReference != nil:
-			docRef, err = goblReference(ref.InvoiceDocumentReference)
+			docRef, err = GoblReference(ref.InvoiceDocumentReference)
 		case ref.SelfBilledInvoiceDocumentReference != nil:
-			docRef, err = goblReference(ref.SelfBilledInvoiceDocumentReference)
+			docRef, err = GoblReference(ref.SelfBilledInvoiceDocumentReference)
 		case ref.CreditNoteDocumentReference != nil:
-			docRef, err = goblReference(ref.CreditNoteDocumentReference)
+			docRef, err = GoblReference(ref.CreditNoteDocumentReference)
 		case ref.AdditionalDocumentReference != nil:
-			docRef, err = goblReference(ref.AdditionalDocumentReference)
+			docRef, err = GoblReference(ref.AdditionalDocumentReference)
 		}
 		if err != nil {
 			return err

--- a/lines.go
+++ b/lines.go
@@ -97,8 +97,8 @@ func (ui *Invoice) addLines(inv *bill.Invoice, context Context) { //nolint:gocyc
 
 		if l.Period != nil {
 			invLine.InvoicePeriod = &Period{
-				StartDate: formatDate(l.Period.Start),
-				EndDate:   formatDate(l.Period.End),
+				StartDate: FormatDate(l.Period.Start),
+				EndDate:   FormatDate(l.Period.End),
 			}
 		}
 

--- a/lines_parse.go
+++ b/lines_parse.go
@@ -44,14 +44,14 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 		// skip this line
 		return nil, nil
 	}
-	price, err := num.AmountFromString(normalizeNumericString(docLine.Price.PriceAmount.Value))
+	price, err := num.AmountFromString(NormalizeNumericString(docLine.Price.PriceAmount.Value))
 	if err != nil {
 		return nil, err
 	}
 
 	if docLine.Price.BaseQuantity != nil {
 		// Base quantity is the number of item units to which the price applies
-		baseQuantity, err := num.AmountFromString(normalizeNumericString(docLine.Price.BaseQuantity.Value))
+		baseQuantity, err := num.AmountFromString(NormalizeNumericString(docLine.Price.BaseQuantity.Value))
 		if err != nil {
 			return nil, err
 		}
@@ -81,13 +81,13 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 		iq = docLine.CreditedQuantity
 	}
 	if iq != nil {
-		line.Quantity, err = num.AmountFromString(normalizeNumericString(iq.Value))
+		line.Quantity, err = num.AmountFromString(NormalizeNumericString(iq.Value))
 		if err != nil {
 			return nil, err
 		}
 
 		if iq.UnitCode != "" {
-			line.Item.Unit = goblUnitFromUNECE(cbc.Code(iq.UnitCode))
+			line.Item.Unit = GoblUnitFromUNECE(cbc.Code(iq.UnitCode))
 		}
 	}
 
@@ -95,7 +95,7 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 		for _, note := range docLine.Note {
 			if note != "" {
 				notes = append(notes, &org.Note{
-					Text: cleanString(note),
+					Text: CleanString(note),
 				})
 			}
 		}
@@ -119,7 +119,7 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 	}
 
 	if docLine.InvoicePeriod != nil {
-		line.Period, err = goblPeriodDates(docLine.InvoicePeriod)
+		line.Period, err = GoblPeriodDates(docLine.InvoicePeriod)
 		if err != nil {
 			return nil, err
 		}
@@ -164,10 +164,10 @@ func calculateRequiredPrecision(price, baseQuantity num.Amount) uint32 {
 
 func goblConvertLineItem(di *Item, item *org.Item) {
 	if di.Name != "" {
-		item.Name = cleanString(di.Name)
+		item.Name = CleanString(di.Name)
 	}
 	if di.Description != nil {
-		item.Description = cleanString(*di.Description)
+		item.Description = CleanString(*di.Description)
 	}
 
 	if di.OriginCountry != nil {
@@ -184,8 +184,8 @@ func goblConvertLineItem(di *Item, item *org.Item) {
 		item.Meta = make(cbc.Meta)
 		for _, property := range *di.AdditionalItemProperty {
 			if property.Name != "" && property.Value != "" {
-				key := formatKey(property.Name)
-				item.Meta[key] = cleanString(property.Value)
+				key := FormatKey(property.Name)
+				item.Meta[key] = CleanString(property.Value)
 			}
 		}
 	}
@@ -208,14 +208,14 @@ func goblConvertLineItemTaxes(di *Item, line *bill.Line, taxCategoryMap map[stri
 		})
 
 		// Try to get exemption code from TaxTotal
-		key := buildTaxCategoryKey(ctc.TaxScheme.ID.Value, ctc.ID.Value, ctc.Percent)
+		key := BuildTaxCategoryKey(ctc.TaxScheme.ID.Value, ctc.ID.Value, ctc.Percent)
 		if info, ok := taxCategoryMap[key]; ok && info.exemptionReasonCode != "" {
 			line.Taxes[0].Ext = line.Taxes[0].Ext.Set(cef.ExtKeyVATEX, cbc.Code(info.exemptionReasonCode))
 		}
 
 	}
 	if ctc.Percent != nil {
-		percentStr := normalizeNumericString(*ctc.Percent)
+		percentStr := NormalizeNumericString(*ctc.Percent)
 		if !strings.HasSuffix(percentStr, "%") {
 			percentStr += "%"
 		}

--- a/ordering.go
+++ b/ordering.go
@@ -86,8 +86,8 @@ func (ui *Invoice) addOrdering(o *bill.Ordering, context Context) {
 		if o.Period != nil {
 			ui.InvoicePeriod = []Period{
 				{
-					StartDate: formatDate(o.Period.Start),
-					EndDate:   formatDate(o.Period.End),
+					StartDate: FormatDate(o.Period.Start),
+					EndDate:   FormatDate(o.Period.End),
 				},
 			}
 		}

--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -21,16 +21,17 @@ func hasOrderingData(o *bill.Ordering) bool {
 		len(o.Identities) > 0
 }
 
-func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
+// GoblAddOrdering maps the UBL order references and period onto the GOBL invoice.
+func (ui *Invoice) GoblAddOrdering(out *bill.Invoice) error {
 	ordering := new(bill.Ordering)
 
 	if ui.BuyerReference != "" {
-		ordering.Code = cbc.Code(cleanString(ui.BuyerReference))
+		ordering.Code = cbc.Code(CleanString(ui.BuyerReference))
 	}
 
 	// GOBL does not currently support multiple periods, so only the first one is taken
 	if len(ui.InvoicePeriod) > 0 {
-		p, err := goblPeriodDates(&ui.InvoicePeriod[0])
+		p, err := GoblPeriodDates(&ui.InvoicePeriod[0])
 		if err != nil {
 			return err
 		}
@@ -50,7 +51,7 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
 	if ui.DespatchDocumentReference != nil {
 		ordering.Despatch = make([]*org.DocumentRef, 0)
 		for _, despatchRef := range ui.DespatchDocumentReference {
-			docRef, err := goblReference(&despatchRef)
+			docRef, err := GoblReference(&despatchRef)
 			if err != nil {
 				return err
 			}
@@ -61,7 +62,7 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
 	if ui.ReceiptDocumentReference != nil {
 		ordering.Receiving = make([]*org.DocumentRef, 0)
 		for _, receiptRef := range ui.ReceiptDocumentReference {
-			docRef, err := goblReference(&receiptRef)
+			docRef, err := GoblReference(&receiptRef)
 			if err != nil {
 				return err
 			}
@@ -95,7 +96,7 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
 	if ui.ContractDocumentReference != nil {
 		ordering.Contracts = make([]*org.DocumentRef, 0)
 		for _, contractRef := range ui.ContractDocumentReference {
-			docRef, err := goblReference(&contractRef)
+			docRef, err := GoblReference(&contractRef)
 			if err != nil {
 				return err
 			}
@@ -106,7 +107,7 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
 	if ui.OriginatorDocumentReference != nil {
 		ordering.Tender = make([]*org.DocumentRef, 0)
 		for _, tenderRef := range ui.OriginatorDocumentReference {
-			docRef, err := goblReference(&tenderRef)
+			docRef, err := GoblReference(&tenderRef)
 			if err != nil {
 				return err
 			}
@@ -141,7 +142,8 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
 	return nil
 }
 
-func goblReference(ref *Reference) (*org.DocumentRef, error) {
+// GoblReference maps a UBL document reference to a GOBL document ref.
+func GoblReference(ref *Reference) (*org.DocumentRef, error) {
 	docRef := &org.DocumentRef{
 		Code: cbc.Code(ref.ID.Value),
 	}
@@ -149,7 +151,7 @@ func goblReference(ref *Reference) (*org.DocumentRef, error) {
 		docRef.Type = cbc.Key(ref.DocumentType)
 	}
 	if ref.IssueDate != "" {
-		refDate, err := parseDate(ref.IssueDate)
+		refDate, err := ParseDate(ref.IssueDate)
 		if err != nil {
 			return nil, err
 		}
@@ -159,10 +161,10 @@ func goblReference(ref *Reference) (*org.DocumentRef, error) {
 		docRef.Ext = docRef.Ext.Set(untdid.ExtKeyDocumentType, cbc.Code(ref.DocumentTypeCode))
 	}
 	if ref.DocumentDescription != "" {
-		docRef.Description = cleanString(ref.DocumentDescription)
+		docRef.Description = CleanString(ref.DocumentDescription)
 	}
 	if ref.ValidityPeriod != nil {
-		p, err := goblPeriodDates(ref.ValidityPeriod)
+		p, err := GoblPeriodDates(ref.ValidityPeriod)
 		if err != nil {
 			return nil, err
 		}
@@ -171,20 +173,21 @@ func goblReference(ref *Reference) (*org.DocumentRef, error) {
 	return docRef, nil
 }
 
-func goblPeriodDates(invoicePeriod *Period) (*cal.Period, error) {
+// GoblPeriodDates maps a UBL period to a GOBL cal.Period.
+func GoblPeriodDates(invoicePeriod *Period) (*cal.Period, error) {
 	if invoicePeriod.StartDate == "" && invoicePeriod.EndDate == "" {
 		return nil, nil
 	}
 	period := &cal.Period{}
 	if invoicePeriod.StartDate != "" {
-		start, err := parseDate(invoicePeriod.StartDate)
+		start, err := ParseDate(invoicePeriod.StartDate)
 		if err != nil {
 			return nil, err
 		}
 		period.Start = start
 	}
 	if invoicePeriod.EndDate != "" {
-		end, err := parseDate(invoicePeriod.EndDate)
+		end, err := ParseDate(invoicePeriod.EndDate)
 		if err != nil {
 			return nil, err
 		}

--- a/party_parse.go
+++ b/party_parse.go
@@ -15,7 +15,7 @@ func goblParty(party *Party, o *options) *org.Party {
 	p := &org.Party{}
 
 	if party.PartyLegalEntity != nil && party.PartyLegalEntity.RegistrationName != nil {
-		p.Name = cleanString(*party.PartyLegalEntity.RegistrationName)
+		p.Name = CleanString(*party.PartyLegalEntity.RegistrationName)
 	}
 
 	if eID := party.EndpointID; eID != nil {
@@ -32,10 +32,10 @@ func goblParty(party *Party, o *options) *org.Party {
 
 	if party.PartyName != nil {
 		if p.Name == "" {
-			p.Name = cleanString(party.PartyName.Name)
+			p.Name = CleanString(party.PartyName.Name)
 		} else if party.PartyName.Name != p.Name {
 			// Only set alias if it's different from the name
-			p.Alias = cleanString(party.PartyName.Name)
+			p.Alias = CleanString(party.PartyName.Name)
 		}
 	}
 
@@ -43,7 +43,7 @@ func goblParty(party *Party, o *options) *org.Party {
 		p.People = []*org.Person{
 			{
 				Name: &org.Name{
-					Given: cleanString(*party.Contact.Name),
+					Given: CleanString(*party.Contact.Name),
 				},
 			},
 		}
@@ -59,14 +59,14 @@ func goblParty(party *Party, o *options) *org.Party {
 		if party.Contact.Telephone != nil {
 			p.Telephones = []*org.Telephone{
 				{
-					Number: cleanString(*party.Contact.Telephone),
+					Number: CleanString(*party.Contact.Telephone),
 				},
 			}
 		}
 		if party.Contact.ElectronicMail != nil {
 			p.Emails = []*org.Email{
 				{
-					Address: cleanString(*party.Contact.ElectronicMail),
+					Address: CleanString(*party.Contact.ElectronicMail),
 				},
 			}
 		}
@@ -89,11 +89,11 @@ func goblDeliveryParty(party *Party) *org.Party {
 	p := &org.Party{}
 
 	if party.PartyLegalEntity != nil && party.PartyLegalEntity.RegistrationName != nil {
-		p.Name = cleanString(*party.PartyLegalEntity.RegistrationName)
+		p.Name = CleanString(*party.PartyLegalEntity.RegistrationName)
 	}
 	if party.PartyName != nil {
 		if p.Name == "" {
-			p.Name = cleanString(party.PartyName.Name)
+			p.Name = CleanString(party.PartyName.Name)
 		}
 	}
 
@@ -113,27 +113,27 @@ func parseAddress(address *PostalAddress) *org.Address {
 		addr.Country = l10n.ISOCountryCode(address.Country.IdentificationCode)
 	}
 	if address.StreetName != nil {
-		addr.Street = cleanString(*address.StreetName)
+		addr.Street = CleanString(*address.StreetName)
 	}
 	if address.AdditionalStreetName != nil {
-		addr.StreetExtra = cleanString(*address.AdditionalStreetName)
+		addr.StreetExtra = CleanString(*address.AdditionalStreetName)
 	}
 	if address.CityName != nil {
-		addr.Locality = cleanString(*address.CityName)
+		addr.Locality = CleanString(*address.CityName)
 	}
 	if address.PostalZone != nil {
-		addr.Code = cbc.Code(cleanString(*address.PostalZone))
+		addr.Code = cbc.Code(CleanString(*address.PostalZone))
 	}
 	if address.CountrySubentity != nil {
-		addr.Region = cleanString(*address.CountrySubentity)
+		addr.Region = CleanString(*address.CountrySubentity)
 	}
 	if address.BuildingNumber != nil {
-		addr.Number = cleanString(*address.BuildingNumber)
+		addr.Number = CleanString(*address.BuildingNumber)
 	}
 	// CitySubdivisionName is used by ZATCA to represent the district,
 	// which maps to StreetExtra in GOBL.
 	if address.CitySubdivisionName != nil && addr.StreetExtra == "" {
-		addr.StreetExtra = cleanString(*address.CitySubdivisionName)
+		addr.StreetExtra = CleanString(*address.CitySubdivisionName)
 	}
 	return addr
 }

--- a/payment.go
+++ b/payment.go
@@ -183,7 +183,7 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 		}
 	}
 	if ui.CreditNoteTypeCode != nil && inv.Payment.Terms != nil && len(inv.Payment.Terms.DueDates) > 0 {
-		formattedDate := formatDate(*inv.Payment.Terms.DueDates[0].Date)
+		formattedDate := FormatDate(*inv.Payment.Terms.DueDates[0].Date)
 		ui.PaymentMeans[0].PaymentDueDate = &formattedDate
 	}
 	// BR-KSA-17: Debit and credit note must contain the
@@ -221,6 +221,6 @@ func (ui *Invoice) addPaymentTerms(pymt *bill.PaymentDetails) {
 
 	// Only one due date allowed under EN 16931
 	if ui.CreditNoteTypeCode == nil && len(pymt.Terms.DueDates) > 0 {
-		ui.DueDate = formatDate(*pymt.Terms.DueDates[0].Date)
+		ui.DueDate = FormatDate(*pymt.Terms.DueDates[0].Date)
 	}
 }

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -46,7 +46,7 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice, o *options) error {
 
 	if ui.PaymentTerms != nil {
 		payment.Terms = &pay.Terms{
-			Notes: cleanString(ui.PaymentTerms.Note),
+			Notes: CleanString(ui.PaymentTerms.Note),
 		}
 	}
 
@@ -59,7 +59,7 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice, o *options) error {
 	}
 
 	if dueDate != "" {
-		d, err := parseDate(dueDate)
+		d, err := ParseDate(dueDate)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice, o *options) error {
 		if len(in.PrepaidPayment) > 0 {
 			payment.Advances = make([]*pay.Record, 0, len(in.PrepaidPayment))
 			for _, p := range in.PrepaidPayment {
-				amount, err := num.AmountFromString(normalizeNumericString(p.PaidAmount.Value))
+				amount, err := num.AmountFromString(NormalizeNumericString(p.PaidAmount.Value))
 				if err != nil {
 					return err
 				}
@@ -97,7 +97,7 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice, o *options) error {
 					Amount: amount,
 				}
 				if p.ReceivedDate != nil {
-					d, err := parseDate(*p.ReceivedDate)
+					d, err := ParseDate(*p.ReceivedDate)
 					if err != nil {
 						return err
 					}
@@ -109,7 +109,7 @@ func (ui *Invoice) goblAddPayment(out *bill.Invoice, o *options) error {
 	*/
 
 	if ui.LegalMonetaryTotal.PrepaidAmount != nil {
-		totalPrepaid, err := num.AmountFromString(normalizeNumericString(ui.LegalMonetaryTotal.PrepaidAmount.Value))
+		totalPrepaid, err := num.AmountFromString(NormalizeNumericString(ui.LegalMonetaryTotal.PrepaidAmount.Value))
 		if err != nil {
 			return err
 		}
@@ -137,7 +137,7 @@ func goblInvoiceInstructions(out *bill.Invoice, paymentMeans *PaymentMeans) *pay
 	}
 
 	if paymentMeans.PaymentMeansCode.Name != nil {
-		instructions.Detail = cleanString(*paymentMeans.PaymentMeansCode.Name)
+		instructions.Detail = CleanString(*paymentMeans.PaymentMeansCode.Name)
 	}
 
 	if paymentMeans.PaymentID != nil {
@@ -164,7 +164,7 @@ func goblCreditTransfer(paymentMeans *PaymentMeans) []*pay.CreditTransfer {
 	account := paymentMeans.PayeeFinancialAccount
 
 	if account.ID != nil {
-		id := cleanString(*account.ID)
+		id := CleanString(*account.ID)
 		if isIBAN(id) {
 			creditTransfer.IBAN = id
 		} else {
@@ -172,10 +172,10 @@ func goblCreditTransfer(paymentMeans *PaymentMeans) []*pay.CreditTransfer {
 		}
 	}
 	if account.Name != nil {
-		creditTransfer.Name = cleanString(*account.Name)
+		creditTransfer.Name = CleanString(*account.Name)
 	}
 	if account.FinancialInstitutionBranch != nil && account.FinancialInstitutionBranch.ID != nil {
-		creditTransfer.BIC = cleanString(*account.FinancialInstitutionBranch.ID)
+		creditTransfer.BIC = CleanString(*account.FinancialInstitutionBranch.ID)
 	}
 
 	return []*pay.CreditTransfer{creditTransfer}

--- a/totals.go
+++ b/totals.go
@@ -161,7 +161,7 @@ func (ui *Invoice) buildTaxCategoryMap() map[string]*taxCategoryInfo {
 			if subtotal.TaxCategory.ID != nil && subtotal.TaxCategory.TaxScheme != nil {
 				schemeID := subtotal.TaxCategory.TaxScheme.ID.Value
 				categoryID := subtotal.TaxCategory.ID.Value
-				key := buildTaxCategoryKey(schemeID, categoryID, subtotal.TaxCategory.Percent)
+				key := BuildTaxCategoryKey(schemeID, categoryID, subtotal.TaxCategory.Percent)
 				info := &taxCategoryInfo{}
 				if subtotal.TaxCategory.TaxExemptionReasonCode != nil {
 					info.exemptionReasonCode = *subtotal.TaxCategory.TaxExemptionReasonCode
@@ -185,7 +185,7 @@ func (ui *Invoice) goblAddTaxNotes(inv *bill.Invoice) {
 			}
 			note := &tax.Note{
 				Category: cbc.Code(tc.TaxScheme.ID.Value),
-				Text:     cleanString(*tc.TaxExemptionReason),
+				Text:     CleanString(*tc.TaxExemptionReason),
 				Ext:      tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyTaxCategory: cbc.Code(tc.ID.Value)}),
 			}
 			inv.Tax = inv.Tax.MergeNotes(note)
@@ -214,11 +214,11 @@ func goblExchangeRates(docCurrency, taxCurrency cur.Code, taxTotals []TaxTotal) 
 		return nil
 	}
 
-	docAmount, err := num.AmountFromString(normalizeNumericString(taxTotals[0].TaxAmount.Value))
+	docAmount, err := num.AmountFromString(NormalizeNumericString(taxTotals[0].TaxAmount.Value))
 	if err != nil || docAmount.IsZero() {
 		return nil
 	}
-	taxAmount, err := num.AmountFromString(normalizeNumericString(taxTotals[1].TaxAmount.Value))
+	taxAmount, err := num.AmountFromString(NormalizeNumericString(taxTotals[1].TaxAmount.Value))
 	if err != nil {
 		return nil
 	}

--- a/utils.go
+++ b/utils.go
@@ -11,15 +11,15 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// cleanString strips the Unicode replacement character (U+FFFD) which can
+// CleanString strips the Unicode replacement character (U+FFFD) which can
 // appear in badly-encoded XML documents and causes canonical JSON
 // serialization to fail.
-func cleanString(s string) string {
+func CleanString(s string) string {
 	return strings.ReplaceAll(s, "\uFFFD", "")
 }
 
-// formatKey formats a string to comply with GOBL key requirements.
-func formatKey(key string) cbc.Key {
+// FormatKey formats a string to comply with GOBL key requirements.
+func FormatKey(key string) cbc.Key {
 	key = strings.ToLower(key)
 	key = strings.ReplaceAll(key, " ", "-")
 	re := regexp.MustCompile(`[^a-z0-9-+]`)
@@ -30,8 +30,8 @@ func formatKey(key string) cbc.Key {
 	return cbc.Key(key)
 }
 
-// goblUnitFromUNECE maps UN/ECE code to GOBL equivalent.
-func goblUnitFromUNECE(unece cbc.Code) org.Unit {
+// GoblUnitFromUNECE maps UN/ECE code to GOBL equivalent.
+func GoblUnitFromUNECE(unece cbc.Code) org.Unit {
 	for _, def := range org.UnitDefinitions {
 		if def.UNECE == unece {
 			return def.Unit
@@ -44,10 +44,10 @@ func goblUnitFromUNECE(unece cbc.Code) org.Unit {
 // UNTDID 4451 text subject qualifier codes, e.g. "#AAI#some text".
 var noteCodePattern = regexp.MustCompile(`^#([A-Z0-9]+)#(.*)$`)
 
-// parseNote converts a raw UBL note string into a GOBL Note. If the string
+// ParseNote converts a raw UBL note string into a GOBL Note. If the string
 // matches the #CODE#text format the code is stored as the untdid text-subject ext.
-func parseNote(text string) *org.Note {
-	text = cleanString(text)
+func ParseNote(text string) *org.Note {
+	text = CleanString(text)
 	if m := noteCodePattern.FindStringSubmatch(text); m != nil {
 		return &org.Note{
 			Ext:  tax.ExtensionsOf(cbc.CodeMap{untdid.ExtKeyTextSubject: cbc.Code(m[1])}),
@@ -57,7 +57,8 @@ func parseNote(text string) *org.Note {
 	return &org.Note{Text: text}
 }
 
-func formatNote(note *org.Note) string {
+// FormatNote renders a GOBL note as its UBL note text.
+func FormatNote(note *org.Note) string {
 	if note == nil {
 		return ""
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -25,7 +25,7 @@ func TestParseDate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseDate(tt.input)
+			result, err := ParseDate(tt.input)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Empty(t, result)
@@ -154,7 +154,7 @@ func TestUnitFromUNECE(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := goblUnitFromUNECE(cbc.Code(tt.input))
+			result := GoblUnitFromUNECE(cbc.Code(tt.input))
 			assert.Equal(t, tt.expected, string(result))
 		})
 	}
@@ -162,12 +162,12 @@ func TestUnitFromUNECE(t *testing.T) {
 
 // Define tests for the FormatKey function
 func TestFormatKey(t *testing.T) {
-	assert.Equal(t, cbc.Key("test"), formatKey("Test"))
-	assert.Equal(t, cbc.Key("test-key-2"), formatKey("Test Key 2"))
-	assert.Equal(t, cbc.Key("multiple-spaces"), formatKey("Multiple   Spaces"))
-	assert.Equal(t, cbc.Key("numbers-123"), formatKey("Numbers 123"))
-	assert.Equal(t, cbc.Key("trailing-space"), formatKey("Trailing Space  "))
-	assert.Equal(t, cbc.Key("mixed-case-with-123-numbers"), formatKey("MiXeD cAsE wItH 123 NuMbErS"))
+	assert.Equal(t, cbc.Key("test"), FormatKey("Test"))
+	assert.Equal(t, cbc.Key("test-key-2"), FormatKey("Test Key 2"))
+	assert.Equal(t, cbc.Key("multiple-spaces"), FormatKey("Multiple   Spaces"))
+	assert.Equal(t, cbc.Key("numbers-123"), FormatKey("Numbers 123"))
+	assert.Equal(t, cbc.Key("trailing-space"), FormatKey("Trailing Space  "))
+	assert.Equal(t, cbc.Key("mixed-case-with-123-numbers"), FormatKey("MiXeD cAsE wItH 123 NuMbErS"))
 }
 
 func TestCalculateRequiredPrecision(t *testing.T) {


### PR DESCRIPTION
## What

Exports a set of internal converter helpers so a **country addon can reuse them instead of copying**, without changing any behaviour. Follow-up to #106 (which completed the wire model); this is the second half that lets the DK OIOUBL overlay call into gobl.ubl rather than fork it.

Promoted to exported:

- **Dates:** `FormatDate`, `ParseDate`
- **Strings:** `CleanString`, `FormatKey`, `NormalizeNumericString`
- **Notes:** `ParseNote`, `FormatNote`
- **Tax:** `BuildTaxCategoryKey`, `NormalizeTaxPercent`
- **Units:** `GoblUnitFromUNECE`
- **Invoice/refs:** `InvoiceNumber`, `GoblReference`, `GoblPeriodDates`
- **Parse methods:** `GoblAddOrdering`, `GoblAddAttachments`

## Why

The DK OIOUBL converter currently keeps byte-for-byte copies of these helpers because they were unexported. Exporting them lets the overlay depend on gobl.ubl directly, so date/string/tax-key formatting stays consistent across all UBL profiles and there's a single place to fix bugs.

## Notes

- **Pure renames** — no logic changed. Every exported func got a terse doc comment where revive required one.
- **Output is byte-identical**: all context goldens (en16931, peppol, france-cius/extended, xrechnung, zatca) are unchanged; tests pass with no `-update`.

## Verification

- `GOWORK=off go build ./... && go test ./...` — green, goldens byte-identical
- `golangci-lint run` — 0 issues; `gofmt` clean
