### PR TITLE
Allow triggering the release workflow manually

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ on:
       - main
     paths-ignore:
       - "README.md"
+  # Manual escape hatch: re-fire the release when the push event is lost
+  # (e.g. dropped webhooks during a GitHub Actions incident).
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
The release workflow only fires on pushes to main, so a dropped push event — as happened with #122 during yesterday's GitHub Actions incident — leaves the release permanently unpublished: there is no way to re-fire it, and the tag never gets created.

Adding `workflow_dispatch` makes the release recoverable: the same workflow (version tag + GoReleaser) can be triggered manually from the Actions tab or with `gh workflow run release.yaml`.

Merging this also re-fires the release for current main, which publishes the version #122 should have produced.
