### PR TITLE
Treat empty tags as absent when parsing

### DIFF
--- a/delivery_parse.go
+++ b/delivery_parse.go
@@ -63,7 +63,9 @@ func (ui *Invoice) goblAddDelivery(out *bill.Invoice) error {
 		}
 	}
 
-	if ui.DeliveryTerms != nil {
+	// Terms with no ID carry only free text, and an identity with no code fails
+	// validation.
+	if ui.DeliveryTerms != nil && ui.DeliveryTerms.ID != "" {
 		d.Identities = []*org.Identity{
 			{
 				Code: cbc.Code(ui.DeliveryTerms.ID),

--- a/party_parse.go
+++ b/party_parse.go
@@ -57,17 +57,23 @@ func goblParty(party *Party, o *options) *org.Party {
 
 	if party.Contact != nil {
 		if party.Contact.Telephone != nil {
-			p.Telephones = []*org.Telephone{
-				{
-					Number: cleanString(*party.Contact.Telephone),
-				},
+			number := cleanString(*party.Contact.Telephone)
+			if number != "" {
+				p.Telephones = []*org.Telephone{
+					{
+						Number: number,
+					},
+				}
 			}
 		}
 		if party.Contact.ElectronicMail != nil {
-			p.Emails = []*org.Email{
-				{
-					Address: cleanString(*party.Contact.ElectronicMail),
-				},
+			address := cleanString(*party.Contact.ElectronicMail)
+			if address != "" {
+				p.Emails = []*org.Email{
+					{
+						Address: address,
+					},
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Two details that were being dropped between UBL and GOBL, both found building
the Danish OIOUBL converter against Erhvervsstyrelsen's official sample corpus.
Each one turns a perfectly good source document into GOBL that fails GOBL's own
validation.

- **An empty tag is not an empty value.** A self-closing `<cbc:Telephone/>`
  unmarshals to a pointer to an empty string, not nil, so `goblParty` built a
  `Telephone` with a blank `Number` — a required field. The document then failed
  validation for a party that simply had no phone number.
- **Free-text delivery terms carry no identity.** `DeliveryTerms` with no `ID`
  produced an `org.Identity` with no code, which also fails validation.

## Scope

Deliberately small: both are parse-side fixes to an EN 16931 mapping.

Several larger changes were considered and dropped after measuring them:

- Moving the delivery location's `SchemeID` from `Identity.Label` to the
  `iso-scheme-id` extension. It changed behaviour for every UBL consumer, forced
  all 12 golden fixtures to be regenerated, and cost `DELIVERY_Advanced_Invoice_02`
  from the corpus, because a scheme written as an extension is not read back on
  the way out.
- Reading the delivery party's `PostalAddress`. UBL-CR-394 says a UBL invoice
  should not carry one, so this moved to `gobl.dk.oioubl`, which relocates it to
  the delivery location before parsing.
- Omitting an empty `<cac:DeliveryLocation/>`, and emitting a location that
  states only an identifier (BT-71). Both are real — Peppol and OIOUBL each
  reject the empty element (*F-INV239*) — but neither shape arises from a corpus
  document, and outbound senders are expected to state a delivery address.

## Verification

- Build, vet, lint, tests: green. **No golden fixtures change**, so this is
  behaviour-preserving for every existing test.
- Corpus round-trip `xml → gobl → xml → gobl → xml` with schematron at every
  stage: 100/142 clean, unchanged. Of the 456 OIOUBL documents there, 121 reach
  the parser and 114 convert to a valid envelope; the rest are Orders, Reminders
  and other document types this converter does not handle.
