### PR TITLE
feat: map CompanyLegalForm to/from party registration (BT-33)

### DIFF
--- a/party.go
+++ b/party.go
@@ -143,6 +143,14 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 		}
 	}
 
+	// BT-33: additional legal information (cbc:CompanyLegalForm)
+	if party.Registration != nil && party.Registration.Other != "" {
+		if p.PartyLegalEntity == nil {
+			p.PartyLegalEntity = &PartyLegalEntity{}
+		}
+		p.PartyLegalEntity.CompanyLegalForm = &party.Registration.Other
+	}
+
 	contact := &Contact{}
 
 	if tID := party.TaxID; tID != nil && party.TaxID.Code != "" {

--- a/party_parse.go
+++ b/party_parse.go
@@ -18,6 +18,13 @@ func goblParty(party *Party, o *options) *org.Party {
 		p.Name = cleanString(*party.PartyLegalEntity.RegistrationName)
 	}
 
+	// BT-33: additional legal information (cbc:CompanyLegalForm)
+	if party.PartyLegalEntity != nil && party.PartyLegalEntity.CompanyLegalForm != nil {
+		p.Registration = &org.Registration{
+			Other: cleanString(*party.PartyLegalEntity.CompanyLegalForm),
+		}
+	}
+
 	if eID := party.EndpointID; eID != nil {
 		oi := new(org.Inbox)
 		switch eID.SchemeID {

--- a/party_test.go
+++ b/party_test.go
@@ -70,6 +70,28 @@ func TestNewParty(t *testing.T) {
 		assert.Equal(t, "0088", *doc.PayeeParty.PartyLegalEntity.CompanyID.SchemeID)
 	})
 
+	t.Run("registration maps to CompanyLegalForm for supplier and customer", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-complete.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		// BT-33: additional legal information (cbc:CompanyLegalForm).
+		inv.Supplier.Registration = &org.Registration{Other: "Share capital 100.000 EUR"}
+		inv.Customer.Registration = &org.Registration{Other: "GmbH"}
+
+		require.NoError(t, env.Calculate())
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+
+		require.NotNil(t, doc.AccountingSupplierParty.Party.PartyLegalEntity)
+		require.NotNil(t, doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyLegalForm)
+		assert.Equal(t, "Share capital 100.000 EUR", *doc.AccountingSupplierParty.Party.PartyLegalEntity.CompanyLegalForm)
+
+		require.NotNil(t, doc.AccountingCustomerParty.Party.PartyLegalEntity)
+		require.NotNil(t, doc.AccountingCustomerParty.Party.PartyLegalEntity.CompanyLegalForm)
+		assert.Equal(t, "GmbH", *doc.AccountingCustomerParty.Party.PartyLegalEntity.CompanyLegalForm)
+	})
+
 	t.Run("norwegian VAT numbers carry the MVA suffix", func(t *testing.T) {
 		env := loadTestEnvelope(t, "invoice-complete.json")
 		inv, ok := env.Extract().(*bill.Invoice)

--- a/test/data/parse/en16931/out/ubl-example5.json
+++ b/test/data/parse/en16931/out/ubl-example5.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bed7c079ba1f06d65d5d80337e1f4518e4b8998c66577586a3e0d71b5b81e961"
+			"val": "c3c224719103d2feff58506fd5f98288784e6e7f6bcd6a5a00b729b7eb9c874f"
 		}
 	},
 	"doc": {
@@ -352,7 +352,10 @@
 					{
 						"num": "+3198989898"
 					}
-				]
+				],
+				"registration": {
+					"other": "Export"
+				}
 			},
 			"projects": [
 				{

--- a/test/data/parse/france-cius/out/b2b-reg.json
+++ b/test/data/parse/france-cius/out/b2b-reg.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0062de6133202ae69d0b482d66135ac9fe7fdbc7a7a76fdfff54347cd344056b"
+			"val": "ebca6f5a2a7f0ff6a3c6851e117bc263a331ef8616ea6475fa9c611bf2790780"
 		},
 		"from": "iso6523-actorid-upis::0225:324872211",
 		"to": "iso6523-actorid-upis::0225:439368049"
@@ -106,7 +106,10 @@
 				{
 					"num": "01 02 03 54 87"
 				}
-			]
+			],
+			"registration": {
+				"other": "SARL AU CAPITAL DE 50 000 EUROS"
+			}
 		},
 		"customer": {
 			"name": "LE CLIENT",

--- a/test/data/parse/peppol/out/Allowance-example.json
+++ b/test/data/parse/peppol/out/Allowance-example.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "21af8297969d61908fcbcf7639447953fc1600ddc9275967d39602cd3b9e62d5"
+			"val": "76724bc2486df928a94003df9b3d9ef63d69ea2c553ec758dd05cc1296576f8b"
 		}
 	},
 	"doc": {
@@ -72,7 +72,10 @@
 					"code": "GB 123 EW",
 					"country": "GB"
 				}
-			]
+			],
+			"registration": {
+				"other": "AdditionalLegalInformation"
+			}
 		},
 		"customer": {
 			"name": "Buyer Official Name",

--- a/test/data/parse/peppol/out/Vat-category-S.json
+++ b/test/data/parse/peppol/out/Vat-category-S.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "443a92b49a6d800f948b6961cf2552a17d108ab61e6d2f0a16aa459cf6693839"
+			"val": "f1a1aa239a54364209e5ac0991105031d43b7a713b31a45d6c865b1a638730fe"
 		}
 	},
 	"doc": {
@@ -74,7 +74,10 @@
 				{
 					"num": "9384203984"
 				}
-			]
+			],
+			"registration": {
+				"other": "AdditionalLegalInformation"
+			}
 		},
 		"customer": {
 			"name": "Buyer Official Name",


### PR DESCRIPTION
## What

Maps the UBL `cac:PartyLegalEntity/cbc:CompanyLegalForm` element — **BT-33 "Seller additional legal information"** in the EN 16931 semantic model — to and from GOBL's `org.Party.Registration`, for **both the supplier and customer** parties.

## How

- **GOBL → UBL** (`newParty` in `party.go`): when `party.Registration.Other` is set, emit it as `cbc:CompanyLegalForm` (creating `PartyLegalEntity` if needed).
- **UBL → GOBL** (`goblParty` in `party_parse.go`): when `cbc:CompanyLegalForm` is present, populate `party.registration.other`.

Both the supplier and the customer flow through these shared helpers, so the mapping covers both at once (`$.doc.supplier.registration` and `$.doc.customer.registration`).

The free-text value lands in `registration.other`, the catch-all field of `org.Registration` — the natural fit for BT-33's free-text legal information.

## Tests

- Added a round-trip unit test asserting `CompanyLegalForm` is emitted for both supplier and customer.
- Regenerated four `parse` golden files whose source XML already carried `cbc:CompanyLegalForm` (e.g. `b2b-reg.xml` → `"other": "SARL AU CAPITAL DE 50 000 EUROS"`), confirming the UBL → GOBL direction.
- Full suite + `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)