### PR TITLE
fix: keep the raw UN/ECE unit code instead of mapping to a GOBL unit

### DIFF
--- a/lines_parse.go
+++ b/lines_parse.go
@@ -87,7 +87,7 @@ func goblConvertLine(docLine *InvoiceLine, taxCategoryMap map[string]*taxCategor
 		}
 
 		if iq.UnitCode != "" {
-			line.Item.Unit = goblUnitFromUNECE(cbc.Code(iq.UnitCode))
+			line.Item.Unit = org.Unit(iq.UnitCode)
 		}
 	}
 

--- a/lines_parse_test.go
+++ b/lines_parse_test.go
@@ -30,7 +30,7 @@ func TestParseLines(t *testing.T) {
 		line := lines[0]
 		assert.Equal(t, "PATAT FRITES 10MM 10KG", line.Item.Name)
 		assert.Equal(t, "2", line.Quantity.String())
-		assert.Equal(t, org.Unit("item"), line.Item.Unit)
+		assert.Equal(t, org.Unit("EA"), line.Item.Unit)
 		assert.Equal(t, "9.95", line.Item.Price.String())
 		assert.Equal(t, cbc.Code("VAT"), line.Taxes[0].Category)
 		assert.Equal(t, "6%", line.Taxes[0].Percent.String())
@@ -38,7 +38,7 @@ func TestParseLines(t *testing.T) {
 		line = lines[19]
 		assert.Equal(t, "FRITUUR VET 10 KG RETOUR", line.Item.Name)
 		assert.Equal(t, "6", line.Quantity.String())
-		assert.Equal(t, org.Unit("item"), line.Item.Unit)
+		assert.Equal(t, org.Unit("EA"), line.Item.Unit)
 		assert.Equal(t, "18.33", line.Item.Price.String())
 		assert.Equal(t, cbc.Code("VAT"), line.Taxes[0].Category)
 		assert.Equal(t, "6%", line.Taxes[0].Percent.String())
@@ -62,7 +62,7 @@ func TestParseLines(t *testing.T) {
 		assert.Equal(t, "JB007", line.Item.Ref.String())
 		assert.Equal(t, "Scratch on box", line.Notes[0].Text)
 		assert.Equal(t, "Processor: Intel Core 2 Duo SU9400 LV (1.4GHz). RAM: 3MB. Screen 1440x900", line.Item.Description)
-		assert.Equal(t, org.Unit("item"), line.Item.Unit)
+		assert.Equal(t, org.Unit("EA"), line.Item.Unit)
 		assert.Equal(t, l10n.ISOCountryCode("DE"), line.Item.Origin)
 		assert.Equal(t, "1273.00", line.Item.Price.String())
 		assert.Equal(t, cbc.Code("VAT"), line.Taxes[0].Category)
@@ -93,7 +93,7 @@ func TestParseLines(t *testing.T) {
 		line = lines[1]
 		assert.Equal(t, "Returned \"Advanced computing\" book", line.Item.Name)
 		assert.Equal(t, "-1", line.Quantity.String())
-		assert.Equal(t, org.Unit("item"), line.Item.Unit)
+		assert.Equal(t, org.Unit("EA"), line.Item.Unit)
 		assert.Equal(t, "3.96", line.Item.Price.String())
 		assert.Equal(t, cbc.Code("VAT"), line.Taxes[0].Category)
 		assert.Equal(t, "15%", line.Taxes[0].Percent.String())

--- a/test/data/parse/en16931/out/credit-note1.json
+++ b/test/data/parse/en16931/out/credit-note1.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9a859176b4b7400632a42a3805b0feada387215cd1a96760c6483ca0aa6aa72e"
+			"val": "7474e4a1b5b31c83b3ad440d9a249ade271fd02c0afb0b6f2efd3a4c0670a770"
 		}
 	},
 	"doc": {
@@ -102,7 +102,7 @@
 					],
 					"description": "Acme beeswax",
 					"price": "1.00",
-					"unit": "kg"
+					"unit": "KGM"
 				},
 				"sum": "100.00",
 				"total": "100.00",

--- a/test/data/parse/en16931/out/custom-namespace-prefixes.json
+++ b/test/data/parse/en16931/out/custom-namespace-prefixes.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9a859176b4b7400632a42a3805b0feada387215cd1a96760c6483ca0aa6aa72e"
+			"val": "7474e4a1b5b31c83b3ad440d9a249ade271fd02c0afb0b6f2efd3a4c0670a770"
 		}
 	},
 	"doc": {
@@ -102,7 +102,7 @@
 					],
 					"description": "Acme beeswax",
 					"price": "1.00",
-					"unit": "kg"
+					"unit": "KGM"
 				},
 				"sum": "100.00",
 				"total": "100.00",

