### PR TITLE
ubl: Parse records transport routing from args, not the document

### DIFF
--- a/context.go
+++ b/context.go
@@ -125,6 +125,8 @@ func isFrenchBillingMode(profileID string) bool {
 
 type options struct {
 	context Context
+	from    cbc.URI
+	to      cbc.URI
 }
 
 // Option is used to define configuration options to use during
@@ -136,6 +138,18 @@ type Option func(*options)
 func WithContext(c Context) Option {
 	return func(o *options) {
 		o.context = c
+	}
+}
+
+// WithRouting supplies the transport addresses the receiving app was routed
+// with (the Peppol SBD From / To — who sent the document, who received it).
+// They are recorded verbatim on the parsed envelope's Head.From / Head.To,
+// regardless of the document type, so a received document is never mislabelled
+// with GOBL's document-derived, outgoing-direction guess. See Invoice.Convert.
+func WithRouting(from, to cbc.URI) Option {
+	return func(o *options) {
+		o.from = from
+		o.to = to
 	}
 }
 

--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -36,13 +36,17 @@ var InvoiceTagMap = map[string][]cbc.Key{
 // It automatically detects the context based on CustomizationID and ProfileID.
 // Binary attachments are ignored during conversion - use ExtractBinaryAttachments
 // to retrieve them separately.
-func (ui *Invoice) Convert() (*gobl.Envelope, error) {
+func (ui *Invoice) Convert(opts ...Option) (*gobl.Envelope, error) {
 	o := new(options)
-
-	// Detect context from the invoice
-	ctx := FindContext(ui.CustomizationID, ui.profileID())
-	if ctx != nil {
+	// Detect the context from the invoice first; callers may then override it
+	// (and supply routing) via opts.
+	if ctx := FindContext(ui.CustomizationID, ui.profileID()); ctx != nil {
 		o.context = *ctx
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(o)
+		}
 	}
 
 	inv, err := ui.goblInvoice(o)
@@ -51,6 +55,9 @@ func (ui *Invoice) Convert() (*gobl.Envelope, error) {
 	}
 
 	env := gobl.NewEnvelope()
+	// Received document: record the transport routing before calculation so
+	// GOBL respects it instead of deriving an outgoing-direction guess.
+	setEnvelopeRouting(env, o)
 	if err := env.Insert(inv); err != nil {
 		return nil, err
 	}

--- a/routing_parse_test.go
+++ b/routing_parse_test.go
@@ -1,0 +1,37 @@
+package ubl_test
+
+import (
+	"testing"
+
+	ubl "github.com/invopop/gobl.ubl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertRoutingFromArgs verifies that a received UBL document records the
+// transport addresses it was routed with (WithRouting) on Head.From / Head.To,
+// rather than GOBL's document-derived, outgoing-direction guess.
+func TestConvertRoutingFromArgs(t *testing.T) {
+	xmlData, err := testLoadXML("discount-taxes.xml")
+	require.NoError(t, err)
+	parse := func(t *testing.T) *ubl.Invoice {
+		t.Helper()
+		doc, err := ubl.Parse(xmlData)
+		require.NoError(t, err)
+		inv, ok := doc.(*ubl.Invoice)
+		require.True(t, ok)
+		return inv
+	}
+
+	t.Run("routing args are recorded verbatim on Head.From/To", func(t *testing.T) {
+		// The routing layer supplies fully-qualified participant URIs; Convert
+		// records them verbatim rather than deriving From/To from the document.
+		env, err := parse(t).Convert(ubl.WithRouting(
+			"iso6523-actorid-upis::0192:sender",
+			"iso6523-actorid-upis::0192:receiver",
+		))
+		require.NoError(t, err)
+		assert.Equal(t, "iso6523-actorid-upis::0192:sender", string(env.Head.From))
+		assert.Equal(t, "iso6523-actorid-upis::0192:receiver", string(env.Head.To))
+	})
+}

--- a/ubl.go
+++ b/ubl.go
@@ -13,6 +13,19 @@ import (
 	"github.com/invopop/xmlctx"
 )
 
+// setEnvelopeRouting records the transport addresses the document was received
+// with (opts' WithRouting) on the envelope's Head.From / Head.To, BEFORE the
+// envelope is calculated. The addresses are the fully-qualified participant
+// URIs the routing layer supplies and are recorded verbatim. GOBL's
+// normalizeRouting only fills empty routing fields, so setting them first makes
+// it respect them rather than derive them from the document assuming an
+// outgoing (supplier→customer) direction — wrong for a received document.
+// Applies to any document type.
+func setEnvelopeRouting(env *gobl.Envelope, o *options) {
+	env.Head.From = o.from
+	env.Head.To = o.to
+}
+
 var (
 	// ErrUnknownDocumentType is returned when the document type
 	// is not recognized during parsing.


### PR DESCRIPTION
## What

Adds a `WithRouting(from, to)` option and has `Invoice.Convert` record those
transport addresses on the parsed envelope's `Head.From` / `Head.To`, **before**
calculation.

## Why

A parsed UBL document is one we *received*, so its `Head.From/To` should be the
transport addresses the receiving app was routed with (who sent it → who
received it). Previously `Convert` left routing unset, so `normalizeRouting`
derived it from the document assuming an **outgoing** direction (supplier →
customer) — mislabelling who received an inbound document.

Setting the routing from the args before `env.Insert` makes GOBL respect them
(`normalizeRouting` only fills empty routing fields). The args are recorded
**verbatim** — ubl does not qualify them; the routing layer supplies
fully-qualified `iso6523-actorid-upis::…` participant URIs (see invopop/peppol#80).

`Convert` detects the invoice's context first and then applies opts, so a
caller-supplied `WithContext` takes effect. `setEnvelopeRouting` is
document-type agnostic, so future parsed types get the same treatment. Mirrors
the gobl.cii change.

## Coordinates with

- invopop/peppol#80 — supplies the fully-qualified routing args
- invopop/gobl.cii#64 — the symmetric CII change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
