### PR TITLE
Stop reading the NA order reference filler back as a purchase order

### DIFF
--- a/ordering.go
+++ b/ordering.go
@@ -46,6 +46,10 @@ type ProjectReference struct {
 	ID string `xml:"cbc:ID,omitempty"`
 }
 
+// orderReferenceNotApplicable is the filler OIOUBL and Peppol accept when
+// there is no order reference to give.
+const orderReferenceNotApplicable = "NA"
+
 func (ui *Invoice) addPreceding(refs []*org.DocumentRef) {
 	if len(refs) == 0 {
 		return
@@ -182,6 +186,6 @@ func (ui *Invoice) addOrdering(o *bill.Ordering, context Context) {
 		if ui.OrderReference == nil {
 			ui.OrderReference = &OrderReference{}
 		}
-		ui.OrderReference.ID = "NA"
+		ui.OrderReference.ID = orderReferenceNotApplicable
 	}
 }

--- a/ordering.go
+++ b/ordering.go
@@ -121,7 +121,7 @@ func (ui *Invoice) addOrdering(o *bill.Ordering, context Context) {
 				if ui.OrderReference == nil {
 					// TODO: once we have a Peppol addon this should be delegated there
 					ui.OrderReference = &OrderReference{
-						ID: "NA",
+						ID: orderReferenceNotApplicable,
 					}
 				}
 				ui.OrderReference.SalesOrderID = o.Sales[0].Code.String()

--- a/ordering_parse.go
+++ b/ordering_parse.go
@@ -78,11 +78,15 @@ func (ui *Invoice) goblAddOrdering(out *bill.Invoice, o *options) error {
 		}
 	}
 
-	if ui.OrderReference != nil && ui.OrderReference.ID != "" {
-		ordering.Purchases = []*org.DocumentRef{
-			{
-				Code: cbc.Code(ui.OrderReference.ID),
-			},
+	if ui.OrderReference != nil {
+		// BT-13: "NA" is the agreed filler for "no purchase order" where the
+		// element is mandatory, so it is not an order reference.
+		if id := ui.OrderReference.ID; id != "" && id != orderReferenceNotApplicable {
+			ordering.Purchases = []*org.DocumentRef{
+				{
+					Code: cbc.Code(id),
+				},
+			}
 		}
 		// BT-14: Sales order reference
 		if ui.OrderReference.SalesOrderID != "" {

--- a/ordering_parse_test.go
+++ b/ordering_parse_test.go
@@ -3,6 +3,7 @@ package ubl_test
 import (
 	"testing"
 
+	ubl "github.com/invopop/gobl.ubl"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/stretchr/testify/assert"
@@ -42,4 +43,52 @@ func TestParseOrdering(t *testing.T) {
 		assert.Equal(t, cbc.Code("5433"), ordering.Despatch[0].Code)
 	})
 
+}
+
+func TestParseOrderingNotApplicable(t *testing.T) {
+	t.Run("NA is not a purchase order", func(t *testing.T) {
+		e := parseXMLInvoice(t, "peppol/sales-order-example.xml")
+
+		inv, ok := e.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		require.NotNil(t, inv.Ordering)
+		assert.Empty(t, inv.Ordering.Purchases)
+	})
+
+	t.Run("a sales order alongside NA survives", func(t *testing.T) {
+		e := parseXMLInvoice(t, "peppol/sales-order-example.xml")
+
+		inv, ok := e.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		require.NotNil(t, inv.Ordering)
+		require.Len(t, inv.Ordering.Sales, 1)
+		assert.Equal(t, cbc.Code("123456"), inv.Ordering.Sales[0].Code)
+	})
+
+	t.Run("an invoice with no ordering gains none on a round trip", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-minimal.json")
+
+		doc, err := ubl.ConvertInvoice(env, ubl.WithContext(ubl.ContextPeppol))
+		require.NoError(t, err)
+		require.Equal(t, "NA", doc.OrderReference.ID)
+
+		data, err := ubl.Bytes(doc)
+		require.NoError(t, err)
+
+		out, err := ubl.Parse(data)
+		require.NoError(t, err)
+		parsed, ok := out.(*ubl.Invoice)
+		require.True(t, ok)
+
+		env2, err := parsed.Convert()
+		require.NoError(t, err)
+		inv, ok := env2.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		if inv.Ordering != nil {
+			assert.Empty(t, inv.Ordering.Purchases)
+		}
+	})
 }

--- a/test/data/parse/peppol/out/nbio-stuck-ubl.json
+++ b/test/data/parse/peppol/out/nbio-stuck-ubl.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2c12a5fb0ae6183d8d1943bc13ab4280ef57a02a992ed08ae54f6e510f285f95"
+			"val": "2854af867387c4ee37c3f8442c5502683c70bcedf4e6a4ea94e7d0b99b06ccff"
 		}
 	},
 	"doc": {
@@ -149,12 +149,7 @@
 			}
 		],
 		"ordering": {
-			"code": "John Doe",
-			"purchases": [
-				{
-					"code": "NA"
-				}
-			]
+			"code": "John Doe"
 		},
 		"payment": {
 			"terms": {

--- a/test/data/parse/peppol/out/sales-order-example.json
+++ b/test/data/parse/peppol/out/sales-order-example.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "ec782c00eee0cd16eb97a636d6092498a9602b475ec8a6761af70d151d4026a2"
+			"val": "cd2244aeefa3bc75b40bce725d8754b849ef7437c43eda27dfd9b75a639cc139"
 		}
 	},
 	"doc": {
@@ -206,11 +206,6 @@
 		"ordering": {
 			"code": "0150abc",
 			"cost": "4025:123:4343",
-			"purchases": [
-				{
-					"code": "NA"
-				}
-			],
 			"sales": [
 				{
 					"code": "123456"


### PR DESCRIPTION
## Context

`cac:OrderReference/cbc:ID` is mandatory when there is no buyer reference, so the converter writes `NA` into it to satisfy PEPPOL-EN16931-R003 (BT-13). The parser had no knowledge of that convention and mapped any non-empty `OrderReference/ID` to a purchase order, so an invoice with no ordering at all came back from a round trip carrying `ordering.purchases[0].code = "NA"`.

It isn't only our own output that does this. `NA` is the agreed filler in the wild — `test/data/parse/peppol/sales-order-example.xml` carries it with a comment saying exactly that — and two committed golden files had recorded the phantom purchase order as expected output.

`SalesOrderID` (BT-14) was also read inside the same branch, so a document whose only real reference is a sales order depended on the filler being present to keep it.

## Changes

- Name the filler as a constant beside the converter that writes it.
- Skip it when parsing, so an `OrderReference/ID` of `NA` produces no purchase order.
- Read `SalesOrderID` independently, so a document carrying only a sales order keeps it.
- Regenerate the two goldens that had recorded the phantom purchase order.
