### PR TITLE
feat: map party electronic address via the endpoint object

### DIFF
--- a/party.go
+++ b/party.go
@@ -14,6 +14,14 @@ import (
 // SchemeIDEmail is the EAS codelist value for email
 const SchemeIDEmail = "EM"
 
+// mailtoScheme is the URI scheme GOBL uses for email endpoints
+// (e.g. "mailto:billing@example.com").
+const mailtoScheme = "mailto"
+
+// peppolEndpointScheme is the URI scheme GOBL uses for Peppol participant
+// identifier endpoints (e.g. "iso6523-actorid-upis::9930:111111125").
+const peppolEndpointScheme = "iso6523-actorid-upis"
+
 // TaxSchemeVAT is the tax scheme code for VAT
 const TaxSchemeVAT = "VAT"
 
@@ -42,6 +50,40 @@ type Party struct {
 type EndpointID struct {
 	SchemeID string `xml:"schemeID,attr"`
 	Value    string `xml:",chardata"`
+}
+
+// newEndpointID maps a party's preferred electronic address (its first
+// endpoint) to a UBL EndpointID. It understands the two URI forms emitted
+// by GOBL normalization:
+//   - "mailto:<address>"                      -> schemeID "EM"
+//   - "iso6523-actorid-upis::<scheme>:<code>" -> schemeID "<scheme>"
+func newEndpointID(party *org.Party) *EndpointID {
+	ep := party.FirstEndpoint()
+	if ep == nil {
+		return nil
+	}
+	switch ep.URI.Scheme() {
+	case mailtoScheme:
+		if addr := ep.URI.Opaque(); addr != "" {
+			return &EndpointID{SchemeID: SchemeIDEmail, Value: addr}
+		}
+	case peppolEndpointScheme:
+		if scheme, code, ok := splitPeppolEndpoint(ep.URI.Opaque()); ok {
+			return &EndpointID{SchemeID: scheme, Value: code}
+		}
+	}
+	return nil
+}
+
+// splitPeppolEndpoint splits the opaque part of an
+// "iso6523-actorid-upis::<scheme>:<code>" URI (which URL parsing exposes
+// as ":<scheme>:<code>") into its scheme and code components.
+func splitPeppolEndpoint(opaque string) (scheme, code string, ok bool) {
+	parts := strings.SplitN(strings.TrimPrefix(opaque, ":"), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 // Identification represents an identification
@@ -204,20 +246,7 @@ func newParty(party *org.Party, ctx Context) *Party { //nolint:gocyclo
 		p.Contact = contact
 	}
 
-	if len(party.Inboxes) > 0 {
-		ib := party.Inboxes[0]
-		if ib.Email != "" {
-			p.EndpointID = &EndpointID{
-				SchemeID: SchemeIDEmail,
-				Value:    ib.Email,
-			}
-		} else if ib.Scheme != "" {
-			p.EndpointID = &EndpointID{
-				SchemeID: ib.Scheme.String(),
-				Value:    ib.Code.String(),
-			}
-		}
-	}
+	p.EndpointID = newEndpointID(party)
 
 	if party.Alias != "" {
 		p.PartyName = &PartyName{

--- a/party_parse.go
+++ b/party_parse.go
@@ -18,16 +18,8 @@ func goblParty(party *Party, o *options) *org.Party {
 		p.Name = cleanString(*party.PartyLegalEntity.RegistrationName)
 	}
 
-	if eID := party.EndpointID; eID != nil {
-		oi := new(org.Inbox)
-		switch eID.SchemeID {
-		case "EM": // email
-			oi.Email = eID.Value
-		default:
-			oi.Scheme = cbc.Code(eID.SchemeID)
-			oi.Code = cbc.Code(eID.Value)
-		}
-		p.Inboxes = append(p.Inboxes, oi)
+	if ep := goblEndpoint(party.EndpointID); ep != nil {
+		p.Endpoints = append(p.Endpoints, ep)
 	}
 
 	if party.PartyName != nil {
@@ -77,6 +69,23 @@ func goblParty(party *Party, o *options) *org.Party {
 	handlePartyIdentifications(party, p, o)
 
 	return p
+}
+
+// goblEndpoint maps a UBL EndpointID to a GOBL endpoint URI:
+//   - schemeID "EM" -> "mailto:<value>"
+//   - any other EAS -> "iso6523-actorid-upis::<schemeID>:<value>"
+func goblEndpoint(eID *EndpointID) *org.Endpoint {
+	if eID == nil || eID.Value == "" || eID.SchemeID == "" {
+		return nil
+	}
+	var uri cbc.URI
+	switch eID.SchemeID {
+	case SchemeIDEmail: // email
+		uri = cbc.URI(mailtoScheme + ":" + eID.Value)
+	default:
+		uri = cbc.URI(peppolEndpointScheme + "::" + eID.SchemeID + ":" + eID.Value)
+	}
+	return &org.Endpoint{URI: uri}
 }
 
 // goblDeliveryParty creates a GOBL party with only the BTs available

--- a/party_parse_test.go
+++ b/party_parse_test.go
@@ -52,8 +52,7 @@ func TestParseParty(t *testing.T) {
 		assert.Equal(t, "Antonio Salesmacher", seller.People[0].Name.Given)
 		assert.Equal(t, "antonio@salescompany.no", seller.Emails[0].Address)
 		assert.Equal(t, "46211230", seller.Telephones[0].Number)
-		assert.Equal(t, "seller@email.de", seller.Inboxes[0].Email)
-		assert.Equal(t, "", seller.Inboxes[0].Scheme.String())
+		assert.Equal(t, "mailto:seller@email.de", seller.Endpoints[0].URI.String())
 
 		customer := inv.Customer
 		require.NotNil(t, customer)
@@ -126,8 +125,7 @@ func TestParseParty(t *testing.T) {
 		assert.Equal(t, cbc.Code("123 45"), supplier.Addresses[0].Code)
 		assert.Equal(t, l10n.ISOCountryCode("BE"), supplier.Addresses[0].Country)
 
-		assert.Equal(t, "0151", supplier.Inboxes[0].Scheme.String())
-		assert.Equal(t, "99100100100", supplier.Inboxes[0].Code.String())
+		assert.Equal(t, "iso6523-actorid-upis::0151:99100100100", supplier.Endpoints[0].URI.String())
 
 	})
 }

--- a/test/data/convert/en16931/invoice-attachments.json
+++ b/test/data/convert/en16931/invoice-attachments.json
@@ -38,6 +38,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "inbox@example.com"

--- a/test/data/convert/en16931/invoice-complete.json
+++ b/test/data/convert/en16931/invoice-complete.json
@@ -39,6 +39,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "inbox@example.com"

--- a/test/data/convert/france-cius/credit-note-fr.json
+++ b/test/data/convert/france-cius/credit-note-fr.json
@@ -7,7 +7,7 @@
 			"val": "f9eb179a4a90faf19af2b198312d65680f06f145b967df7090a7711b7210e055"
 		},
 		"from": "iso6523-actorid-upis::0225:334175221",
-		"to": "iso6523-actorid-upis::9957:552100554"
+		"to": "iso6523-actorid-upis::0225:552100554"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",

--- a/test/data/convert/france-cius/credit-note-fr.json
+++ b/test/data/convert/france-cius/credit-note-fr.json
@@ -110,7 +110,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::9957:552100554"
+					"uri": "iso6523-actorid-upis::0225:552100554"
 				}
 			],
 			"inboxes": [

--- a/test/data/convert/france-cius/invoice-fr-cius.json
+++ b/test/data/convert/france-cius/invoice-fr-cius.json
@@ -7,7 +7,7 @@
 			"val": "4483daaa187e1495cd522cbe2620488ebcb4c19d1863ca5f43cefbc6ab3fa056"
 		},
 		"from": "iso6523-actorid-upis::0225:334175221",
-		"to": "iso6523-actorid-upis::9957:552100554"
+		"to": "iso6523-actorid-upis::0225:552100554"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",

--- a/test/data/convert/france-cius/invoice-fr-cius.json
+++ b/test/data/convert/france-cius/invoice-fr-cius.json
@@ -103,7 +103,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::9957:552100554"
+					"uri": "iso6523-actorid-upis::0225:552100554"
 				}
 			],
 			"inboxes": [

--- a/test/data/convert/france-extended/invoice-fr-extended-detailed.json
+++ b/test/data/convert/france-extended/invoice-fr-extended-detailed.json
@@ -43,7 +43,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::9957:334175221"
+					"uri": "iso6523-actorid-upis::0225:334175221"
 				}
 			],
 			"inboxes": [
@@ -80,7 +80,7 @@
 			},
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::9957:552100554"
+					"uri": "iso6523-actorid-upis::0225:552100554"
 				}
 			],
 			"inboxes": [

--- a/test/data/convert/france-extended/invoice-fr-extended-detailed.json
+++ b/test/data/convert/france-extended/invoice-fr-extended-detailed.json
@@ -6,8 +6,8 @@
 			"alg": "sha256",
 			"val": "a2b28e38062700aa4c15257f31dcdf77be0a4d539f0223884591048b2d3d5547"
 		},
