### PR TITLE
fix: emit the mandatory NetworkID inside CardAccount

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -78,6 +78,7 @@ type PrepaidPayment struct {
 }
 
 const sepaSchemeID = "SEPA"
+const cardNetworkNotApplicable = "NA"
 
 func (ui *Invoice) addPayment(inv *bill.Invoice, ctx Context) error {
 	if inv == nil || inv.Payment == nil {
@@ -175,8 +176,10 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 		}
 	}
 	if instr.Card != nil {
+		network := cardNetworkNotApplicable
 		ui.PaymentMeans[0].CardAccount = &CardAccount{
 			PrimaryAccountNumberID: &instr.Card.Last4,
+			NetworkID:              &network,
 		}
 		if instr.Card.Holder != "" {
 			ui.PaymentMeans[0].CardAccount.HolderName = &instr.Card.Holder

--- a/payment_test.go
+++ b/payment_test.go
@@ -71,6 +71,33 @@ func TestNewPayment(t *testing.T) {
 		assert.Equal(t, "MANDATE-123", doc.PaymentMeans[0].PaymentMandate.ID.Value)
 	})
 
+	t.Run("card payment includes the network ID required by the schema", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-minimal.json")
+
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Payment.Instructions.CreditTransfer = nil
+		inv.Payment.Instructions.Card = &pay.Card{Last4: "0312"}
+
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc.PaymentMeans)
+
+		card := doc.PaymentMeans[0].CardAccount
+		require.NotNil(t, card)
+		require.NotNil(t, card.PrimaryAccountNumberID)
+		assert.Equal(t, "0312", *card.PrimaryAccountNumberID)
+		// cbc:NetworkID is mandatory in UBL, but has no EN 16931 business term.
+		require.NotNil(t, card.NetworkID)
+		assert.Equal(t, "NA", *card.NetworkID)
+		assert.Nil(t, card.HolderName)
+
+		data, err := ubl.Bytes(doc)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "<cac:CardAccount>\n      <cbc:PrimaryAccountNumberID>0312</cbc:PrimaryAccountNumberID>\n      <cbc:NetworkID>NA</cbc:NetworkID>\n    </cac:CardAccount>")
+	})
+
 	t.Run("document type extension", func(t *testing.T) {
 		env := loadTestEnvelope(t, "invoice-minimal.json")
 


### PR DESCRIPTION
## Problem

Any invoice with card payment instructions failed UBL schema validation:

```
[SAX] cvc-complex-type.2.4.b: The content of element 'cac:CardAccount' is not
complete. One of '{urn:...:CommonBasicComponents-2":NetworkID}' is expected.
```

`CardAccountType` in the UBL 2.1 schema declares `cbc:NetworkID` as
`minOccurs="1"` (see `test/data/schema/common/UBL-CommonAggregateComponents-2.1.xsd`),
but we only ever emitted `cbc:PrimaryAccountNumberID` and, optionally,
`cbc:HolderName`.

## Fix

`cbc:NetworkID` has no EN 16931 business term and no counterpart in GOBL's
`pay.Card`, so there is nothing to map it from. Peppol BIS documents it as a
"syntax required element not related to a business term" with the example value
`NA`, which is what we now emit:

```xml
<cac:CardAccount>
  <cbc:PrimaryAccountNumberID>0312</cbc:PrimaryAccountNumberID>
  <cbc:NetworkID>NA</cbc:NetworkID>
</cac:CardAccount>
```

The struct field order already matched the XSD sequence, so no reordering was
needed. The parse direction keeps ignoring `NetworkID`, and a round trip
regenerates the placeholder.

## Notes

- Advances with a `card` are unaffected: they only map to `cac:PrepaidPayment` /
  `LegalMonetaryTotal/PrepaidAmount`, which have no card fields in UBL. Only
  `instructions.card` reaches `cac:CardAccount`.
- A card with a `holder` but no `last4` still emits an empty
  `<cbc:PrimaryAccountNumberID/>`. That is schema-valid and passes Peppol's
  BR-51 (a warning asserting length ≤ 10), so it was left as-is.

## Testing

New subtest in `TestNewPayment` covering the struct and the serialized element
order. Full suite and `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
