### PR TITLE
Reference the XRechnung addon key as a constant

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,12 +3,16 @@ package ubl
 import (
 	"github.com/invopop/gobl.fr.ctc/addon/flow2"
 	zatca "github.com/invopop/gobl.sa.zatca/addon"
-	"github.com/invopop/gobl/addons/de/xrechnung"
 	"github.com/invopop/gobl/addons/eu/en16931"
 	"github.com/invopop/gobl/addons/fr/facturx"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 )
+
+// AddonKeyXRechnung is the GOBL addon key XRechnung documents declare.
+// The addon itself lives in gobl.de.xinvoice; naming the key here avoids
+// importing that module, which would be a dependency cycle.
+const AddonKeyXRechnung cbc.Key = "de-xrechnung-v3"
 
 // Peppol Billing Profile IDs
 const (
@@ -196,7 +200,7 @@ var ContextPeppolSelfBilled = Context{
 var ContextXRechnung = Context{
 	CustomizationID: "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0",
 	ProfileID:       PeppolBillingProfileIDDefault,
-	Addons:          []cbc.Key{xrechnung.V3},
+	Addons:          []cbc.Key{AddonKeyXRechnung},
 	VESIDs: VESIDMapping{
 		Invoice:    "de.xrechnung:ubl-invoice:3.0.2",
 		CreditNote: "de.xrechnung:ubl-creditnote:3.0.2",

--- a/context_test.go
+++ b/context_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	ubl "github.com/invopop/gobl.ubl"
-	"github.com/invopop/gobl/addons/de/xrechnung"
 	"github.com/invopop/gobl/addons/eu/en16931"
 	"github.com/invopop/gobl/addons/fr/facturx"
 	"github.com/invopop/gobl/bill"
@@ -69,7 +68,7 @@ func TestContextXRechnung(t *testing.T) {
 		inv, ok := env.Extract().(*bill.Invoice)
 		require.True(t, ok)
 
-		inv.SetAddons(xrechnung.V3)
+		inv.SetAddons(ubl.AddonKeyXRechnung)
 		require.NoError(t, inv.Calculate())
 
 		// Convert with XRechnung context


### PR DESCRIPTION
`ContextXRechnung` imported `gobl/addons/de/xrechnung` only to name the addon key. Those addon packages are moving to `gobl.de.xinvoice`, and importing that module here would be a cycle, so the key is written as a constant instead.

No behaviour change, and it is compatible with both the current GOBL core and the one that no longer ships the German addons — so it can be released ahead of that change.