-		"from": "iso6523-actorid-upis::9957:334175221",
-		"to": "iso6523-actorid-upis::9957:552100554"
+		"from": "iso6523-actorid-upis::0225:334175221",
+		"to": "iso6523-actorid-upis::0225:552100554"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",

--- a/test/data/convert/france-extended/invoice-fr-extended.json
+++ b/test/data/convert/france-extended/invoice-fr-extended.json
@@ -43,7 +43,7 @@
 			],
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::9957:334175221"
+					"uri": "iso6523-actorid-upis::0225:334175221"
 				}
 			],
 			"inboxes": [
@@ -80,7 +80,7 @@
 			},
 			"endpoints": [
 				{
-					"uri": "iso6523-actorid-upis::9957:552100554"
+					"uri": "iso6523-actorid-upis::0225:552100554"
 				}
 			],
 			"inboxes": [

--- a/test/data/convert/france-extended/invoice-fr-extended.json
+++ b/test/data/convert/france-extended/invoice-fr-extended.json
@@ -6,8 +6,8 @@
 			"alg": "sha256",
 			"val": "004d79df173676f9e56f16b764e1f731dd522cbb038c7b17858ebe0d5f419ba1"
 		},
-		"from": "iso6523-actorid-upis::9957:334175221",
-		"to": "iso6523-actorid-upis::9957:552100554"
+		"from": "iso6523-actorid-upis::0225:334175221",
+		"to": "iso6523-actorid-upis::0225:552100554"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",

