### PR TITLE
Adding OrderableUnitFactorRate to Price and fixing contactName's nil crash

### DIFF
--- a/common.go
+++ b/common.go
@@ -117,9 +117,10 @@ type AdditionalItemProperty struct {
 
 // Price represents the price of an item
 type Price struct {
-	PriceAmount     Amount           `xml:"cbc:PriceAmount"`
-	BaseQuantity    *Quantity        `xml:"cbc:BaseQuantity,omitempty"`
-	AllowanceCharge *AllowanceCharge `xml:"cac:AllowanceCharge,omitempty"`
+	PriceAmount             Amount           `xml:"cbc:PriceAmount"`
+	BaseQuantity            *Quantity        `xml:"cbc:BaseQuantity,omitempty"`
+	OrderableUnitFactorRate *string          `xml:"cbc:OrderableUnitFactorRate,omitempty"`
+	AllowanceCharge         *AllowanceCharge `xml:"cac:AllowanceCharge,omitempty"`
 }
 
 func getTypeCode(inv *bill.Invoice) (string, error) {

--- a/party.go
+++ b/party.go
@@ -474,6 +474,9 @@ func newAddress(addresses []*org.Address, ctx Context) *PostalAddress {
 }
 
 func contactName(n *org.Name) string {
+	if n == nil {
+		return ""
+	}
 	given := n.Given
 	surname := n.Surname
 


### PR DESCRIPTION
## Summary

Two small, independent fixes carved out of #113 per review feedback (a field slipped into that PR that isn't related to the utils extraction):

- Added `OrderableUnitFactorRate` to the shared `Price` wire model — a standard UBL 2.1 `cac:Price` field (per the official `UBL-CommonAggregateComponents-2.1.xsd`) that was silently dropped on unmarshal. Field only, no calculation change: `BaseQuantity` division is already correct for EN16931/Peppol.
- Fixed `contactName` crashing on a `Contact` with no `Name` (only an `ID`) — a valid, common shape found via real official OIOUBL samples.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` all clean