--- a/test/data/parse/en16931/out/ubl-example1.json
+++ b/test/data/parse/en16931/out/ubl-example1.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0334798d68fe23fe2148ca221022ac2f972464186e027f8f287d343c5c13e26c"
+			"val": "253c39bd49d5dcd82771ad0f4a5c367ade57c5659e402979ad356e420bcea9f4"
 		}
 	},
 	"doc": {
@@ -76,7 +76,7 @@
 					"ref": "166022",
 					"name": "PATAT FRITES 10MM 10KG",
 					"price": "9.95",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "19.90",
 				"taxes": [
@@ -98,7 +98,7 @@
 					"ref": "661813",
 					"name": "PKAAS 50PL. JONG BEL. 1KG",
 					"price": "9.85",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "9.85",
 				"taxes": [
@@ -120,7 +120,7 @@
 					"ref": "438146",
 					"name": "POT KETCHUP 3 LT",
 					"price": "8.29",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "8.29",
 				"taxes": [
@@ -142,7 +142,7 @@
 					"ref": "438103",
 					"name": "FRITESSAUS 3 LRR",
 					"price": "7.23",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "14.46",
 				"taxes": [
@@ -164,7 +164,7 @@
 					"ref": "666955",
 					"name": "KOFFIE BLIK 3,5KG SNELF",
 					"price": "35.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "35.00",
 				"taxes": [
@@ -186,7 +186,7 @@
 					"ref": "664871",
 					"name": "KOFFIE 3.5 KG BLIK STAND",
 					"price": "35.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "35.00",
 				"taxes": [
@@ -208,7 +208,7 @@
 					"ref": "350257",
 					"name": "SUIKERKLONT",
 					"price": "10.65",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "10.65",
 				"taxes": [
@@ -230,7 +230,7 @@
 					"ref": "350258",
 					"name": "1 KG UL BLOKJES",
 					"price": "1.55",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1.55",
 				"taxes": [
@@ -252,7 +252,7 @@
 					"ref": "999998",
 					"name": "BLOCKNOTE A5",
 					"price": "4.79",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "14.37",
 				"taxes": [
@@ -274,7 +274,7 @@
 					"ref": "740810",
 					"name": "CHIPS NAT KLEIN ZAKJES",
 					"price": "8.29",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "8.29",
 				"taxes": [
@@ -296,7 +296,7 @@
 					"ref": "740829",
 					"name": "CHIPS PAP KLEINE ZAKJES",
 					"price": "8.29",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "16.58",
 				"taxes": [
@@ -318,7 +318,7 @@
 					"ref": "740828",
 					"name": "TR KL PAKJES APPELSAP",
 					"price": "9.95",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "9.95",
 				"taxes": [
@@ -340,7 +340,7 @@
 					"ref": "740827",
 					"name": "PK CHOCOLADEMEL",
 					"price": "1.65",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "3.30",
 				"taxes": [
@@ -362,7 +362,7 @@
 					"ref": "999996",
 					"name": "KRAT BIER",
 					"price": "10.80",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "10.80",
 				"taxes": [
@@ -384,7 +384,7 @@
 					"ref": "999995",
 					"name": "STATIEGELD",
 					"price": "3.90",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "3.90",
 				"taxes": [
@@ -406,7 +406,7 @@
 					"ref": "102172",
 					"name": "BLEEK 3 X 750 ML",
 					"price": "3.80",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "7.60",
 				"taxes": [
@@ -428,7 +428,7 @@
 					"ref": "999994",
 					"name": "WC PAPIER",
 					"price": "4.67",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "9.34",
 				"taxes": [
@@ -450,7 +450,7 @@
 					"ref": "999993",
 					"name": "BALPENNEN 50 ST BLAUW",
 					"price": "18.63",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "18.63",
 				"taxes": [
@@ -472,7 +472,7 @@
 					"ref": "999992",
 					"name": "EM FRITUURVET",
 					"price": "17.02",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "102.12",
 				"taxes": [
@@ -494,7 +494,7 @@
 					"ref": "175137",
 					"name": "FRITUUR VET 10 KG RETOUR",
 					"price": "18.33",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "109.98",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example10.json
+++ b/test/data/parse/en16931/out/ubl-example10.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "f722009c82d155a2aa4c28da71fe9662310359eed759888bb9e370a4646775cc"
+			"val": "36a6502c5f5167182aa43c0ca058d67b6ff04a288308f3e6413b50065c816b5b"
 		}
 	},
 	"doc": {
@@ -75,7 +75,7 @@
 				"item": {
 					"name": "Getransporteerde kWh’s",
 					"price": "0.00880",
-					"unit": "kwh",
+					"unit": "KWH",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -102,7 +102,7 @@
 				"item": {
 					"name": "Systeemdiensten",
 					"price": "0.00101",
-					"unit": "kwh",
+					"unit": "KWH",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -183,7 +183,7 @@
 				"item": {
 					"name": "Vastrecht Transportdienst",
 					"price": "36.7500",
-					"unit": "mon",
+					"unit": "MON",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -210,7 +210,7 @@
 				"item": {
 					"name": "Vastrecht Aansluitdienst",
 					"price": "56.5000",
-					"unit": "mon",
+					"unit": "MON",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -237,7 +237,7 @@
 				"item": {
 					"name": "Huur Transformatoren",
 					"price": "83.34",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "83.34",
 				"taxes": [
@@ -258,7 +258,7 @@
 				"item": {
 					"name": "Huur Schakelinstallaties",
 					"price": "190.31",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "190.31",
 				"taxes": [
@@ -279,7 +279,7 @@
 				"item": {
 					"name": "Huur Overige Apparaten",
 					"price": "64.21",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "64.21",
 				"taxes": [
@@ -300,7 +300,7 @@
 				"item": {
 					"name": "Huur Meterdiensten",
 					"price": "64.46",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "64.46",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example2.json
+++ b/test/data/parse/en16931/out/ubl-example2.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "9d7140095ce4165c5e4db9d0649085575c3c6f0d95c2f4f7fe242cbd53dd6a00"
+			"val": "8e011956f1a6b725ab78202e55bada800f1875e4152c2f25ccd4305be5c84dbd"
 		}
 	},
 	"doc": {
@@ -129,7 +129,7 @@
 					],
 					"description": "Processor: Intel Core 2 Duo SU9400 LV (1.4GHz). RAM: 3MB. Screen 1440x900",
 					"price": "1273.00",
-					"unit": "item",
+					"unit": "EA",
 					"origin": "DE",
 					"meta": {
 						"color": "Black"
@@ -190,7 +190,7 @@
 						}
 					],
 					"price": "3.96",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "-3.96",
 				"taxes": [
@@ -235,7 +235,7 @@
 						}
 					],
 					"price": "2.48",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "4.96",
 				"taxes": [
@@ -275,7 +275,7 @@
 						}
 					],
 					"price": "25.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "-25.00",
 				"taxes": [
@@ -313,7 +313,7 @@
 						}
 					],
 					"price": "0.75",
-					"unit": "m",
+					"unit": "MTR",
 					"meta": {
 						"type": "Cat5"
 					}

--- a/test/data/parse/en16931/out/ubl-example3.json
+++ b/test/data/parse/en16931/out/ubl-example3.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "50d4aa3a9e0cad86c0396a44879d4785c52d13d855be9060170820d2a1217927"
+			"val": "d4e7b0e2ff943424b49adc0bec2e3ceb9e02e910c5c879c41b2076eb6aee461b"
 		}
 	},
 	"doc": {
@@ -91,7 +91,7 @@
 					"name": "Paper subscription",
 					"description": "Subscription fee 1st quarter",
 					"price": "800.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1600.00",
 				"taxes": [
@@ -113,7 +113,7 @@
 					"name": "Paper subscription",
 					"description": "Subscription fee 1st quarter",
 					"price": "800.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1600.00",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example4.json
+++ b/test/data/parse/en16931/out/ubl-example4.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fee953eea91eb485b83cc33c43aabf3b2e745d1add0ef8757dbfe1d3ace45fb1"
+			"val": "08f14e825b775c3a10db36ac42842c50cd1ddd044a12f1734f0ff883fa3d8fa8"
 		}
 	},
 	"doc": {
@@ -103,7 +103,7 @@
 					"name": "Printing paper",
 					"description": "Printing paper, 2mm",
 					"price": "1.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1000.00",
 				"taxes": [
@@ -126,7 +126,7 @@
 					"name": "Parker Pen",
 					"description": "Parker Pen, Black, model Sansa",
 					"price": "5.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "500.00",
 				"taxes": [
@@ -148,7 +148,7 @@
 					"ref": "JB009",
 					"name": "American Cookies",
 					"price": "5.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "2500.00",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example5.json
+++ b/test/data/parse/en16931/out/ubl-example5.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "60063072781fff478bbc252138ab8a495fdcbfd05769cb4b189ae74a1b67e9d4"
+			"val": "354422c00dfc6c72a2870f842caab78459d98587aa325926c7e53d0f80a67380"
 		}
 	},
 	"doc": {
@@ -139,7 +139,7 @@
 					],
 					"description": "Printing paper, 2mm",
 					"price": "1.00",
-					"unit": "item",
+					"unit": "EA",
 					"origin": "NL",
 					"meta": {
 						"thickness": "2 mm"
@@ -202,7 +202,7 @@
 					"name": "Parker Pen",
 					"description": "Parker Pen, Black, model Sansa",
 					"price": "5.00",
-					"unit": "item",
+					"unit": "EA",
 					"origin": "NL"
 				},
 				"sum": "500.00",
@@ -230,7 +230,7 @@
 					"ref": "JB009",
 					"name": "American Cookies",
 					"price": "5.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "2500.00",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example6.json
+++ b/test/data/parse/en16931/out/ubl-example6.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1f7094add9239bb4211c182763e2ec7b4cc8b6c2f09b60c8589314ce3b25992f"
+			"val": "007648a8d4a3429243461af497e327b531a971cfaf80491ab1f940ea6ed86d53"
 		}
 	},
 	"doc": {
@@ -51,7 +51,7 @@
 				"item": {
 					"name": "Printing paper",
 					"price": "1.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1000.00",
 				"taxes": [
@@ -72,7 +72,7 @@
 				"item": {
 					"name": "Parker Pen",
 					"price": "5.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "500.00",
 				"taxes": [
@@ -93,7 +93,7 @@
 				"item": {
 					"name": "American Cookies",
 					"price": "5.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "2500.00",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example7.json
+++ b/test/data/parse/en16931/out/ubl-example7.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7105bd91c95c222145f2bb83d7bb14c7fbaf3ffe203288a247df4362e258848a"
+			"val": "91edf2cddd5e2884857803001896cf572357d14c1ac3a49c040c46b1febceacd"
 		}
 	},
 	"doc": {
@@ -107,7 +107,7 @@
 					"name": "Road tax",
 					"description": "Weight-based tax, vehicles 3000 KGM",
 					"price": "2500.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "2500.00",
 				"taxes": [
@@ -129,7 +129,7 @@
 					"name": "Road Register fee",
 					"description": "Annual registration fee",
 					"price": "700.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "700.00",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example8.json
+++ b/test/data/parse/en16931/out/ubl-example8.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "7738e5bd9fb0c96b979a0b1e5d734cf912ba5687379807483bdce0ec23810f09"
+			"val": "3d4df96663f64fd70c384f50efc59eab44a4e1a2c000146a5ffee71dfa7ba36c"
 		}
 	},
 	"doc": {
@@ -75,7 +75,7 @@
 				"item": {
 					"name": "Getransporteerde kWh’s",
 					"price": "0.00880",
-					"unit": "kwh",
+					"unit": "KWH",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -102,7 +102,7 @@
 				"item": {
 					"name": "Systeemdiensten",
 					"price": "0.00101",
-					"unit": "kwh",
+					"unit": "KWH",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -183,7 +183,7 @@
 				"item": {
 					"name": "Vastrecht Transportdienst",
 					"price": "36.7500",
-					"unit": "mon",
+					"unit": "MON",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -210,7 +210,7 @@
 				"item": {
 					"name": "Vastrecht Aansluitdienst",
 					"price": "56.5000",
-					"unit": "mon",
+					"unit": "MON",
 					"meta": {
 						"contract-transportvermogen": "132,00 kW",
 						"correctiefactor": "1,0130",
@@ -237,7 +237,7 @@
 				"item": {
 					"name": "Huur Transformatoren",
 					"price": "83.34",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "83.34",
 				"taxes": [
@@ -258,7 +258,7 @@
 				"item": {
 					"name": "Huur Schakelinstallaties",
 					"price": "190.31",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "190.31",
 				"taxes": [
@@ -279,7 +279,7 @@
 				"item": {
 					"name": "Huur Overige Apparaten",
 					"price": "64.21",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "64.21",
 				"taxes": [
@@ -300,7 +300,7 @@
 				"item": {
 					"name": "Huur Meterdiensten",
 					"price": "64.46",
-					"unit": "mon"
+					"unit": "MON"
 				},
 				"sum": "64.46",
 				"taxes": [

--- a/test/data/parse/en16931/out/ubl-example9.json
+++ b/test/data/parse/en16931/out/ubl-example9.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "c12d80e01847c16ff11233e6b881c3e5fa562e9138de6a8e40458af48ab93cd8"
+			"val": "0deba789b07f893a31790244a0b310375d87f68098db9a1d93979302a720bffa"
 		}
 	},
 	"doc": {
@@ -73,7 +73,7 @@
 				"item": {
 					"name": "IExpress licentiekosten",
 					"price": "49.00",
-					"unit": "mon",
+					"unit": "MON",
 					"meta": {
 						"verbruikscategorie": "Start"
 					}

--- a/test/data/parse/france-cius/out/b2b-reg.json
+++ b/test/data/parse/france-cius/out/b2b-reg.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "132770d4f6e9291485fa849890307348c52b16e8abbc20790a0daa297042b462"
+			"val": "2876e64fc498a13f0808f2f26ece451affbfca79adbe11af4324be9530d53269"
 		},
 		"from": "iso6523-actorid-upis::0225:324872211",
 		"to": "iso6523-actorid-upis::0225:439368049"
@@ -176,7 +176,7 @@
 					"name": "REMBOURSEMENT",
 					"description": "Description du remboursement",
 					"price": "60.0000",
-					"unit": "one"
+					"unit": "C62"
 				},
 				"sum": "60.00",
 				"taxes": [
@@ -226,7 +226,7 @@
 					],
 					"description": "Description de l'article",
 					"price": "0.7000",
-					"unit": "one",
+					"unit": "C62",
 					"origin": "FR",
 					"meta": {
 						"co2g": "12"
@@ -292,7 +292,7 @@
 					],
 					"description": "Description du moule",
 					"price": "10.00000",
-					"unit": "one",
+					"unit": "C62",
 					"meta": {
 						"co2g": "30",
 						"couleur": "BLANC"
@@ -324,7 +324,7 @@
 					"name": "SUPPORT TEL",
 					"description": "Description de la prestation de support associée",
 					"price": "7.0000",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "14.00",
 				"taxes": [

--- a/test/data/parse/peppol/out/Allowance-example.json
+++ b/test/data/parse/peppol/out/Allowance-example.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "74a156c1f38d94a0ec30c088473df4123820f90d2d4b0dfe5538ee48ec57d166"
+			"val": "96ec2b40d348c94d60e60a81b6d738bdebd74b3075eb262efc6f79ace708339e"
 		}
 	},
 	"doc": {
@@ -146,7 +146,7 @@
 					],
 					"description": "Description of item",
 					"price": "410.00",
-					"unit": "one",
+					"unit": "C62",
 					"origin": "NO"
 				},
 				"sum": "4100.00",
@@ -207,7 +207,7 @@
 					],
 					"description": "Description of item",
 					"price": "100.00",
-					"unit": "one",
+					"unit": "C62",
 					"meta": {
 						"additionalitemname": "AdditionalItemValue"
 					}
@@ -249,7 +249,7 @@
 					],
 					"description": "Description of item",
 					"price": "100.00",
-					"unit": "one",
+					"unit": "C62",
 					"meta": {
 						"additionalitemname": "AdditionalItemValue"
 					}

--- a/test/data/parse/peppol/out/Vat-category-S.json
+++ b/test/data/parse/peppol/out/Vat-category-S.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "b9e98b35eb4f156a843e99ed1537e6a0fb10135364e8e74925ede20e55e77def"
+			"val": "cf5c0a6f32748710c2b9812f08363b4366c121eac488a67703f12560f695b5ca"
 		}
 	},
 	"doc": {
@@ -141,7 +141,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "one",
+					"unit": "C62",
 					"origin": "NO"
 				},
 				"sum": "4000.00",
@@ -183,7 +183,7 @@
 					],
 					"description": "Description of item",
 					"price": "200.00",
-					"unit": "one"
+					"unit": "C62"
 				},
 				"sum": "2000.00",
 				"taxes": [
@@ -219,7 +219,7 @@
 					],
 					"description": "Description of item",
 					"price": "90.00",
-					"unit": "one",
+					"unit": "C62",
 					"meta": {
 						"additionalitemname": "AdditionalItemValue"
 					}

--- a/test/data/parse/peppol/out/base-creditnote-correction.json
+++ b/test/data/parse/peppol/out/base-creditnote-correction.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1e280f009b3f6967c0187b090bb565d0eb18dbcf1a7287fca78984947b2b911a"
+			"val": "18a0247ab3106d4a66bec98fc634144a151186c9bd5fac8f5b44c745216ff1da"
 		}
 	},
 	"doc": {
@@ -138,7 +138,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -174,7 +174,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/base-example.json
+++ b/test/data/parse/peppol/out/base-example.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "a0cba560aab2e55b82672f947a58d88dc9dc625d82345df7107c0db39b954ba7"
+			"val": "6577f2acfb3022b994345b73c9c93c680c419e7ebd9249435cea207b723e362f"
 		}
 	},
 	"doc": {
@@ -133,7 +133,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -169,7 +169,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/base-negative-inv-correction.json
+++ b/test/data/parse/peppol/out/base-negative-inv-correction.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0090e43b22687057fafa72049b79b2d84ebb9e2ef4f82427ae361c6a09ab9548"
+			"val": "3601f6dead9babc2f6a71d9f38f34d4af628b42bbad8feceb24cefe09047cd1c"
 		}
 	},
 	"doc": {
@@ -138,7 +138,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-2800.00",
@@ -174,7 +174,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "1500.00",

--- a/test/data/parse/peppol/out/example-encoding.json
+++ b/test/data/parse/peppol/out/example-encoding.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6ec4f2539268d2d60895aee1cb49b684c76614699f4639e5ad336d63059f6ee9"
+			"val": "9cf03176bddc095b1ba6582b02d1b2a707475726be53266adbd26e071778bc3e"
 		}
 	},
 	"doc": {
@@ -88,7 +88,7 @@
 					"name": "Test Widget XL",
 					"description": "Widget with bad encoding character",
 					"price": "50.00",
-					"unit": "one"
+					"unit": "C62"
 				},
 				"sum": "100.00",
 				"taxes": [

--- a/test/data/parse/peppol/out/nbio-stuck-ubl.json
+++ b/test/data/parse/peppol/out/nbio-stuck-ubl.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2854af867387c4ee37c3f8442c5502683c70bcedf4e6a4ea94e7d0b99b06ccff"
+			"val": "a98dcab9cee2c1a77c8e3704911d10389658c8d6caa4aa143c1251107412e32c"
 		}
 	},
 	"doc": {
@@ -133,7 +133,7 @@
 					"name": "service: example service",
 					"description": "\u003cp\u003eExample service description with HTML tags.\u003c/p\u003e",
 					"price": "195.0000",
-					"unit": "piece"
+					"unit": "H87"
 				},
 				"sum": "195.00",
 				"taxes": [

--- a/test/data/parse/peppol/out/partial-invoice.json
+++ b/test/data/parse/peppol/out/partial-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "1e41fe4c792b4032b4ed83e0411a86f04cb9e783a24acfb139ee75e6c2598382"
+			"val": "84cd7e5c639a84a2066fff006198c70705f69a018dec63dc98ec835f70dfb3fb"
 		}
 	},
 	"doc": {
@@ -136,7 +136,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -172,7 +172,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/proforma-invoice.json
+++ b/test/data/parse/peppol/out/proforma-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "58c404e07e06c382c0102ddc2a9553c332d43bbdd4371faa4c00414e29f2020f"
+			"val": "f1af3c69de497114446bf2157572a10b17a3c88c64886a81df3dcfed9ce73a1d"
 		}
 	},
 	"doc": {
@@ -133,7 +133,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -169,7 +169,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/sales-order-example.json
+++ b/test/data/parse/peppol/out/sales-order-example.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "cd2244aeefa3bc75b40bce725d8754b849ef7437c43eda27dfd9b75a639cc139"
+			"val": "591f51ea2a2b3b3ea1476a095b7df56f0b0109aacbea49d095b41e35b4700c9d"
 		}
 	},
 	"doc": {
@@ -133,7 +133,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -169,7 +169,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/self-billed-creditnote.json
+++ b/test/data/parse/peppol/out/self-billed-creditnote.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "ad41243490f35cb824f80aac462185ab837909e246f4db64b71d7210e8cb093d"
+			"val": "c7a352e66ffef1d76b7183dcc283791ea4b7d3dfadf80549a5660868c99fb898"
 		}
 	},
 	"doc": {
@@ -141,7 +141,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -177,7 +177,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/self-billed-invoice.json
+++ b/test/data/parse/peppol/out/self-billed-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "6df1db84080525e4c2c557efdf79016f910d2492036c4b1373650761d7245db6"
+			"val": "cf4d804795c9fa53072fef76e6addf27bb1aa16ec1f604dea7bbd74488447e8d"
 		}
 	},
 	"doc": {
@@ -136,7 +136,7 @@
 					],
 					"description": "Description of item",
 					"price": "400.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "2800.00",
@@ -172,7 +172,7 @@
 					],
 					"description": "Description 2",
 					"price": "500.00",
-					"unit": "day",
+					"unit": "DAY",
 					"origin": "NO"
 				},
 				"sum": "-1500.00",

--- a/test/data/parse/peppol/out/sg-invoice.json
+++ b/test/data/parse/peppol/out/sg-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "025b683de94c2d3a26b5c44551534279f24602ecbbfc09002ba52af6c12f7732"
+			"val": "754bfcf8a6d998341d57e7d316433b838487998e722525f01861946f8bd50dd9"
 		}
 	},
 	"doc": {
@@ -161,7 +161,7 @@
 					],
 					"description": "Supply",
 					"price": "0.05735092",
-					"unit": "kwh",
+					"unit": "KWH",
 					"meta": {
 						"utilityconsumptionpoint": "871690930000222221",
 						"utilityconsumptionpointaddress": "VE HAZERSWOUDE-XXXXX"
@@ -227,7 +227,7 @@
 					],
 					"description": "Supply",
 					"price": "0.827901924",
-					"unit": "kl",
+					"unit": "K6",
 					"meta": {
 						"utilityconsumptionpoint": "871690930000222221",
 						"utilityconsumptionpointaddress": "VE HAZERSWOUDE-XXXXX"

--- a/test/data/parse/peppol/out/vat-category-E.json
+++ b/test/data/parse/peppol/out/vat-category-E.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e12091060fc0ba82123f38741589480120e4a8443f57df206e0a00ebb717a316"
+			"val": "7f8a7ea785ee986dece98b71494be2101365951977c933c271e5560581f5a8da"
 		}
 	},
 	"doc": {
@@ -85,7 +85,7 @@
 						}
 					],
 					"price": "120.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1200.00",
 				"taxes": [

--- a/test/data/parse/peppol/out/vat-category-O-invalid-bytes.json
+++ b/test/data/parse/peppol/out/vat-category-O-invalid-bytes.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "dde819630baa4d13bea8d8fe0ce2b5706cd4c659d12e85f11b813d618619a2df"
+			"val": "7fc4bb7c7a7487bdd9059ded4abc7dd66a9e2e99a22d37a7a65b1b098468a080"
 		}
 	},
 	"doc": {
@@ -84,7 +84,7 @@
 					"name": "Road tax",
 					"description": "Weight-based tax, vehicles \u003e3000 KGM",
 					"price": "3200.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "3200.00",
 				"taxes": [

--- a/test/data/parse/peppol/out/vat-category-O.json
+++ b/test/data/parse/peppol/out/vat-category-O.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "bd06e717055848fb99d5739861643d9ed753d76d7058e577e616242b7ed99386"
+			"val": "059b86bf60ff83bed9599b745e0b71a03a4838e32cd146ee90cdf131e80e5b3b"
 		}
 	},
 	"doc": {
@@ -84,7 +84,7 @@
 					"name": "Road tax",
 					"description": "Weight-based tax, vehicles \u003e3000 KGM",
 					"price": "3200.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "3200.00",
 				"taxes": [

--- a/test/data/parse/peppol/out/vat-category-Z.json
+++ b/test/data/parse/peppol/out/vat-category-Z.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "14becb6e2e6a03514f80f4a23236e79a7c24d801f34dbf09dc21d9dec470eb3e"
+			"val": "aaa09a0f130e73c92009a5da2ad6375ae29c3fe6e6c1bf475cc8324af330d0e6"
 		}
 	},
 	"doc": {
@@ -85,7 +85,7 @@
 						}
 					],
 					"price": "120.00",
-					"unit": "item"
+					"unit": "EA"
 				},
 				"sum": "1200.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/credit-note-summary.json
+++ b/test/data/parse/zatca/out/credit-note-summary.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "025465f8c39b7f13b74ceb25013c6add336a182ffcd68d0b20dff9af47cb4539"
+			"val": "57bfba631d1a6f95d8b6bdee3e10ce3ef3021dea08c37b83244ccb34125e4c24"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					"ref": "SVC-DEV-01",
 					"name": "Development services",
 					"price": "120.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "600.00",
 				"discounts": [
@@ -152,7 +152,7 @@
 					"ref": "ITM-DESK-01",
 					"name": "Office desk return",
 					"price": "850.00",
-					"unit": "one"
+					"unit": "C62"
 				},
 				"sum": "850.00",
 				"taxes": [
@@ -174,7 +174,7 @@
 					"ref": "TRV-FLT-01",
 					"name": "Domestic flights for cancelled visit",
 					"price": "300.00",
-					"unit": "one"
+					"unit": "C62"
 				},
 				"sum": "600.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/simplified-credit-note.json
+++ b/test/data/parse/zatca/out/simplified-credit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "0362740a653c896cea2b1bde09c3d458df1365ee036014d8ba7e6184ec35ece1"
+			"val": "3c72976a58ab329fabb4f009891c034d5af4a02312555e46e2b3abc1fd121c85"
 		}
 	},
 	"doc": {
@@ -82,7 +82,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "450.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/simplified-debit-note.json
+++ b/test/data/parse/zatca/out/simplified-debit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "5d3dd9635723ebca9fc7b0a530b8ebb6baea3a4bbabb9fa79857cf60c89812b3"
+			"val": "a4e49ff081c10d03574c7eaaf55c5a9a62741cbe4e17f3a5f16433fd83206a79"
 		}
 	},
 	"doc": {
@@ -82,7 +82,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "450.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/simplified-invoice.json
+++ b/test/data/parse/zatca/out/simplified-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e71f02d1915504bb747893ca921257105013e026d7661fcd0bbaa85ddb9d7d8b"
+			"val": "92978a4f2e0fad910e0e99baef3ffade9892e78a998e5e31cec24e3e4dc83dec"
 		}
 	},
 	"doc": {
@@ -75,7 +75,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "1800.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/standard-credit-note.json
+++ b/test/data/parse/zatca/out/standard-credit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "2986642675a9b9abe647b9dcc59fe3a9d431e13c15642bc0dd26b38f500d5c66"
+			"val": "5b626872d199ce52d4ea919d14cea2162efc4a1d640902b029426b4293cd2fae"
 		}
 	},
 	"doc": {
@@ -85,7 +85,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "450.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/standard-debit-note.json
+++ b/test/data/parse/zatca/out/standard-debit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "e06f280fa7661bc6ad020936f4c9142cef35e355fded91a3d3d2f5dd7eec563c"
+			"val": "85e0741efe26662278c93f074578dd8c79f2a58d0fc83d96de954329a1335eeb"
 		}
 	},
 	"doc": {
@@ -85,7 +85,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "450.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/standard-invoice.json
+++ b/test/data/parse/zatca/out/standard-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "fd6c10ef5fee27ea8e595eebad54d299e4b44fcc70cbae565a255de06adc85f6"
+			"val": "0b9ad2456a66b2561e98489439f5f35cd4cb258db06dc43b538ff2f410e9f19d"
 		}
 	},
 	"doc": {
@@ -78,7 +78,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "1800.00",
 				"taxes": [

--- a/test/data/parse/zatca/out/standard-usd-invoice.json
+++ b/test/data/parse/zatca/out/standard-usd-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
 		"dig": {
 			"alg": "sha256",
-			"val": "548648315fb3e9a351105300d1b4014c0e0c27e989c99e322bd4938bad16febe"
+			"val": "3cf959a32cc7cf3b77532ddf1681be4035fe8c22c8ad76cb9fa2f6c072d8a667"
 		}
 	},
 	"doc": {
@@ -85,7 +85,7 @@
 				"item": {
 					"name": "Development services",
 					"price": "90.00",
-					"unit": "h"
+					"unit": "HUR"
 				},
 				"sum": "1800.00",
 				"taxes": [

--- a/utils.go
+++ b/utils.go
@@ -30,16 +30,6 @@ func formatKey(key string) cbc.Key {
 	return cbc.Key(key)
 }
 
-// goblUnitFromUNECE maps UN/ECE code to GOBL equivalent.
-func goblUnitFromUNECE(unece cbc.Code) org.Unit {
-	for _, def := range org.UnitDefinitions {
-		if def.UNECE == unece {
-			return def.Unit
-		}
-	}
-	return org.Unit(unece)
-}
-
 // noteCodePattern matches the #CODE#text format used in UBL notes to encode
 // UNTDID 4451 text subject qualifier codes, e.g. "#AAI#some text".
 var noteCodePattern = regexp.MustCompile(`^#([A-Z0-9]+)#(.*)$`)

--- a/utils_test.go
+++ b/utils_test.go
@@ -138,7 +138,6 @@ func TestTagCodeParseZATCA(t *testing.T) {
 	}
 }
 
-// Define tests for the UnitFromUNECE function
 // Define tests for the FormatKey function
 func TestFormatKey(t *testing.T) {
 	assert.Equal(t, cbc.Key("test"), formatKey("Test"))

--- a/utils_test.go
+++ b/utils_test.go
@@ -139,27 +139,6 @@ func TestTagCodeParseZATCA(t *testing.T) {
 }
 
 // Define tests for the UnitFromUNECE function
-func TestUnitFromUNECE(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"Known UNECE code", "HUR", "h"},
-		{"Known UNECE code", "SEC", "s"},
-		{"Known UNECE code", "MTR", "m"},
-		{"Known UNECE code", "GRM", "g"},
-		{"Unknown UNECE code", "XYZ", "XYZ"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := goblUnitFromUNECE(cbc.Code(tt.input))
-			assert.Equal(t, tt.expected, string(result))
-		})
-	}
-}
-
 // Define tests for the FormatKey function
 func TestFormatKey(t *testing.T) {
 	assert.Equal(t, cbc.Key("test"), formatKey("Test"))


### PR DESCRIPTION
## Summary
- When parsing a UBL invoice line's quantity unit code (`InvoicedQuantity`/`CreditedQuantity` `unitCode`), stop mapping it to a "friendly" GOBL unit via `goblUnitFromUNECE` and just store the raw UN/ECE code directly on `line.Item.Unit`.
- `org.Unit.Validate()` already accepts a raw UN/ECE code as a valid value (see `org.Unit.UNECE()`/`regexpUNECEUnit` in gobl), so the lookup table was an unnecessary, lossy round-trip: it only covered a subset of UN/ECE codes and silently fell back to the raw code anyway when a mapping wasn't found.
- Removed the now-dead `goblUnitFromUNECE` helper and its test.
- Updated `TestParseLines` assertions and regenerated the golden `test/data/parse/**/out/*.json` fixtures (only the `unit` field and resulting digest hash changed — verified via diff).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test ./...`