--- a/test/data/convert/invoice-attachments.json
+++ b/test/data/convert/invoice-attachments.json
@@ -38,6 +38,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "inbox@example.com"

--- a/test/data/convert/invoice-complete.json
+++ b/test/data/convert/invoice-complete.json
@@ -38,6 +38,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:inbox@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "inbox@example.com"

--- a/test/data/convert/peppol/invoice-intra-comunity.json
+++ b/test/data/convert/peppol/invoice-intra-comunity.json
@@ -41,6 +41,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::9930:111111125"
+				}
+			],
 			"inboxes": [
 				{
 					"scheme": "9930",

--- a/test/data/convert/xrechnung/credit-note-xr.json
+++ b/test/data/convert/xrechnung/credit-note-xr.json
@@ -47,6 +47,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"key": "email",
@@ -79,6 +84,11 @@
 				"country": "DE",
 				"code": "282741168"
 			},
+			"endpoints": [
+				{
+					"uri": "mailto:email@sample.com"
+				}
+			],
 			"inboxes": [
 				{
 					"key": "email",

--- a/test/data/convert/xrechnung/invoice-due-date-with-notes.json
+++ b/test/data/convert/xrechnung/invoice-due-date-with-notes.json
@@ -51,6 +51,11 @@
 					]
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "billing@example.com"
@@ -82,6 +87,11 @@
 				"country": "DE",
 				"code": "282741168"
 			},
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"email": "billing@example.com"

--- a/test/data/convert/xrechnung/invoice-xr-minimal.json
+++ b/test/data/convert/xrechnung/invoice-xr-minimal.json
@@ -39,6 +39,11 @@
 					}
 				}
 			],
+			"endpoints": [
+				{
+					"uri": "mailto:billing@example.com"
+				}
+			],
 			"inboxes": [
 				{
 					"key": "email",
@@ -71,6 +76,11 @@
 				"country": "DE",
 				"code": "282741168"
 			},
+			"endpoints": [
+				{
+					"uri": "mailto:email@sample.com"
+				}
+			],
 			"inboxes": [
 				{
 					"key": "email",

--- a/test/data/parse/en16931/out/ubl-example2.json
+++ b/test/data/parse/en16931/out/ubl-example2.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "282d97abc8a84964422902cedce112870524853712a3f3aae77eeddf1998d769"
+			"val": "86ee9e83da867f403ead25d09c9c84c3fa1dbb4b09ffd0422691e6122674f016"
 		}
 	},
 	"doc": {
@@ -399,9 +399,9 @@
 						}
 					}
 				],
