### PR TITLE
feat: map GOBL ordering issuer to supplier ServiceProviderParty

### DIFF
--- a/invoice_parse.go
+++ b/invoice_parse.go
@@ -95,7 +95,7 @@ func (ui *Invoice) goblInvoice(o *options) (*bill.Invoice, error) {
 	if err := ui.goblAddPayment(out, o); err != nil {
 		return nil, err
 	}
-	if err := ui.goblAddOrdering(out); err != nil {
+	if err := ui.goblAddOrdering(out, o); err != nil {
 		return nil, err
 	}
 	if err := ui.goblAddDelivery(out); err != nil {

--- a/ordering.go
+++ b/ordering.go
@@ -83,9 +83,6 @@ func (ui *Invoice) addOrdering(o *bill.Ordering, context Context) {
 			}
 		}
 
-		// The ordering issuer (a third party that issued the document on behalf
-		// of the supplier but is not liable for tax) maps to the supplier's
-		// ServiceProviderParty/Party.
 		if o.Issuer != nil && ui.AccountingSupplierParty.Party != nil {
 			ui.AccountingSupplierParty.Party.ServiceProviderParty = &ServiceProviderParty{
 				Party: newParty(o.Issuer, context),

--- a/ordering.go
+++ b/ordering.go
@@ -83,6 +83,15 @@ func (ui *Invoice) addOrdering(o *bill.Ordering, context Context) {
 			}
 		}
 
+		// The ordering issuer (a third party that issued the document on behalf
+		// of the supplier but is not liable for tax) maps to the supplier's
+		// ServiceProviderParty/Party.
+		if o.Issuer != nil && ui.AccountingSupplierParty.Party != nil {
+			ui.AccountingSupplierParty.Party.ServiceProviderParty = &ServiceProviderParty{
+				Party: newParty(o.Issuer, context),
+			}
+		}
+
 		if o.Period != nil {
 			ui.InvoicePeriod = []Period{
 				{

--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -18,14 +18,20 @@ func hasOrderingData(o *bill.Ordering) bool {
 		len(o.Projects) > 0 ||
 		len(o.Contracts) > 0 ||
 		len(o.Tender) > 0 ||
-		len(o.Identities) > 0
+		len(o.Identities) > 0 ||
+		o.Issuer != nil
 }
 
-func (ui *Invoice) goblAddOrdering(out *bill.Invoice) error {
+func (ui *Invoice) goblAddOrdering(out *bill.Invoice, o *options) error {
 	ordering := new(bill.Ordering)
 
 	if ui.BuyerReference != "" {
 		ordering.Code = cbc.Code(cleanString(ui.BuyerReference))
+	}
+
+	// The supplier's ServiceProviderParty carries the ordering issuer.
+	if sp := ui.AccountingSupplierParty.Party; sp != nil && sp.ServiceProviderParty != nil {
+		ordering.Issuer = goblParty(sp.ServiceProviderParty.Party, o)
 	}
 
 	// GOBL does not currently support multiple periods, so only the first one is taken

--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -29,7 +29,6 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice, o *options) error {
 		ordering.Code = cbc.Code(cleanString(ui.BuyerReference))
 	}
 
-	// The supplier's ServiceProviderParty carries the ordering issuer.
 	if sp := ui.AccountingSupplierParty.Party; sp != nil && sp.ServiceProviderParty != nil {
 		ordering.Issuer = goblParty(sp.ServiceProviderParty.Party, o)
 	}

--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -29,9 +29,7 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice, o *options) error {
 		ordering.Code = cbc.Code(cleanString(ui.BuyerReference))
 	}
 
-	if sp := ui.AccountingSupplierParty.Party; sp != nil && sp.ServiceProviderParty != nil {
-		ordering.Issuer = goblParty(sp.ServiceProviderParty.Party, o)
-	}
+	ordering.Issuer = ui.goblOrderingIssuer(o)
 
 	// GOBL does not currently support multiple periods, so only the first one is taken
 	if len(ui.InvoicePeriod) > 0 {
@@ -144,6 +142,14 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice, o *options) error {
 	}
 
 	return nil
+}
+
+func (ui *Invoice) goblOrderingIssuer(o *options) *org.Party {
+	sp := ui.AccountingSupplierParty.Party
+	if sp == nil || sp.ServiceProviderParty == nil {
+		return nil
+	}
+	return goblParty(sp.ServiceProviderParty.Party, o)
 }
 
 func goblReference(ref *Reference) (*org.DocumentRef, error) {

--- a/ordering_test.go
+++ b/ordering_test.go
@@ -3,7 +3,12 @@ package ubl_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl"
+	ubl "github.com/invopop/gobl.ubl"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewOrdering(t *testing.T) {
@@ -15,4 +20,53 @@ func TestNewOrdering(t *testing.T) {
 		assert.Equal(t, "NA", doc.OrderReference.ID)
 	})
 
+}
+
+func TestOrderingIssuer(t *testing.T) {
+	// issuerEnv loads a complete invoice and attaches an ordering issuer.
+	issuerEnv := func(t *testing.T) *gobl.Envelope {
+		t.Helper()
+		env := loadTestEnvelope(t, "invoice-complete.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+		if inv.Ordering == nil {
+			inv.Ordering = &bill.Ordering{}
+		}
+		inv.Ordering.Issuer = &org.Party{
+			Name: "Billing Service Provider SL",
+		}
+		require.NoError(t, env.Calculate())
+		return env
+	}
+
+	t.Run("maps ordering issuer to supplier ServiceProviderParty", func(t *testing.T) {
+		doc, err := ubl.ConvertInvoice(issuerEnv(t))
+		require.NoError(t, err)
+
+		sp := doc.AccountingSupplierParty.Party.ServiceProviderParty
+		require.NotNil(t, sp, "ServiceProviderParty should be set from ordering.issuer")
+		require.NotNil(t, sp.Party)
+		require.NotNil(t, sp.Party.PartyName)
+		assert.Equal(t, "Billing Service Provider SL", sp.Party.PartyName.Name)
+	})
+
+	t.Run("round-trips issuer back to GOBL ordering", func(t *testing.T) {
+		doc, err := ubl.ConvertInvoice(issuerEnv(t))
+		require.NoError(t, err)
+		data, err := ubl.Bytes(doc)
+		require.NoError(t, err)
+
+		parsed, err := ubl.Parse(data)
+		require.NoError(t, err)
+		out, ok := parsed.(*ubl.Invoice)
+		require.True(t, ok)
+		outEnv, err := out.Convert()
+		require.NoError(t, err)
+		outInv, ok := outEnv.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		require.NotNil(t, outInv.Ordering)
+		require.NotNil(t, outInv.Ordering.Issuer)
+		assert.Equal(t, "Billing Service Provider SL", outInv.Ordering.Issuer.Name)
+	})
 }

--- a/party.go
+++ b/party.go
@@ -27,9 +27,7 @@ type CustomerParty struct {
 	Party *Party `xml:"cac:Party"`
 }
 
-// ServiceProviderParty represents a service provider party. It carries the
-// ordering issuer: a third party responsible for issuing the document on behalf
-// of the supplier but not liable for tax.
+// ServiceProviderParty represents a service provider party in a transaction
 type ServiceProviderParty struct {
 	Party *Party `xml:"cac:Party"`
 }

--- a/party.go
+++ b/party.go
@@ -36,15 +36,13 @@ type ServiceProviderParty struct {
 
 // Party represents a party involved in a transaction
 type Party struct {
-	EndpointID          *EndpointID       `xml:"cbc:EndpointID"`
-	PartyIdentification []Identification  `xml:"cac:PartyIdentification"`
-	PartyName           *PartyName        `xml:"cac:PartyName"`
-	PostalAddress       *PostalAddress    `xml:"cac:PostalAddress"`
-	PartyTaxScheme      []PartyTaxScheme  `xml:"cac:PartyTaxScheme"`
-	PartyLegalEntity    *PartyLegalEntity `xml:"cac:PartyLegalEntity"`
-	Contact             *Contact          `xml:"cac:Contact"`
-	// ServiceProviderParty follows Contact in the UBL PartyType sequence and
-	// holds the ordering issuer when present on the supplier party.
+	EndpointID           *EndpointID           `xml:"cbc:EndpointID"`
+	PartyIdentification  []Identification      `xml:"cac:PartyIdentification"`
+	PartyName            *PartyName            `xml:"cac:PartyName"`
+	PostalAddress        *PostalAddress        `xml:"cac:PostalAddress"`
+	PartyTaxScheme       []PartyTaxScheme      `xml:"cac:PartyTaxScheme"`
+	PartyLegalEntity     *PartyLegalEntity     `xml:"cac:PartyLegalEntity"`
+	Contact              *Contact              `xml:"cac:Contact"`
 	ServiceProviderParty *ServiceProviderParty `xml:"cac:ServiceProviderParty"`
 }
 

--- a/party.go
+++ b/party.go
@@ -27,6 +27,13 @@ type CustomerParty struct {
 	Party *Party `xml:"cac:Party"`
 }
 
+// ServiceProviderParty represents a service provider party. It carries the
+// ordering issuer: a third party responsible for issuing the document on behalf
+// of the supplier but not liable for tax.
+type ServiceProviderParty struct {
+	Party *Party `xml:"cac:Party"`
+}
+
 // Party represents a party involved in a transaction
 type Party struct {
 	EndpointID          *EndpointID       `xml:"cbc:EndpointID"`
@@ -36,6 +43,9 @@ type Party struct {
 	PartyTaxScheme      []PartyTaxScheme  `xml:"cac:PartyTaxScheme"`
 	PartyLegalEntity    *PartyLegalEntity `xml:"cac:PartyLegalEntity"`
 	Contact             *Contact          `xml:"cac:Contact"`
+	// ServiceProviderParty follows Contact in the UBL PartyType sequence and
+	// holds the ordering issuer when present on the supplier party.
+	ServiceProviderParty *ServiceProviderParty `xml:"cac:ServiceProviderParty"`
 }
 
 // EndpointID represents an endpoint identifier


### PR DESCRIPTION
## What

Maps GOBL `bill.Ordering.Issuer` ⇄ UBL `Invoice/cac:AccountingSupplierParty/cac:Party/cac:ServiceProviderParty/cac:Party`, in both the convert and parse directions.

The ordering issuer represents *a third party responsible for issuing the document on behalf of the supplier, but not liable for tax* — which is exactly what UBL's `ServiceProviderParty` models.

## Changes

- **`party.go`** — new `ServiceProviderParty` wire type; added the field to `Party`, positioned after `Contact` per the UBL `PartyType` element sequence.
- **`ordering.go`** (convert) — `addOrdering` maps `Ordering.Issuer` via `newParty` onto the supplier's `ServiceProviderParty/Party` (after the seller/tax-representative swap so it lands on the final supplier party). The full party is carried (name, address, tax scheme, contact, identities).
- **`ordering_parse.go`** (parse) — reverse mapping into `Ordering.Issuer`; added `Issuer` to `hasOrderingData`; threaded `*options` through `goblAddOrdering`.
- **`invoice_parse.go`** — updated the `goblAddOrdering` call site.
- **`ordering_test.go`** — added `TestOrderingIssuer` (convert + round-trip).

## Gating / conformance note

The field is emitted **unconditionally** — intentionally not gated by profile. `ServiceProviderParty` is guarded by EN16931 rule **UBL-CR-195**, so it raises a *warning* (not an error) under EN16931/Peppol/France CIUS, and validates clean under France Extended (which relaxes UBL-CR-195). Verified against the FNFE/CEN schematrons via phive. This is an accepted trade-off — we don't gate extended-only fields.

## Tests

`go test ./...` green. New convert + round-trip coverage in `TestOrderingIssuer`; existing `TestNewOrdering` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)