### PR TITLE
fix: emit the ISO 6523 scheme ID on the delivery location ID

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -1,6 +1,9 @@
 package ubl
 
-import "github.com/invopop/gobl/bill"
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/catalogues/iso"
+)
 
 // Delivery represents delivery information
 type Delivery struct {
@@ -49,7 +52,12 @@ func newDelivery(del *bill.DeliveryDetails, ctx Context) *Delivery {
 				Address: newAddress(del.Receiver.Addresses, ctx),
 			}
 		if len(del.Identities) > 0 {
-			out.DeliveryLocation.ID = &IDType{Value: del.Identities[0].Code.String()}
+			id := del.Identities[0]
+			idType := &IDType{Value: id.Code.String()}
+			if s := id.Ext.Get(iso.ExtKeySchemeID).String(); s != "" {
+				idType.SchemeID = &s
+			}
+			out.DeliveryLocation.ID = idType
 		}
 	}
 

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -5,6 +5,10 @@ import (
 
 	ubl "github.com/invopop/gobl.ubl"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/catalogues/iso"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,6 +45,38 @@ func TestNewDelivery(t *testing.T) {
 		assert.Len(t, doc.Delivery, 1)
 		assert.Equal(t, "2024-02-10", *doc.Delivery[0].ActualDeliveryDate)
 		assert.Nil(t, doc.Delivery[0].DeliveryLocation)
+	})
+
+	t.Run("delivery location identity with iso scheme id propagates to SchemeID", func(t *testing.T) {
+		env := loadTestEnvelope(t, "invoice-without-buyers-tax-id.json")
+		inv, ok := env.Extract().(*bill.Invoice)
+		require.True(t, ok)
+
+		inv.Delivery.Identities = []*org.Identity{
+			{
+				Code: "6754238987643",
+				Ext:  tax.ExtensionsOf(cbc.CodeMap{iso.ExtKeySchemeID: "0088"}),
+			},
+		}
+
+		require.NoError(t, env.Calculate())
+		doc, err := ubl.ConvertInvoice(env)
+		require.NoError(t, err)
+
+		require.NotNil(t, doc.Delivery[0].DeliveryLocation)
+		id := doc.Delivery[0].DeliveryLocation.ID
+		require.NotNil(t, id)
+		assert.Equal(t, "6754238987643", id.Value)
+		require.NotNil(t, id.SchemeID)
+		assert.Equal(t, "0088", *id.SchemeID)
+	})
+
+	t.Run("delivery location identity without iso scheme id leaves SchemeID unset", func(t *testing.T) {
+		doc := testInvoiceFrom(t, "invoice-without-buyers-tax-id.json")
+
+		id := doc.Delivery[0].DeliveryLocation.ID
+		require.NotNil(t, id)
+		assert.Nil(t, id.SchemeID)
 	})
 
 	t.Run("delivery with no date", func(t *testing.T) {


### PR DESCRIPTION
## What

`cac:DeliveryLocation/cbc:ID` was always built from the delivery
identity's code alone. If the identity carried an `iso-scheme-id`
extension (the ISO 6523 ICD scheme, e.g. `0088` for GLN), it was
silently dropped instead of being emitted as the `schemeID` attribute.

## Fix

`newDelivery` now checks `id.Ext.Get(iso.ExtKeySchemeID)` and sets
`IDType.SchemeID` when present — the same pattern already used for
party identifiers in `party.go`.

## Test data

No existing golden fixture carries an `ext` on its delivery identity
(they only set a display `label`), so **convert goldens are
unchanged**. Added two focused unit tests in `delivery_test.go`
covering the extension-present and extension-absent cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)