-				"inboxes": [
+				"endpoints": [
 					{
-						"email": "seller@email.de"
+						"uri": "mailto:seller@email.de"
 					}
 				],
 				"addresses": [

--- a/test/data/parse/en16931/out/ubl-example5.json
+++ b/test/data/parse/en16931/out/ubl-example5.json
@@ -4,8 +4,9 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bed7c079ba1f06d65d5d80337e1f4518e4b8998c66577586a3e0d71b5b81e961"
-		}
+			"val": "dce32bdb5f350174f0ca7810232ac88e45ccf7b4734dc541b158832ed02ada80"
+		},
+		"to": "mailto:info@buyercompany.dk"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -80,9 +81,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"email": "info@buyercompany.dk"
+					"uri": "mailto:info@buyercompany.dk"
 				}
 			],
 			"addresses": [
@@ -328,9 +329,9 @@
 						}
 					}
 				],
-				"inboxes": [
+				"endpoints": [
 					{
-						"email": "info@selco.nl"
+						"uri": "mailto:info@selco.nl"
 					}
 				],
 				"addresses": [

--- a/test/data/parse/france-cius/out/b2b-reg.json
+++ b/test/data/parse/france-cius/out/b2b-reg.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0062de6133202ae69d0b482d66135ac9fe7fdbc7a7a76fdfff54347cd344056b"
+			"val": "93e99f6b9c1d74c2c7e0ad7428526c68e9556ad6cecb5762682b7736e85762f1"
 		},
 		"from": "iso6523-actorid-upis::0225:324872211",
 		"to": "iso6523-actorid-upis::0225:439368049"
@@ -81,13 +81,6 @@
 					"uri": "iso6523-actorid-upis::0225:324872211"
 				}
 			],
-			"inboxes": [
-				{
-					"key": "peppol",
-					"scheme": "0225",
-					"code": "324872211"
-				}
-			],
 			"addresses": [
 				{
 					"street": "35 rue d'ici",
@@ -133,13 +126,6 @@
 			"endpoints": [
 				{
 					"uri": "iso6523-actorid-upis::0225:439368049"
-				}
-			],
-			"inboxes": [
-				{
-					"key": "peppol",
-					"scheme": "0225",
-					"code": "439368049"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/Allowance-example.json
+++ b/test/data/parse/peppol/out/Allowance-example.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "21af8297969d61908fcbcf7639447953fc1600ddc9275967d39602cd3b9e62d5"
-		}
+			"val": "a73c7fc0848d2bedf25903b82da94acc0dad67d06e3a6fc40d5d92f360c942a7"
+		},
+		"from": "iso6523-actorid-upis::0088:7300010000001",
+		"to": "iso6523-actorid-upis::0002:4598375937"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -58,10 +60,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "7300010000001"
+					"uri": "iso6523-actorid-upis::0088:7300010000001"
 				}
 			],
 			"addresses": [
@@ -103,10 +104,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "4598375937"
+					"uri": "iso6523-actorid-upis::0002:4598375937"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/Vat-category-S.json
+++ b/test/data/parse/peppol/out/Vat-category-S.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "443a92b49a6d800f948b6961cf2552a17d108ab61e6d2f0a16aa459cf6693839"
-		}
+			"val": "ca9ec0753041096405fea20611380ccfc79d1195afac1334df950b7c1f50bf3c"
+		},
+		"from": "iso6523-actorid-upis::0088:7300010000001",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -50,10 +52,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "7300010000001"
+					"uri": "iso6523-actorid-upis::0088:7300010000001"
 				}
 			],
 			"addresses": [
@@ -98,10 +99,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/base-creditnote-correction.json
+++ b/test/data/parse/peppol/out/base-creditnote-correction.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0800c3aad5d8d5778eb42b502749096db799db35f801d69272b9117d2e8648b1"
-		}
+			"val": "d548807fd5a48ec2843883129f0792beb3cb61cda741436bd6a858e09bd61b28"
+		},
+		"from": "iso6523-actorid-upis::0088:9482348239847239874",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -45,10 +47,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -90,10 +91,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/base-example.json
+++ b/test/data/parse/peppol/out/base-example.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "4f143bec72342b8f0eba109d78cb4cab14f7df576fa2d585851169d6b87716f3"
-		}
+			"val": "1d8977121f613bc618ba3b77477d8836ef4d9132d34bedc76e6d44353cee6864"
+		},
+		"from": "iso6523-actorid-upis::0088:9482348239847239874",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -40,10 +42,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -85,10 +86,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/base-negative-inv-correction.json
+++ b/test/data/parse/peppol/out/base-negative-inv-correction.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "5a4c9b5d6cbbc1951e90963044ba31bb4ae3df2ed32d023c31629437fbdfc58e"
-		}
+			"val": "48845adaf929bf34b0acaf448ad6653b40c6e03fd2181d09aa50d4961977c0dd"
+		},
+		"from": "iso6523-actorid-upis::0088:9482348239847239874",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -45,10 +47,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -90,10 +91,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/example-encoding.json
+++ b/test/data/parse/peppol/out/example-encoding.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6ec4f2539268d2d60895aee1cb49b684c76614699f4639e5ad336d63059f6ee9"
-		}
+			"val": "0de99a066fad6827cc49b531fd0fff6bbac30ab281eef3d49d663cd218b0c0b8"
+		},
+		"from": "iso6523-actorid-upis::0088:1234567890123",
+		"to": "iso6523-actorid-upis::0088:9876543210987"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -37,10 +39,9 @@
 					"code": "HRB12345"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "1234567890123"
