### PR TITLE
Recover the BIC when UBL nests it inside the financial institution

### DIFF
--- a/payment.go
+++ b/payment.go
@@ -201,17 +201,17 @@ func (ui *Invoice) addPaymentInstructions(inv *bill.Invoice, ctx Context) error 
 
 func newCreditTransferAccount(ct *pay.CreditTransfer) *FinancialAccount {
 	pfa := new(FinancialAccount)
-	if ct.IBAN != "" {
+	if !ct.IBAN.IsEmpty() {
 		id := ct.IBAN.String()
 		pfa.ID = &id
-	} else if ct.Number != "" {
+	} else if !ct.Number.IsEmpty() {
 		id := ct.Number.String()
 		pfa.ID = &id
 	}
 	if ct.Name != "" {
 		pfa.Name = &ct.Name
 	}
-	if ct.BIC != "" {
+	if !ct.BIC.IsEmpty() {
 		bic := ct.BIC.String()
 		pfa.FinancialInstitutionBranch = &Branch{ID: &bic}
 	}

--- a/payment_parse.go
+++ b/payment_parse.go
@@ -174,8 +174,15 @@ func goblCreditTransfer(paymentMeans *PaymentMeans) []*pay.CreditTransfer {
 	if account.Name != nil {
 		creditTransfer.Name = cleanString(*account.Name)
 	}
-	if account.FinancialInstitutionBranch != nil && account.FinancialInstitutionBranch.ID != nil {
-		creditTransfer.BIC = cbc.Code(cleanString(*account.FinancialInstitutionBranch.ID))
+	// UBL carries the BIC either on the branch itself (BT-86) or nested inside
+	// its financial institution.
+	if branch := account.FinancialInstitutionBranch; branch != nil {
+		switch {
+		case branch.ID != nil:
+			creditTransfer.BIC = cbc.Code(cleanString(*branch.ID))
+		case branch.FinancialInstitution != nil && branch.FinancialInstitution.ID != nil:
+			creditTransfer.BIC = cbc.Code(cleanString(*branch.FinancialInstitution.ID))
+		}
 	}
 
 	return []*pay.CreditTransfer{creditTransfer}

--- a/payment_parse_test.go
+++ b/payment_parse_test.go
@@ -149,6 +149,21 @@ func TestParsePaymentInstructions(t *testing.T) {
 		require.Len(t, payment.Instructions.CreditTransfer, 1)
 		assert.Equal(t, cbc.Code("NL28RBOS0420242228"), payment.Instructions.CreditTransfer[0].IBAN)
 	})
+
+	t.Run("instructions with the BIC nested in the financial institution", func(t *testing.T) {
+		e := parseXMLInvoice(t, "peppol/nbio-stuck-ubl.xml")
+
+		inv, ok := e.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		payment := inv.Payment
+		require.NotNil(t, payment)
+
+		require.NotNil(t, payment.Instructions)
+		require.Len(t, payment.Instructions.CreditTransfer, 1)
+		assert.Equal(t, cbc.Code("BE68539007547034"), payment.Instructions.CreditTransfer[0].IBAN)
+		assert.Equal(t, cbc.Code("GKCCBEBB"), payment.Instructions.CreditTransfer[0].BIC)
+	})
 }
 
 func TestParsePaymentTerms(t *testing.T) {

--- a/test/data/parse/peppol/out/nbio-stuck-ubl.json
+++ b/test/data/parse/peppol/out/nbio-stuck-ubl.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2c12a5fb0ae6183d8d1943bc13ab4280ef57a02a992ed08ae54f6e510f285f95"
+			"val": "4017421da4ceafa9a213cfbfc724bddcdf6ec65c65dec4aa70f7c343d3a08576"
 		}
 	},
 	"doc": {
@@ -177,7 +177,8 @@
 				"ref": "020250000001",
 				"credit_transfer": [
 					{
-						"iban": "BE68539007547034"
+						"iban": "BE68539007547034",
+						"bic": "GKCCBEBB"
 					}
 				],
 				"ext": {


### PR DESCRIPTION
## Context

UBL can carry the payee's BIC in two places: on `cac:FinancialInstitutionBranch/cbc:ID` (BT-86), or one level deeper under `cac:FinancialInstitution/cbc:ID`. The parser only read the first, so a document using the nested form lost the BIC entirely.

`test/data/parse/peppol/nbio-stuck-ubl.xml` is one of those documents — its `GKCCBEBB` never reached the parsed invoice, as the golden output shows. The wire model already declared `FinancialInstitution` for this element, but nothing read it.

## Changes

- Fall back to the nested `FinancialInstitution/ID` when the branch carries no ID of its own.
- Assert the recovered BIC on the Peppol fixture that exercises the nested form.
- Use `cbc.Code`'s `IsEmpty` in `newCreditTransferAccount`, now that those fields are codes.

Outbound is unchanged: the BIC still goes to BT-86. The fallback only fires where the parser previously produced nothing, so no existing document parses differently.