+					"uri": "iso6523-actorid-upis::0088:1234567890123"
 				}
 			],
 			"addresses": [
@@ -65,10 +66,9 @@
 					"code": "HRB98765"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9876543210987"
+					"uri": "iso6523-actorid-upis::0088:9876543210987"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/invoice-peppol.json
+++ b/test/data/parse/peppol/out/invoice-peppol.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "4b46f9a01f0c0b693586695bf9bd6661b556126514db8715fc8dda4a0beb679b"
-		}
+			"val": "4e7877e5d15e5a0246042e6961ab3762b0f2d757adc95ccf5b242869ee1c12c6"
+		},
+		"from": "iso6523-actorid-upis::0151:99100100100",
+		"to": "iso6523-actorid-upis::0007:TBCNTRLS1001"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -38,10 +40,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0151",
-					"code": "99100100100"
+					"uri": "iso6523-actorid-upis::0151:99100100100"
 				}
 			],
 			"addresses": [
@@ -67,10 +68,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0007",
-					"code": "TBCNTRLS1001"
+					"uri": "iso6523-actorid-upis::0007:TBCNTRLS1001"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/nbio-stuck-ubl.json
+++ b/test/data/parse/peppol/out/nbio-stuck-ubl.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2c12a5fb0ae6183d8d1943bc13ab4280ef57a02a992ed08ae54f6e510f285f95"
-		}
+			"val": "1238cc7e1ed3915d71061662dd79cef13fe83d673c7637ce252015e13a5be52f"
+		},
+		"from": "iso6523-actorid-upis::9925:BE0123456789",
+		"to": "iso6523-actorid-upis::0208:0987654321"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -56,10 +58,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "9925",
-					"code": "BE0123456789"
+					"uri": "iso6523-actorid-upis::9925:BE0123456789"
 				}
 			],
 			"addresses": [
@@ -109,10 +110,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0208",
-					"code": "0987654321"
+					"uri": "iso6523-actorid-upis::0208:0987654321"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/partial-invoice.json
+++ b/test/data/parse/peppol/out/partial-invoice.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "da1925d0d653fae45d9d844df3c4d44a6c551008de218c2ee7c7c34e42531541"
-		}
+			"val": "4d4ce8bc59e99fca3a2e910763eced90f14052d2eaf2eafaaf0fdc25c3a52c69"
+		},
+		"from": "iso6523-actorid-upis::0088:9482348239847239874",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -43,10 +45,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -88,10 +89,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/proforma-invoice.json
+++ b/test/data/parse/peppol/out/proforma-invoice.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "657f58deb9e304370a1f351917270a2aff4686fc8ba36b944b1aed86acdac24f"
-		}
+			"val": "92e91efcea0f372da16ef37217406501a76b0df890c9213a075ffc51873d28c6"
+		},
+		"from": "iso6523-actorid-upis::0088:9482348239847239874",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -40,10 +42,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -85,10 +86,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/sales-order-example.json
+++ b/test/data/parse/peppol/out/sales-order-example.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "08b7db78d63cbb1b8f4ce1b258fc4f04362277ed0fca5c737cd16b02c45f87a4"
-		}
+			"val": "a9270457758e3a70496eca79d7559aae570de602573cea66fa128ed3a9606038"
+		},
+		"from": "iso6523-actorid-upis::0088:9482348239847239874",
+		"to": "iso6523-actorid-upis::0002:FR23342"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -40,10 +42,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -85,10 +86,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/self-billed-creditnote.json
+++ b/test/data/parse/peppol/out/self-billed-creditnote.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "adbbf8b25fb926adf10cbe23aafd86d1d69764a17a73983b441445c56b295db4"
-		}
+			"val": "5bfd5181c69f00afd2447b2b83af0ddf00d2eeb07b6b5629ce864198140a70d8"
+		},
+		"from": "iso6523-actorid-upis::0002:FR23342",
+		"to": "iso6523-actorid-upis::0088:9482348239847239874"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -48,10 +50,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -93,10 +94,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/self-billed-invoice.json
+++ b/test/data/parse/peppol/out/self-billed-invoice.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "95061413af3eb198d404584c2dae85747045de53bb2808d41280726fadf4c56b"
-		}
+			"val": "6d603a5307ab4ed86e6a03dcbd2f06781141d47e40188a2c808aa9f7bc7ba0bf"
+		},
+		"from": "iso6523-actorid-upis::0002:FR23342",
+		"to": "iso6523-actorid-upis::0088:9482348239847239874"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -43,10 +45,9 @@
 					"code": "99887766"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "9482348239847239874"
+					"uri": "iso6523-actorid-upis::0088:9482348239847239874"
 				}
 			],
 			"addresses": [
@@ -88,10 +89,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0002",
-					"code": "FR23342"
+					"uri": "iso6523-actorid-upis::0002:FR23342"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/sg-invoice.json
+++ b/test/data/parse/peppol/out/sg-invoice.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7eabad06dcc6d005a8f5281151b235fb4a915e9feac06ffb86bce0ebea4b7512"
-		}
+			"val": "d3dc1020ed68151a102f8ecaaad94175d804a4a6cdb06729b1e48667444320c6"
+		},
+		"from": "iso6523-actorid-upis::0195:SGTST123457890SC",
+		"to": "iso6523-actorid-upis::0195:SGUEN199912345A"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -52,10 +54,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0195",
-					"code": "SGTST123457890SC"
+					"uri": "iso6523-actorid-upis::0195:SGTST123457890SC"
 				}
 			],
 			"addresses": [
@@ -102,10 +103,9 @@
 					}
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0195",
-					"code": "SGUEN199912345A"
+					"uri": "iso6523-actorid-upis::0195:SGUEN199912345A"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/vat-category-E.json
+++ b/test/data/parse/peppol/out/vat-category-E.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e12091060fc0ba82123f38741589480120e4a8443f57df206e0a00ebb717a316"
-		}
+			"val": "5f8d339fbdbc40354b89e6ca06302f0ebfb49858991378dc79d2a2ed39e01d70"
+		},
+		"from": "iso6523-actorid-upis::0088:7300010000001",
+		"to": "iso6523-actorid-upis::0184:DK12345678"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -35,10 +37,9 @@
 					"code": "7300010000001"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "7300010000001"
+					"uri": "iso6523-actorid-upis::0088:7300010000001"
 				}
 			],
 			"addresses": [
@@ -52,10 +53,9 @@
 		},
 		"customer": {
 			"name": "The Buyercompany",
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0184",
-					"code": "DK12345678"
+					"uri": "iso6523-actorid-upis::0184:DK12345678"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/vat-category-O-invalid-bytes.json
+++ b/test/data/parse/peppol/out/vat-category-O-invalid-bytes.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "dde819630baa4d13bea8d8fe0ce2b5706cd4c659d12e85f11b813d618619a2df"
-		}
+			"val": "05128126d05a6883827b8793b1cc3591faf5ab3d87b55cf931bf9e6687c10eb5"
+		},
+		"from": "iso6523-actorid-upis::0088:7300010000001",
+		"to": "iso6523-actorid-upis::0192:987654325"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -40,10 +42,9 @@
 					"code": "7300010000001"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "7300010000001"
+					"uri": "iso6523-actorid-upis::0088:7300010000001"
 				}
 			],
 			"addresses": [
@@ -57,10 +58,9 @@
 		},
 		"customer": {
 			"name": "The Buyercompany",
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0192",
-					"code": "987654325"
+					"uri": "iso6523-actorid-upis::0192:987654325"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/vat-category-O.json
+++ b/test/data/parse/peppol/out/vat-category-O.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bd06e717055848fb99d5739861643d9ed753d76d7058e577e616242b7ed99386"
-		}
+			"val": "2127ed057c2b8c82bf0c28fbb7d4e6b2ae642ed5731cd4fe023925fcf3378fa7"
+		},
+		"from": "iso6523-actorid-upis::0088:7300010000001",
+		"to": "iso6523-actorid-upis::0192:987654325"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -40,10 +42,9 @@
 					"code": "7300010000001"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "7300010000001"
+					"uri": "iso6523-actorid-upis::0088:7300010000001"
 				}
 			],
 			"addresses": [
@@ -57,10 +58,9 @@
 		},
 		"customer": {
 			"name": "The Buyercompany",
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0192",
-					"code": "987654325"
+					"uri": "iso6523-actorid-upis::0192:987654325"
 				}
 			],
 			"addresses": [

--- a/test/data/parse/peppol/out/vat-category-Z.json
+++ b/test/data/parse/peppol/out/vat-category-Z.json
@@ -4,8 +4,10 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "14becb6e2e6a03514f80f4a23236e79a7c24d801f34dbf09dc21d9dec470eb3e"
-		}
+			"val": "dd020e44ef41ae660a721ccc73745557834ece9fcf20b31ae4e401d502e756f9"
+		},
+		"from": "iso6523-actorid-upis::0088:7300010000001",
+		"to": "iso6523-actorid-upis::0184:DK12345678"
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
@@ -35,10 +37,9 @@
 					"code": "7300010000001"
 				}
 			],
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0088",
-					"code": "7300010000001"
+					"uri": "iso6523-actorid-upis::0088:7300010000001"
 				}
 			],
 			"addresses": [
@@ -52,10 +53,9 @@
 		},
 		"customer": {
 			"name": "The Buyercompany",
-			"inboxes": [
+			"endpoints": [
 				{
-					"scheme": "0184",
-					"code": "DK12345678"
+					"uri": "iso6523-actorid-upis::0184:DK12345678"
 				}
 			],
 			"addresses": [


### PR DESCRIPTION
## What

Map the UBL `cbc:EndpointID` (BT-34 / BT-49, the party's electronic
address) to and from GOBL's `org.Party.Endpoints` — the `org.Endpoint`
URI — instead of the deprecated `org.Party.Inboxes`.

## Mapping

| GOBL endpoint URI | UBL `EndpointID` |
| --- | --- |
| `mailto:<address>` | `schemeID="EM"` value `<address>` |
| `iso6523-actorid-upis::<scheme>:<code>` | `schemeID="<scheme>"` value `<code>` |

This matches the URI convention GOBL's `eu/en16931` addon uses when it
normalizes Peppol inboxes into endpoints, extended to email (`mailto:`).

- **Serialize:** `newEndpointID` reads `party.FirstEndpoint()`.
- **Parse:** `goblEndpoint` writes the inverse as an `org.Endpoint`.

## Test data

- **Convert goldens are unchanged (byte-identical XML).** Each
  supplier/customer fixture gains an `endpoint` carrying exactly the
  value the old inbox-based serializer emitted, so switching the source
  is a no-op on the wire.
- **⚠️ Four France fixtures** (`france-cius/{credit-note-fr,invoice-fr-cius}`,
  `france-extended/invoice-fr-extended{,-detailed}`) carried a stale
  endpoint `schemeID="9957"` that disagreed with both their inbox and
  the committed golden (`schemeID="0225"`). The `0225` value is newer —
  it arrived with the APP-546 French-validation work, after the `9957`
  endpoints — so I reconciled the endpoints to `0225` to keep the
  reviewed output. **Please confirm `0225` is the intended French EAS
  scheme**; if `9957` is correct instead, it's a one-line fixture change
  plus a golden regen.
- **Parse goldens are regenerated** (second commit): parsed inboxes
  become endpoints, and the envelope head gains the `from`/`to` routing
  now derivable from the endpoints.

## Notes

Depends on GOBL's endpoint model; new builds normalized through the
`en16931` addon already carry endpoints. Paired with the equivalent
change in `gobl.cii`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
